### PR TITLE
SpreadsheetDateTimeParsePatterns & SpreadsheetTimeParsePatterns parsi…

### DIFF
--- a/src/main/resources/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
+++ b/src/main/resources/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
@@ -92,7 +92,8 @@ DATE_DATETIME_TIME            = COLOR | CONDITION | ESCAPE | DATETIME_TEXT_LITER
 
 (* seconds decimal zeroes.............................................................................................*)
 SECOND_MILLIS                 = SECOND,
-                                [ DECIMAL_POINT, DIGIT_ZERO, [{DIGIT_ZERO}]];
+                                [ DECIMAL_POINT, [{DIGIT_ZERO}]];
+
 
 
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
@@ -97,24 +97,80 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     }
 
     @Test
-    public void testParseHourMinutesOnlyPattern() {
+    public void testParseHourMinutes() {
         this.parseAndCheck2("hh:mm",
                 "11:59",
                 LocalDateTime.of(1900, 1, 1, 11, 59));
     }
 
     @Test
-    public void testParseHourMinutesSecondsOnlyPattern() {
+    public void testParseHourMinutesSeconds() {
         this.parseAndCheck2("hh:mm:ss",
                 "11:58:59",
                 LocalDateTime.of(1900, 1, 1, 11, 58, 59));
     }
 
     @Test
-    public void testParseHourMinutesSecondsAmpmOnlyPattern() {
+    public void testParseHourMinutesSecondsDecimal() {
+        this.parseAndCheck2("hh:mm:ss.",
+                "11:58:59.",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59));
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsMillis() {
+        this.parseAndCheck2("hh:mm:ss.0",
+                "11:58:59.1",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59, 100 * 1000));
+    }
+
+    @Test
+    public void testParseHourMinutesSeconds2Millis() {
+        this.parseAndCheck2("hh:mm:ss.00",
+                "11:58:59.12",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59, 120 * 1000));
+    }
+
+    @Test
+    public void testParseHourMinutesSeconds3Millis() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.123",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59, 123 * 1000));
+    }
+
+    @Test
+    public void testParseHourMinutesSeconds3Millis2() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.12",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59, 120 * 1000));
+    }
+
+    @Test
+    public void testParseHourMinutesSeconds3Millis3() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.1",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59, 100 * 1000));
+    }
+
+    @Test
+    public void testParseHourMinutesSeconds3Millis4() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.",
+                LocalDateTime.of(1900, 1, 1, 11, 58, 59));
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsAmpm() {
         this.parseAndCheck2("hh:mm:ss AM/PM",
                 "11:58:59 PM",
                 LocalDateTime.of(1900, 1, 1, 23, 58, 59));
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsMillisAmpm() {
+        this.parseAndCheck2("hh:mm:ss.0 AM/PM",
+                "11:58:59.1 PM",
+                LocalDateTime.of(1900, 1, 1, 23, 58, 59, 100 * 1000));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
@@ -112,24 +112,118 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     }
 
     @Test
-    public void testParseHourMinutesOnlyPattern() {
+    public void testParseHourMinutes() {
         this.parseAndCheck2("hh:mm",
                 "11:59",
                 LocalTime.of(11, 59));
     }
 
     @Test
-    public void testParseHourMinutesSecondsOnlyPattern() {
+    public void testParseHourMinutesSeconds() {
         this.parseAndCheck2("hh:mm:ss",
                 "11:58:59",
                 LocalTime.of(11, 58, 59));
     }
 
     @Test
-    public void testParseHourMinutesSecondsAmpmOnlyPattern() {
+    public void testParseHourMinutesSecondsDecimal() {
+        this.parseAndCheck2("hh:mm:ss.",
+                "11:58:59",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal2() {
+        this.parseAndCheck2("hh:mm:ss.",
+                "11:58:59.",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal1Millis() {
+        this.parseAndCheck2("hh:mm:ss.0",
+                "11:58:59.1",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal1Millis2() {
+        this.parseAndCheck2("hh:mm:ss.0",
+                "11:58:59.",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal2Millis() {
+        this.parseAndCheck2("hh:mm:ss.00",
+                "11:58:59.12",
+                LocalTime.of(11, 58, 59, 120 * 1000)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal3Millis() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.123",
+                LocalTime.of(11, 58, 59, 123 * 1000)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal3Millis2() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.12",
+                LocalTime.of(11, 58, 59, 120 * 1000)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal3Millis3() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.1",
+                LocalTime.of(11, 58, 59, 120 * 1000)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal3Millis4() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59.",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsDecimal3Millis5() {
+        this.parseAndCheck2("hh:mm:ss.000",
+                "11:58:59",
+                LocalTime.of(11, 58, 59)
+        );
+    }
+
+    @Test
+    public void testParseHourMinutesAmpm() {
+        this.parseAndCheck2("hh:mm AM/PM",
+                "11:58 PM",
+                LocalTime.of(23, 58));
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsAmpm() {
         this.parseAndCheck2("hh:mm:ss AM/PM",
                 "11:58:59 PM",
                 LocalTime.of(23, 58, 59));
+    }
+
+    @Test
+    public void testParseHourMinutesSecondsMillisAmpm() {
+        this.parseAndCheck2("hh:mm:ss.0 AM/PM",
+                "11:58:59.1 PM",
+                LocalTime.of(23, 58, 59, 100 * 1000));
     }
 
     @Test


### PR DESCRIPTION
…ng value milliseconds fix

- decimal-point and milliseconds are always optional. Pattern notes maximum not minimum number of digits.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1222
- SpreadsheetFormatTimeParsePattern millisecond value not pattern parsing broken