### PR TITLE
SpreadsheetMetadataComponents now checks defaults

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -173,19 +173,19 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
     public final <V> Optional<V> get(final SpreadsheetMetadataPropertyName<V> propertyName) {
         checkPropertyName(propertyName);
 
-        return this.get0(propertyName);
+        return this.getOrGetDefaults(propertyName);
     }
 
     /**
      * Potentially recursive fetch to find a property, trying locally and then the defaults if one is present.
      */
-    private <V> Optional<V> get0(final SpreadsheetMetadataPropertyName<V> propertyName) {
-        Optional<V> value = this.get1(propertyName);
+    final <V> Optional<V> getOrGetDefaults(final SpreadsheetMetadataPropertyName<V> propertyName) {
+        Optional<V> value = this.getIgnoringDefaults(propertyName);
         if (false == value.isPresent()) {
             // try again with defaults
             final SpreadsheetMetadata defaults = this.defaults;
             if (null != defaults) {
-                value = defaults.get0(propertyName);
+                value = defaults.getOrGetDefaults(propertyName);
             }
         }
         return value;
@@ -194,7 +194,7 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
     /**
      * Sub classes will fetch the property returning the value.
      */
-    abstract <V> Optional<V> get1(final SpreadsheetMetadataPropertyName<V> propertyName);
+    abstract <V> Optional<V> getIgnoringDefaults(final SpreadsheetMetadataPropertyName<V> propertyName);
 
     /**
      * Fetches the required property or throws a {@link SpreadsheetMetadataPropertyValueException}.

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponents.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponents.java
@@ -24,6 +24,10 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+/**
+ * Used to aggregate that all the required properties are present, tracking those that are missing.
+ * This is used only by {@link SpreadsheetMetadata} methods such as getting a {@link walkingkooka.convert.Converter}.
+ */
 final class SpreadsheetMetadataComponents {
 
     static SpreadsheetMetadataComponents with(final SpreadsheetMetadata metadata) {
@@ -46,7 +50,7 @@ final class SpreadsheetMetadataComponents {
 
     <T> T getOrElse(final SpreadsheetMetadataPropertyName<T> propertyName,
                     final Supplier<T> defaultValue) {
-        return this.metadata.get1(propertyName)
+        return this.metadata.getOrGetDefaults(propertyName)
                 .orElseGet(() -> {
                     final T value = defaultValue.get();
                     if (null == value) {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
@@ -73,7 +73,7 @@ final class SpreadsheetMetadataEmpty extends SpreadsheetMetadata {
     // get/set/remove...................................................................................................
 
     @Override
-    <V> Optional<V> get1(final SpreadsheetMetadataPropertyName<V> propertyName) {
+    <V> Optional<V> getIgnoringDefaults(final SpreadsheetMetadataPropertyName<V> propertyName) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
@@ -94,7 +94,7 @@ final class SpreadsheetMetadataNonEmpty extends SpreadsheetMetadata {
     // get..............................................................................................................
 
     @Override
-    <V> Optional<V> get1(final SpreadsheetMetadataPropertyName<V> propertyName) {
+    <V> Optional<V> getIgnoringDefaults(final SpreadsheetMetadataPropertyName<V> propertyName) {
         return Optional.ofNullable(Cast.to(this.value.get(propertyName)));
     }
 


### PR DESCRIPTION
- Fixes numerous public SpreadsheetMetadata component getters
- SpreadsheetMetadata internal getXXX methods given improved naming