### PR TITLE
walkingkooka-net-http-server-hateos 6b172e73db4ddf4e714111382da7fd4d3…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContextTest.java
@@ -335,8 +335,9 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
 
                 @Override
                 public Map<HttpHeaderName<?>, Object> headers() {
-                    return Maps.of(HttpHeaderName.CONTENT_TYPE, contentType().contentType(),
-                            HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse("UTF-8"));
+                    return Maps.of(HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse("UTF-8"),
+                            HttpHeaderName.CONTENT_LENGTH, Long.valueOf(this.body().length),
+                            HttpHeaderName.CONTENT_TYPE, contentType().contentType());
                 }
 
                 public Map<HttpRequestParameterName, List<String>> parameters() {
@@ -379,8 +380,9 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
 
                 @Override
                 public Map<HttpHeaderName<?>, Object> headers() {
-                    return Maps.of(HttpHeaderName.CONTENT_TYPE, contentType().contentType(),
-                            HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse("UTF-8"));
+                    return Maps.of(HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse("UTF-8"),
+                            HttpHeaderName.CONTENT_LENGTH, Long.valueOf(this.body().length),
+                            HttpHeaderName.CONTENT_TYPE, contentType().contentType());
                 }
 
                 public Map<HttpRequestParameterName, List<String>> parameters() {


### PR DESCRIPTION
…a70dc28 20190913

- https://github.com/mP1/walkingkooka-net-http-server-hateos/pull/15
- Content-length must match body length

- MemorySpreadsheetContextTest added missing content-length header