### PR TITLE
SpreadsheetMetadata edit-cell & viewport-cell should call Spreadsheet…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -187,8 +187,7 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
     public final <V> SpreadsheetMetadata set(final SpreadsheetMetadataPropertyName<V> propertyName, final V value) {
         checkPropertyName(propertyName);
 
-        propertyName.checkValue(value);
-        return this.set0(propertyName, value);
+        return this.set0(propertyName, propertyName.checkValue(value));
     }
 
     abstract <V> SpreadsheetMetadata set0(final SpreadsheetMetadataPropertyName<V> propertyName, final V value);

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -317,7 +317,7 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name, Compar
     final JsonPropertyName jsonPropertyName;
 
     /**
-     * Validates the value.
+     * Validates the value, returning the value that will be saved.
      */
     @SuppressWarnings("UnusedReturnValue")
     public T checkValue(final Object value) {
@@ -325,11 +325,10 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name, Compar
             throw new SpreadsheetMetadataPropertyValueException("Missing value", this, value);
         }
 
-        this.checkValue0(value);
-        return Cast.to(value);
+        return this.checkValue0(value);
     }
 
-    abstract void checkValue0(final Object value);
+    abstract T checkValue0(final Object value);
 
     /**
      * Checks the type of the given value and throws a {@link SpreadsheetMetadataPropertyValueException} if this test fails.

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
@@ -31,8 +31,8 @@ abstract class SpreadsheetMetadataPropertyNameCharacter extends SpreadsheetMetad
     }
 
     @Override
-    final void checkValue0(final Object value) {
-        this.checkValueType(value,
+    final Character checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof Character);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameColor.java
@@ -35,8 +35,8 @@ abstract class SpreadsheetMetadataPropertyNameColor extends SpreadsheetMetadataP
     }
 
     @Override
-    final void checkValue0(final Object value) {
-        this.checkValueType(value,
+    final Color checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof Color);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
@@ -37,8 +37,8 @@ final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMet
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    Long checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof Long);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEditCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEditCell.java
@@ -20,9 +20,6 @@ package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 
-import java.util.Locale;
-import java.util.Optional;
-
 /**
  * Holds the cell currently being edited.
  */

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEditRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEditRange.java
@@ -43,8 +43,8 @@ final class SpreadsheetMetadataPropertyNameEditRange extends SpreadsheetMetadata
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetRange checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetRange);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
@@ -32,8 +32,8 @@ abstract class SpreadsheetMetadataPropertyNameEmailAddress extends SpreadsheetMe
     }
 
     @Override
-    final void checkValue0(final Object value) {
-        this.checkValueType(value,
+    final EmailAddress checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof EmailAddress);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
@@ -39,8 +39,8 @@ final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends Spreadsh
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    ExpressionNumberKind checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof ExpressionNumberKind);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
@@ -31,8 +31,8 @@ abstract class SpreadsheetMetadataPropertyNameLocalDateTime extends SpreadsheetM
     }
 
     @Override
-    final void checkValue0(final Object value) {
-        this.checkValueType(value,
+    final LocalDateTime checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof LocalDateTime);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
@@ -37,8 +37,8 @@ final class SpreadsheetMetadataPropertyNameLocale extends SpreadsheetMetadataPro
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    Locale checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof Locale);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePrecision.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePrecision.java
@@ -34,12 +34,13 @@ final class SpreadsheetMetadataPropertyNamePrecision extends SpreadsheetMetadata
     }
 
     @Override
-    void checkValue0(final Object value) {
+    Integer checkValue0(final Object value) {
         final Integer integerValue = this.checkValueType(value,
                 v -> v instanceof Integer);
         if (integerValue < 0) {
             throw new SpreadsheetMetadataPropertyValueException("Expected value >= 0", this, integerValue);
         }
+        return integerValue;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
@@ -38,8 +38,8 @@ final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetad
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    RoundingMode checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof RoundingMode);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetCellReference.java
@@ -31,10 +31,14 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetCellReference extends S
         super(name);
     }
 
+    /**
+     * After checking the type force the {@link SpreadsheetCellReference#toRelative()}
+     */
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
-                v -> v instanceof SpreadsheetCellReference);
+    final SpreadsheetCellReference checkValue0(final Object value) {
+        return this.checkValueType(value,
+                v -> v instanceof SpreadsheetCellReference)
+                .toRelative();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
@@ -40,8 +40,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern extends 
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetDateFormatPattern checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetDateFormatPattern);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns extends 
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetDateParsePatterns checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetDateParsePatterns);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
@@ -40,8 +40,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern exte
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetDateTimeFormatPattern checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetDateTimeFormatPattern);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns exte
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetDateTimeParsePatterns checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetDateTimeParsePatterns);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
@@ -40,8 +40,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMeta
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetId checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetId);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
@@ -40,8 +40,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMe
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetName checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetName);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern extend
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetNumberFormatPattern checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetNumberFormatPattern);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePatterns.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePatterns extend
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetNumberParsePatterns checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetNumberParsePatterns);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern.java
@@ -39,8 +39,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern extends 
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetTextFormatPattern checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetTextFormatPattern);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern extends 
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetTimeFormatPattern checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetTimeFormatPattern);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns.java
@@ -41,8 +41,8 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns extends 
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetTimeParsePatterns checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetTimeParsePatterns);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
@@ -31,12 +31,13 @@ abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadata
     }
 
     @Override
-    final void checkValue0(final Object value) {
+    final String checkValue0(final Object value) {
         final String stringValue = this.checkValueType(value,
                 v -> v instanceof String);
         if (stringValue.isEmpty()) {
             throw new SpreadsheetMetadataPropertyValueException("Invalid value", this, stringValue);
         }
+        return stringValue;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
@@ -50,21 +50,22 @@ final class SpreadsheetMetadataPropertyNameStyle extends SpreadsheetMetadataProp
     }
 
     @Override
-    void checkValue0(final Object value) {
+    TextStyle checkValue0(final Object value) {
         final TextStyle style = this.checkValueType(value, v -> v instanceof TextStyle);
 
         final Set<TextStylePropertyName<?>> missing = Sets.ordered();
-        for(final TextStylePropertyName<?> required : REQUIRED) {
-            if(false == style.get(required).isPresent()) {
+        for (final TextStylePropertyName<?> required : REQUIRED) {
+            if (false == style.get(required).isPresent()) {
                 missing.add(required);
             }
         }
 
-        if(false == missing.isEmpty()) {
+        if (false == missing.isEmpty()) {
             throw new SpreadsheetMetadataPropertyValueException("Missing required properties " + missing,
                     this,
                     value);
         }
+        return style;
     }
 
     private final static TextStylePropertyName[] REQUIRED = new TextStylePropertyName[] {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTwoYearDigit.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTwoYearDigit.java
@@ -34,12 +34,13 @@ final class SpreadsheetMetadataPropertyNameTwoYearDigit extends SpreadsheetMetad
     }
 
     @Override
-    void checkValue0(final Object value) {
+    Integer checkValue0(final Object value) {
         final Integer integerValue = this.checkValueType(value,
                 v -> v instanceof Integer);
         if (integerValue < 0 || integerValue > 99) {
             throw new SpreadsheetMetadataPropertyValueException("Expected int between 0 and including 99", this, integerValue);
         }
+        return integerValue;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCoordinates.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCoordinates.java
@@ -48,8 +48,8 @@ final class SpreadsheetMetadataPropertyNameViewportCoordinates extends Spreadshe
     }
 
     @Override
-    void checkValue0(final Object value) {
-        this.checkValueType(value,
+    SpreadsheetCoordinates checkValue0(final Object value) {
+        return this.checkValueType(value,
                 v -> v instanceof SpreadsheetCoordinates);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameWidth.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameWidth.java
@@ -34,12 +34,13 @@ final class SpreadsheetMetadataPropertyNameWidth extends SpreadsheetMetadataProp
     }
 
     @Override
-    void checkValue0(final Object value) {
+    Integer checkValue0(final Object value) {
         final Integer integerValue = this.checkValueType(value,
                 v -> v instanceof Integer);
         if (integerValue < 0) {
             throw new SpreadsheetMetadataPropertyValueException("Expected int > 0", this, integerValue);
         }
+        return integerValue;
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -104,6 +104,23 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         assertEquals(SpreadsheetMetadataNonEmptyMap.class, metadata.value().getClass(), () -> "" + metadata);
     }
 
+    @Test
+    public void testSetEditCell() {
+        this.setAndCheck(SpreadsheetMetadataPropertyName.EDIT_CELL);
+    }
+
+    @Test
+    public void testSetViewportCell() {
+        this.setAndCheck(SpreadsheetMetadataPropertyName.VIEWPORT_CELL);
+    }
+
+    private void setAndCheck(final SpreadsheetMetadataPropertyName<SpreadsheetCellReference> property) {
+        final SpreadsheetCellReference reference = SpreadsheetCellReference.parseCellReference("B99");
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(property, reference.toAbsolute());
+        assertEquals(reference, metadata.getOrFail(property));
+    }
+
     // NON_LOCALE_DEFAULTS..............................................................................................
 
     @Test


### PR DESCRIPTION
…CellReference.toRelative in set

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1131
- SpreadsheetMetadata edit-cell & viewport-cell should call SpreadsheetCellReference.toRelative in set

- SpreadsheetMetadataPropertyName.checkValue now returns T was void previously.