### PR TITLE
SpreadsheetMetadata.decimalNumberContext no longer Locale defaults

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponents.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponents.java
@@ -17,14 +17,11 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.text.CharSequences;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -43,30 +40,15 @@ final class SpreadsheetMetadataComponents {
     }
 
     <T> T getOrNull(final SpreadsheetMetadataPropertyName<T> propertyName) {
-        return this.getOrElse(propertyName, this::defaultNull);
-    }
-
-    @SuppressWarnings("SameReturnValue")
-    private <T> T defaultNull() {
-        return null;
-    }
-
-    <T> T getOrElse(final SpreadsheetMetadataPropertyName<T> propertyName,
-                    final Supplier<T> defaultValue) {
         return this.metadata.getOrGetDefaults(propertyName)
-                .orElseGet(() -> {
-                    final T value = defaultValue.get();
-                    if (null == value) {
-                        this.addMissing(propertyName);
-                    }
-                    return value;
-                });
+                .orElseGet(() -> this.addMissing(propertyName));
     }
 
     final SpreadsheetMetadata metadata;
 
-    private void addMissing(final SpreadsheetMetadataPropertyName<?> propertyName) {
+    private <T> T addMissing(final SpreadsheetMetadataPropertyName<?> propertyName) {
         this.missing.add(propertyName);
+        return null;
     }
 
     void reportIfMissing() {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDecimalNumberContextComponents.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDecimalNumberContextComponents.java
@@ -22,10 +22,7 @@ import walkingkooka.math.DecimalNumberContexts;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.text.DecimalFormatSymbols;
 import java.util.Locale;
-import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Handles building a {@link DecimalNumberContext} for {@link SpreadsheetMetadata#decimalNumberContext()}.
@@ -44,13 +41,13 @@ final class SpreadsheetMetadataDecimalNumberContextComponents {
     final DecimalNumberContext decimalNumberContext() {
         final SpreadsheetMetadataComponents components = this.components;
 
-        final String currencySymbol = components.getOrElse(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, this::localeCurrencySymbol);
-        final Character decimalSeparator = components.getOrElse(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, this::localeDecimalSeparator);
+        final String currencySymbol = components.getOrNull(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL);
+        final Character decimalSeparator = components.getOrNull(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR);
         final String exponentSymbol = components.getOrNull(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL);
-        final Character groupingSeparator = components.getOrElse(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, this::localeGroupingSeparator);
-        final Character negativeSign = components.getOrElse(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, this::localeNegativeSign);
-        final Character percentSymbol = components.getOrElse(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, this::localePercentageSymbol);
-        final Character positiveSign = components.getOrElse(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, this::localePositiveSign);
+        final Character groupingSeparator = components.getOrNull(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR);
+        final Character negativeSign = components.getOrNull(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN);
+        final Character percentSymbol = components.getOrNull(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL);
+        final Character positiveSign = components.getOrNull(SpreadsheetMetadataPropertyName.POSITIVE_SIGN);
 
         final Locale locale = components.getOrNull(SpreadsheetMetadataPropertyName.LOCALE);
 
@@ -69,61 +66,6 @@ final class SpreadsheetMetadataDecimalNumberContextComponents {
                 locale,
                 new MathContext(precision, roundingMode));
     }
-
-    private String localeCurrencySymbol() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::currencySymbol);
-    }
-
-    private Character localeDecimalSeparator() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::decimalSeparator);
-    }
-
-    private Character localeGroupingSeparator() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::groupingSeparator);
-    }
-
-    private Character localeNegativeSign() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::negativeSign);
-    }
-
-    private Character localePercentageSymbol() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::percentageSymbol);
-    }
-
-    private Character localePositiveSign() {
-        return this.tryPropertyFromLocale(DecimalNumberContext::positiveSign);
-    }
-
-    private <T> T tryPropertyFromLocale(final Function<DecimalNumberContext, T> localDecimalNumberContextGetter) {
-        final DecimalNumberContext decimalNumberContext = this.localDecimalNumberContext();
-        return null != decimalNumberContext ?
-                localDecimalNumberContextGetter.apply(decimalNumberContext) :
-                null;
-    }
-
-    /**
-     * Lazy {@link Locale} getter.
-     */
-    @SuppressWarnings("OptionalAssignedToNull")
-    private DecimalNumberContext localDecimalNumberContext() {
-        if (null == this.locale) {
-            this.locale = this.components.metadata.get(SpreadsheetMetadataPropertyName.LOCALE);
-            this.decimalNumberContext = this.locale
-                    .map(this::localDecimalNumberContext0)
-                    .orElse(null);
-        }
-        return this.decimalNumberContext;
-    }
-
-    private DecimalNumberContext localDecimalNumberContext0(final Locale locale) {
-        return DecimalNumberContexts.decimalFormatSymbols(DecimalFormatSymbols.getInstance(locale),
-                '+',
-                locale,
-                MathContext.DECIMAL32); // exponent, plus, MathContext ignored
-    }
-
-    private Optional<Locale> locale;
-    private DecimalNumberContext decimalNumberContext;
 
     final SpreadsheetMetadataComponents components;
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponentsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponentsTest.java
@@ -56,37 +56,6 @@ public final class SpreadsheetMetadataComponentsTest implements ClassTesting2,
         this.checkMissing(components);
     }
 
-    // getOrElse........................................................................................................
-
-    @Test
-    public void testGetOrElseAbsentSupplierNull() {
-        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.EMPTY);
-        assertEquals(null, components.getOrElse(SpreadsheetMetadataPropertyName.CREATOR, () -> null));
-        this.checkMissing(components, SpreadsheetMetadataPropertyName.CREATOR);
-    }
-
-    @Test
-    public void testGetOrElseSupplierPresent() {
-        final SpreadsheetMetadataPropertyName<EmailAddress> property = SpreadsheetMetadataPropertyName.CREATOR;
-        final EmailAddress value = EmailAddress.parse("user@example.com");
-
-        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.EMPTY);
-        assertEquals(value, components.getOrElse(property, () -> value));
-        this.checkMissing(components);
-    }
-
-    @Test
-    public void testGetOrElsePresent() {
-        final SpreadsheetMetadataPropertyName<EmailAddress> property = SpreadsheetMetadataPropertyName.CREATOR;
-        final EmailAddress value = EmailAddress.parse("user@example.com");
-
-        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.with(Maps.of(property, value)));
-        assertEquals(value, components.getOrElse(property, () -> {
-            throw new UnsupportedOperationException();
-        }));
-        this.checkMissing(components);
-    }
-
     // reportIfMissing..................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -66,7 +66,6 @@ import java.math.BigInteger;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.text.DateFormatSymbols;
-import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -687,7 +686,13 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     private SpreadsheetMetadata createSpreadsheetMetadataWithConverterAndConverterContext() {
         return this.createSpreadsheetMetadataWithConverter()
+                .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "C")
+                .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, 'D')
                 .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
+                .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, 'G')
+                .set(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, 'N')
+                .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, 'R')
+                .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, 'P')
                 .set(SpreadsheetMetadataPropertyName.PRECISION, 16)
                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.DOWN);
     }
@@ -790,38 +795,6 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 });
     }
 
-    @Test
-    public void testDecimalNumberContextLocaleDefaults() {
-        final String exponentSymbol = "E";
-        final Character positiveSign = '+';
-
-        Arrays.stream(Locale.getAvailableLocales())
-                .forEach(locale -> Lists.of(MathContext.DECIMAL32, MathContext.DECIMAL64, MathContext.DECIMAL128, MathContext.UNLIMITED)
-                        .forEach(mc -> {
-                            final int precision = mc.getPrecision();
-                            final RoundingMode roundingMode = mc.getRoundingMode();
-
-                            final DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(locale);
-
-                            this.decimalNumberContextAndCheck(SpreadsheetMetadata.EMPTY
-                                            .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, exponentSymbol)
-                                            .set(SpreadsheetMetadataPropertyName.LOCALE, locale)
-                                            .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, positiveSign)
-                                            .set(SpreadsheetMetadataPropertyName.PRECISION, precision)
-                                            .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, roundingMode),
-                                    symbols.getCurrencySymbol(),
-                                    symbols.getDecimalSeparator(),
-                                    exponentSymbol,
-                                    symbols.getGroupingSeparator(),
-                                    locale,
-                                    symbols.getMinusSign(),
-                                    symbols.getPercent(),
-                                    positiveSign,
-                                    precision,
-                                    roundingMode);
-                        }));
-    }
-
     private void decimalNumberContextAndCheck(final SpreadsheetMetadata metadata,
                                               final String currencySymbol,
                                               final Character decimalSeparator,
@@ -849,9 +822,14 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     @Test
     public void testDecimalNumberContextCached() {
         final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "C")
+                .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, 'D')
                 .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
+                .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, 'G')
                 .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
-                .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, '+')
+                .set(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, 'N')
+                .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, 'R')
+                .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, 'P')
                 .set(SpreadsheetMetadataPropertyName.PRECISION, 16)
                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.FLOOR);
         assertSame(metadata.decimalNumberContext(), metadata.decimalNumberContext());
@@ -1025,7 +1003,14 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     private SpreadsheetMetadata createSpreadsheetMetadataWithFormatterContext() {
         return this.createSpreadsheetMetadataWithConverter()
+                .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "C")
+                .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, 'D')
                 .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
+                .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, 'G')
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, 'N')
+                .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, 'R')
+                .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, 'P')
                 .set(SpreadsheetMetadataPropertyName.PRECISION, 10)
                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.DOWN)
                 .set(SpreadsheetMetadataPropertyName.WIDTH, 10);
@@ -1120,16 +1105,20 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     @Test
     public void testParserContext() {
-        final SpreadsheetMetadata metadata = SpreadsheetMetadataNonEmpty.with(
-                Maps.of(
-                        SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E",
-                        SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.DOUBLE,
-                        SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH,
-                        SpreadsheetMetadataPropertyName.PRECISION, 16,
-                        SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.FLOOR,
-                        SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20
-                )
-        );
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "C")
+                .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, 'D')
+                .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
+                .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.DOUBLE)
+                .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, 'G')
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, 'N')
+                .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, 'R')
+                .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, 'P')
+                .set(SpreadsheetMetadataPropertyName.PRECISION, 10)
+                .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.DOWN)
+                .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20);
+
         assertSame(metadata.parserContext(), metadata.parserContext());
     }
 


### PR DESCRIPTION
- SpreadsheetMetadataComponents.getOrElse() removed
- SpreadsheetMetadataDecimalNumberContextComponents no longer uses locale to source defaults for missing properties.