### PR TITLE
SpreadsheetContext.createMetadata was metadataWithDefaults

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/context/FakeSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/FakeSpreadsheetContext.java
@@ -47,6 +47,11 @@ public class FakeSpreadsheetContext implements SpreadsheetContext {
     }
 
     @Override
+    public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public DateTimeContext dateTimeContext(final SpreadsheetId id) {
         throw new UnsupportedOperationException();
     }
@@ -68,11 +73,6 @@ public class FakeSpreadsheetContext implements SpreadsheetContext {
 
     @Override
     public Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> hateosRouter(final SpreadsheetId id) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContext.java
@@ -75,36 +75,36 @@ final class MemorySpreadsheetContext implements SpreadsheetContext {
     static MemorySpreadsheetContext with(final AbsoluteUrl base,
                                          final HateosContentType contentType,
                                          final Function<BigDecimal, Fraction> fractioner,
+                                         final Function<Optional<Locale>, SpreadsheetMetadata> createMetadata,
                                          final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                         final Function<Optional<Locale>, SpreadsheetMetadata> metadata,
                                          final Function<SpreadsheetId, SpreadsheetStoreRepository> spreadsheetIdToRepository) {
         Objects.requireNonNull(base, "base");
         Objects.requireNonNull(contentType, "contentType");
         Objects.requireNonNull(fractioner, "fractioner");
+        Objects.requireNonNull(createMetadata, "createMetadata");
         Objects.requireNonNull(spreadsheetIdFunctions, "spreadsheetIdFunctions");
-        Objects.requireNonNull(metadata, "metadata");
         Objects.requireNonNull(spreadsheetIdToRepository, "spreadsheetIdToRepository");
 
         return new MemorySpreadsheetContext(base,
                 contentType,
                 fractioner,
+                createMetadata,
                 spreadsheetIdFunctions,
-                metadata,
                 spreadsheetIdToRepository);
     }
 
     private MemorySpreadsheetContext(final AbsoluteUrl base,
                                      final HateosContentType contentType,
                                      final Function<BigDecimal, Fraction> fractioner,
+                                     final Function<Optional<Locale>, SpreadsheetMetadata> createMetadata,
                                      final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                     final Function<Optional<Locale>, SpreadsheetMetadata> metadata,
                                      final Function<SpreadsheetId, SpreadsheetStoreRepository> spreadsheetIdToRepository) {
         super();
 
         this.base = base;
         this.contentType = contentType;
         this.fractioner = fractioner;
-        this.metadata = metadata;
+        this.createMetadata = createMetadata;
         this.spreadsheetIdFunctions = spreadsheetIdFunctions;
         this.spreadsheetIdToRepository = spreadsheetIdToRepository;
     }
@@ -113,6 +113,13 @@ final class MemorySpreadsheetContext implements SpreadsheetContext {
     public Converter converter(final SpreadsheetId id) {
         return this.loadAndGet(id, SpreadsheetMetadata::converter);
     }
+
+    @Override
+    public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
+        return this.createMetadata.apply(locale);
+    }
+
+    private final Function<Optional<Locale>, SpreadsheetMetadata> createMetadata;
 
     @Override
     public DateTimeContext dateTimeContext(final SpreadsheetId id) {
@@ -232,15 +239,6 @@ final class MemorySpreadsheetContext implements SpreadsheetContext {
     private final AbsoluteUrl base;
     private final HateosContentType contentType;
     private final Function<BigDecimal, Fraction> fractioner;
-
-    // metadata.........................................................................................................
-
-    @Override
-    public SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {
-        return this.metadata.apply(locale);
-    }
-
-    private final Function<Optional<Locale>, SpreadsheetMetadata> metadata;
 
     @Override
     public Function<SpreadsheetColorName, Optional<Color>> nameToColor(final SpreadsheetId id) {

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContext.java
@@ -56,6 +56,11 @@ public interface SpreadsheetContext extends Context {
     Converter converter(final SpreadsheetId id);
 
     /**
+     * Returns a {@link SpreadsheetMetadata} with necessary defaults allocating a new {@link SpreadsheetId}.
+     */
+    SpreadsheetMetadata createMetadata(final Optional<Locale> locale);
+
+    /**
      * The {@link DateTimeContext} for the given {@link SpreadsheetId}
      */
     DateTimeContext dateTimeContext(final SpreadsheetId id);
@@ -79,11 +84,6 @@ public interface SpreadsheetContext extends Context {
      * A {@link Router} that can handle hateos requests for the given identified spreadsheet.
      */
     Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> hateosRouter(final SpreadsheetId id);
-
-    /**
-     * Returns a {@link SpreadsheetMetadata} allocating a new {@link SpreadsheetId}.
-     */
-    SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale);
 
     /**
      * Returns a {@link Function} which maps {@link String color name} to {@link Color} for the given {@link SpreadsheetId}.

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContextTesting.java
@@ -34,6 +34,13 @@ public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends
     }
 
     @Test
+    default void testCreateMetadataNullLocaleFails() {
+        assertThrows(NullPointerException.class, () -> {
+            this.createContext().createMetadata(null);
+        });
+    }
+
+    @Test
     default void testDateTimeContextNullSpreadsheetIdFails() {
         assertThrows(NullPointerException.class, () -> {
             this.createContext().dateTimeContext(null);
@@ -58,13 +65,6 @@ public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends
     default void testHateosRouterNullSpreadsheetIdFails() {
         assertThrows(NullPointerException.class, () -> {
             this.createContext().hateosRouter(null);
-        });
-    }
-
-    @Test
-    default void testMetadataWithDefaultsNullLocaleFails() {
-        assertThrows(NullPointerException.class, () -> {
-            this.createContext().metadataWithDefaults(null);
         });
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContexts.java
@@ -48,14 +48,14 @@ public final class SpreadsheetContexts implements PublicStaticHelper {
     public static SpreadsheetContext memory(final AbsoluteUrl base,
                                             final HateosContentType contentType,
                                             final Function<BigDecimal, Fraction> fractioner,
+                                            final Function<Optional<Locale>, SpreadsheetMetadata> createMetadata,
                                             final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                            final Function<Optional<Locale>, SpreadsheetMetadata> metadata,
                                             final Function<SpreadsheetId, SpreadsheetStoreRepository> spreadsheetIdToRepository) {
         return MemorySpreadsheetContext.with(base,
                 contentType,
                 fractioner,
+                createMetadata,
                 spreadsheetIdFunctions,
-                metadata,
                 spreadsheetIdToRepository);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/context/hateos/SpreadsheetContextCreateAndSaveMetadataHateosHandler.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/hateos/SpreadsheetContextCreateAndSaveMetadataHateosHandler.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@link HateosHandler} that invokes {@link SpreadsheetContext#metadataWithDefaults(Optional<Locale>)}
+ * A {@link HateosHandler} that invokes {@link SpreadsheetContext#createMetadata(Optional<Locale>)}
  */
 final class SpreadsheetContextCreateAndSaveMetadataHateosHandler extends SpreadsheetContextSpreadsheetMetadataStoreHateosHandler {
 
@@ -65,16 +65,20 @@ final class SpreadsheetContextCreateAndSaveMetadataHateosHandler extends Spreads
                                                          final Map<HttpRequestAttribute<?>, Object> parameters) {
         checkResourceEmpty(metadata);
 
-        return Optional.of(this.context.metadataWithDefaults( HttpHeaderName.ACCEPT_LANGUAGE.parameterValue(parameters)
-                .flatMap(this::preferredLocal)));
+        final SpreadsheetMetadata saved = this.context.createMetadata(HttpHeaderName.ACCEPT_LANGUAGE.parameterValue(parameters)
+                .flatMap(this::preferredLocale));
+        saved.id()
+                .orElseThrow(() -> new IllegalStateException(SpreadsheetMetadata.class.getSimpleName() + " missing id=" + saved));
+
+        return Optional.of(saved);
     }
 
-    private Optional<Locale> preferredLocal(final AcceptLanguage language) {
+    private Optional<Locale> preferredLocale(final AcceptLanguage language) {
         return language.value().get(0).value().locale();
     }
 
     @Override
     String operation() {
-        return "saveMetadata";
+        return "create/saveMetadata";
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/context/hateos/SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/context/hateos/SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest.java
@@ -58,6 +58,23 @@ public final class SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest exte
     }
 
     @Test
+    public void testHandleWithoutIdCreatesMetadataWithLocaleWithoutIdFails() {
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com")));
+
+        this.handleFails(this.createHandler(new FakeSpreadsheetContext() {
+
+                    @Override
+                    public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
+                        return metadata.set(SpreadsheetMetadataPropertyName.LOCALE, locale.get());
+                    }
+                }),
+                Optional.empty(),
+                Optional.empty(),
+                Maps.of(HttpHeaderName.ACCEPT_LANGUAGE, AcceptLanguage.parse("en;q=0.8, fr-CA;q=0.9")),
+                IllegalStateException.class);
+    }
+
+    @Test
     public void testHandleWithoutIdCreatesMetadataWithLocale() {
         final SpreadsheetMetadata metadata = SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, this.spreadsheetId(),
                 SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com")));
@@ -67,7 +84,7 @@ public final class SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest exte
         this.handleAndCheck(this.createHandler(new FakeSpreadsheetContext() {
 
                     @Override
-                    public SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {
+                    public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
                         return metadata.set(SpreadsheetMetadataPropertyName.LOCALE, locale.get());
                     }
                 }),
@@ -85,7 +102,7 @@ public final class SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest exte
         this.handleAndCheck(this.createHandler(new FakeSpreadsheetContext() {
 
                     @Override
-                    public SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {
+                    public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
                         return metadata;
                     }
                 }),
@@ -128,7 +145,7 @@ public final class SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest exte
     @Test
     public final void testToString() {
         final SpreadsheetContext context = this.context();
-        this.toStringAndCheck(this.createHandler(context), context + " saveMetadata");
+        this.toStringAndCheck(this.createHandler(context), context + " create/saveMetadata");
     }
 
     // helpers..........................................................................................................
@@ -142,13 +159,13 @@ public final class SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest exte
     SpreadsheetContext context() {
         return new FakeSpreadsheetContext() {
             @Override
-            public SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {
-                return SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest.this.metadataWithDefaults();
+            public SpreadsheetMetadata createMetadata(final Optional<Locale> locale) {
+                return SpreadsheetContextCreateAndSaveMetadataHateosHandlerTest.this.createMetadata();
             }
         };
     }
 
-    private SpreadsheetMetadata metadataWithDefaults() {
+    private SpreadsheetMetadata createMetadata() {
         return SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.CREATE_DATE_TIME,
                 LocalDateTime.of(2000, 12, 31, 12, 58, 59)));
     }


### PR DESCRIPTION
- SpreadsheetContextCreateAndSaveMetadataHateosHandler.toString improved
- SpreadsheetContextCreateAndSaveMetadataHateosHandler verifies spreadsheetId present after create.