### PR TITLE
BasicSpreadsheetEngine.rowHeight default to metadata

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -507,7 +507,12 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
 
     @Override
     public double rowHeight(final SpreadsheetRowReference row) {
-        return this.cellStore.maxRowHeight(row);
+        double rowHeight = this.cellStore.maxRowHeight(row);
+        if (0 == rowHeight) {
+            rowHeight = this.metadata.get(SpreadsheetMetadataPropertyName.DEFAULT_ROW_HEIGHT)
+                    .orElse(0.0);
+        }
+        return rowHeight;
     }
 
     private final SpreadsheetMetadata metadata;

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -4773,16 +4773,38 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
-    public void testMaxRowHeight() {
+    public void testRowHeight() {
         final SpreadsheetRowReference row = SpreadsheetRowReference.parseRow("987");
         final double expected = 150.5;
         final BasicSpreadsheetEngine engine = BasicSpreadsheetEngine.with(this.id(),
-                this.metadata(),
+                SpreadsheetMetadata.EMPTY,
                 new FakeSpreadsheetCellStore() {
                     @Override
                     public double maxRowHeight(final SpreadsheetRowReference c) {
                         assertEquals(row, c);
                         return expected;
+                    }
+                },
+                SpreadsheetReferenceStores.fake(),
+                SpreadsheetLabelStores.fake(),
+                SpreadsheetReferenceStores.fake(),
+                SpreadsheetRangeStores.fake(),
+                SpreadsheetRangeStores.fake());
+
+        this.rowHeightAndCheck(engine, row, expected);
+    }
+
+    @Test
+    public void testRowHeightDefaults() {
+        final SpreadsheetRowReference row = SpreadsheetRowReference.parseRow("987");
+        final double expected = 150.5;
+        final BasicSpreadsheetEngine engine = BasicSpreadsheetEngine.with(this.id(),
+                SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadataPropertyName.DEFAULT_ROW_HEIGHT, expected),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public double maxRowHeight(final SpreadsheetRowReference c) {
+                        assertEquals(row, c);
+                        return 0;
                     }
                 },
                 SpreadsheetReferenceStores.fake(),


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1054
- SpreadsheetEngine.rowHeight should default to SpreadsheetMetadata.DEFAULT_COLUMN_HEIGHT
