### PR TITLE
SpreadsheetCellReference/SpreadsheetColumnReference parse support low…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -71,6 +71,33 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
                 column1, column2, column3, column4);
     }
 
+    // parseColumn.......................................................................................................
+
+    @Test
+    public void testParseColumnUpperCased() {
+        this.parseStringAndCheck("A", SpreadsheetColumnReference.with(0, SpreadsheetReferenceKind.RELATIVE));
+    }
+
+    @Test
+    public void testParseColumnUpperCased2() {
+        this.parseStringAndCheck("B", SpreadsheetColumnReference.with(1, SpreadsheetReferenceKind.RELATIVE));
+    }
+
+    @Test
+    public void testParseColumnUpperCasedAbsolute() {
+        this.parseStringAndCheck("$C", SpreadsheetColumnReference.with(2, SpreadsheetReferenceKind.ABSOLUTE));
+    }
+
+    @Test
+    public void testParseColumnLowerCased() {
+        this.parseStringAndCheck("d", SpreadsheetColumnReference.with(3, SpreadsheetReferenceKind.RELATIVE));
+    }
+
+    @Test
+    public void testParseColumnLowerCasedAbsolute() {
+        this.parseStringAndCheck("$e", SpreadsheetColumnReference.with(4, SpreadsheetReferenceKind.ABSOLUTE));
+    }
+
     // parseColumnRange....................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
@@ -45,8 +45,23 @@ public final class SpreadsheetExpressionReferenceTest implements ClassTesting2<S
     }
 
     @Test
-    public void testIsTextCellWithCellReference() {
+    public void testIsTextCellWithCellReferenceUppercase() {
         this.isTextCellReferenceAndCheck("A1", true);
+    }
+
+    @Test
+    public void testIsTextCellWithCellReferenceUppercaseAbsolute() {
+        this.isTextCellReferenceAndCheck("$A1", true);
+    }
+
+    @Test
+    public void testIsTextCellWithCellReferenceLowercase() {
+        this.isTextCellReferenceAndCheck("a1", true);
+    }
+
+    @Test
+    public void testIsTextCellWithCellReferenceLowercaseAbsolute() {
+        this.isTextCellReferenceAndCheck("$a1", true);
     }
 
     @Test
@@ -95,9 +110,39 @@ public final class SpreadsheetExpressionReferenceTest implements ClassTesting2<S
     // parse............................................................................................................
 
     @Test
-    public void testParseCellReference() {
-        final String reference = "A1";
-        this.parseStringAndCheck(reference, SpreadsheetExpressionReference.parseCellReference(reference));
+    public void testParseCellReferenceUpperCaseRelativeRelative() {
+        final String reference = "A2";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(0).setRow(SpreadsheetReferenceKind.RELATIVE.row(1)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseRelativeAbsolute() {
+        final String reference = "C$4";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(2).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(3)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseAbsoluteRelative() {
+        final String reference = "$E6";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(4).setRow(SpreadsheetReferenceKind.RELATIVE.row(5)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseAbsoluteAbsolute() {
+        final String reference = "$G$8";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(6).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(7)));
+    }
+
+    @Test
+    public void testParseCellReferenceLowercaseRelativeRelative() {
+        final String reference = "i10";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(8).setRow(SpreadsheetReferenceKind.RELATIVE.row(9)));
+    }
+
+    @Test
+    public void testParseCellReferenceLowercaseAbsolute() {
+        final String reference = "$k12";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(10).setRow(SpreadsheetReferenceKind.RELATIVE.row(11)));
     }
 
     @Test


### PR DESCRIPTION
…ercase letters

- Also fixed SpreadsheetExpressionReference.isTextCellReference/parse support for absolute column/row components.