### PR TITLE
SpreadsheetFormatterTesting.formatAndCheck removed canFormatAndCheck

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
@@ -53,7 +53,6 @@ public interface SpreadsheetFormatterTesting extends Testing {
                                 final Object value,
                                 final SpreadsheetFormatterContext context,
                                 final SpreadsheetText text) {
-        this.canFormatAndCheck(formatter, value, context, true);
         this.formatAndCheck(formatter,
                 value,
                 context,


### PR DESCRIPTION
- allows testing of default formats.