### PR TITLE
SpreadsheetFormatParserPatterns optional trailing separator

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
@@ -271,8 +271,10 @@ abstract public class SpreadsheetPattern<V> implements Value<V> {
      * Parsers input that requires a single {@link SpreadsheetFormatParserToken token} followed by an optional separator and more tokens.
      */
     private static Parser<SpreadsheetFormatParserContext> parseParser(final Parser<ParserContext> parser) {
+        final Parser<ParserContext> expressionSeparator = SpreadsheetFormatParsers.expressionSeparator().cast();
+
         final Parser<ParserContext> optional = Parsers.sequenceParserBuilder()
-                .required(SpreadsheetFormatParsers.expressionSeparator().cast())
+                .required(expressionSeparator)
                 .required(parser)
                 .build()
                 .repeating();
@@ -280,6 +282,7 @@ abstract public class SpreadsheetPattern<V> implements Value<V> {
         return Parsers.sequenceParserBuilder()
                 .required(parser)
                 .optional(optional.repeating())
+                .optional(expressionSeparator)
                 .build()
                 .orFailIfCursorNotEmpty(ParserReporters.basic())
                 .cast();

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
@@ -134,6 +134,13 @@ public final class SpreadsheetDateParsePatternsTest extends SpreadsheetParsePatt
     }
 
     @Test
+    public void testParseDateOnlyPatternSeparator() {
+        this.parseAndCheck2("dd/mm/yyyy;",
+                "31/12/2000",
+                LocalDate.of(2000, 12, 31));
+    }
+
+    @Test
     public void testParseDateOnlyPatternTwoDigitYear() {
         this.parseAndCheck2("dd/mm/yy",
                 "31/12/20",
@@ -171,6 +178,13 @@ public final class SpreadsheetDateParsePatternsTest extends SpreadsheetParsePatt
     @Test
     public void testParseDateSecondPattern() {
         this.parseAndCheck2("dd/mm/yyyy;yyyy/mm/dd",
+                "2000/12/31",
+                LocalDate.of(2000, 12, 31));
+    }
+
+    @Test
+    public void testParseDateSecondPatternExtraSeparator() {
+        this.parseAndCheck2("dd/mm/yyyy;yyyy/mm/dd;",
                 "2000/12/31",
                 LocalDate.of(2000, 12, 31));
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
@@ -146,8 +146,22 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     }
 
     @Test
+    public void testParseDateTrailingSeparator() {
+        this.parseAndCheck2("yyyymm;",
+                "200012",
+                LocalDateTime.of(2000, 12, 1, 0, 0, 0));
+    }
+
+    @Test
     public void testParseDateTimeMultiplePatterns() {
         this.parseAndCheck2("\"A\"ddmmyyyy hhmmss;\"B\"ddmmyyyy hhmmss",
+                "B31122000 115859",
+                LocalDateTime.of(2000, 12, 31, 11, 58, 59));
+    }
+
+    @Test
+    public void testParseDateTimeMultiplePatternsTrailingSeparator() {
+        this.parseAndCheck2("\"A\"ddmmyyyy hhmmss;\"B\"ddmmyyyy hhmmss;",
                 "B31122000 115859",
                 LocalDateTime.of(2000, 12, 31, 11, 58, 59));
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTest.java
@@ -149,6 +149,34 @@ public final class SpreadsheetNumberParsePatternsTest extends SpreadsheetParsePa
                 BigDecimal.valueOf(1.23));
     }
 
+    @Test
+    public void testParseNumberTrailingSeparator() {
+        this.parseAndCheck2("#.00;",
+                "1.23",
+                BigDecimal.valueOf(1.23));
+    }
+
+    @Test
+    public void testParseNumberFirstPattern() {
+        this.parseAndCheck2("0;0.0%",
+                "9",
+                BigDecimal.valueOf(9));
+    }
+
+    @Test
+    public void testParseNumberSecondPattern() {
+        this.parseAndCheck2("0.0;0$",
+                "9",
+                BigDecimal.valueOf(9 * 100));
+    }
+
+    @Test
+    public void testParseNumberSecondPatternTrailingSeparator() {
+        this.parseAndCheck2("$0.00;0.00;",
+                "1.23",
+                BigDecimal.valueOf(1.23));
+    }
+
     // helpers.........................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTestCase.java
@@ -177,11 +177,6 @@ public abstract class SpreadsheetPatternTestCase<P extends SpreadsheetPattern<V>
         this.parseStringFails("\"unclosed quoted text inside patterns", IllegalArgumentException.class);
     }
 
-    @Test
-    public final void testParseStringHangingSeparatorFails() {
-        this.parseStringFails(this.patternText() + ";", IllegalArgumentException.class);
-    }
-
     // HashCodeEqualsDefined............................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
@@ -140,8 +140,22 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     }
 
     @Test
+    public void testParsePatternTrailingSeparator() {
+        this.parseAndCheck2("hh;",
+                "11",
+                LocalTime.of(11, 0, 0));
+    }
+
+    @Test
     public void testParseHourMultiplePatterns() {
         this.parseAndCheck2("\"A\"hhmmss;\"B\"hhmmss",
+                "B115859",
+                LocalTime.of(11, 58, 59));
+    }
+
+    @Test
+    public void testParseHourMultiplePatternsTrailingSeparator() {
+        this.parseAndCheck2("\"A\"hhmmss;\"B\"hhmmss;",
                 "B115859",
                 LocalTime.of(11, 58, 59));
     }


### PR DESCRIPTION
- reverses previous grammar which failed upon trailing separators
- support added for individual date/dateTime/number/time parse patterns.
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/954