### PR TITLE
BasicSpreadsheetEngineSpreadsheetParserTokenVisitor Introduced

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
@@ -61,13 +61,13 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn extends BasicS
     }
 
     @Override
-    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
+    Optional<SpreadsheetColumnReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
         return this.deleteOrInsert.isDeletedReference(token) ?
-                INVALID_CELL_REFERENCE :
+                Optional.empty() :
                 this.fixCellReferencesWithinExpression0(token);
     }
 
-    private Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression0(final SpreadsheetColumnReferenceParserToken token) {
+    private Optional<SpreadsheetColumnReferenceParserToken> fixCellReferencesWithinExpression0(final SpreadsheetColumnReferenceParserToken token) {
         final SpreadsheetColumnReference old = token.value();
         final int value = old.value();
 
@@ -82,7 +82,7 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn extends BasicS
     }
 
     @Override
-    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
+    Optional<SpreadsheetRowReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
         // only fixing cols refs not rows
         return Optional.of(token);
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
@@ -142,21 +142,16 @@ abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
     }
 
     /**
-     * Returned when the input reference was deleted.
-     */
-    final static Optional<SpreadsheetParserToken> INVALID_CELL_REFERENCE = Optional.empty();
-
-    /**
      * Handles a column {@link SpreadsheetColumnReferenceParserToken} within an expression.
      * It may be returned unmodified, replaced by a function if the reference was deleted or simply have the reference adjusted.
      */
-    abstract Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token);
+    abstract Optional<SpreadsheetColumnReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token);
 
     /**
      * Handles a column {@link SpreadsheetRowReferenceParserToken} within an expression.
      * It may be returned unmodified, replaced by a function if the reference was deleted or simply have the reference adjusted.
      */
-    abstract Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token);
+    abstract Optional<SpreadsheetRowReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token);
 
     /**
      * Adjusts the reference to match the delete or insert column/row value to it still points to the "same" cell.

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
@@ -61,19 +61,19 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow extends BasicSpre
     }
 
     @Override
-    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
+    Optional<SpreadsheetColumnReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
         // only fixing rows refs not cols
         return Optional.of(token);
     }
 
     @Override
-    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
+    Optional<SpreadsheetRowReferenceParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
         return this.deleteOrInsert.isDeletedReference(token) ?
-                INVALID_CELL_REFERENCE :
+                Optional.empty() :
                 this.fixCellReferencesWithinExpression0(token);
     }
 
-    private Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression0(final SpreadsheetRowReferenceParserToken token) {
+    private Optional<SpreadsheetRowReferenceParserToken> fixCellReferencesWithinExpression0(final SpreadsheetRowReferenceParserToken token) {
         final SpreadsheetRowReference old = token.value();
         final int value = old.value();
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
@@ -19,61 +19,17 @@ package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.stack.Stack;
-import walkingkooka.collect.stack.Stacks;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
-import walkingkooka.spreadsheet.parser.SpreadsheetAdditionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetApostropheSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetBetweenSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetColumnReferenceParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDivideSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDivisionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDoubleQuoteSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetExpressionNumberParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetFunctionNameParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetFunctionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGroupParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLabelNameParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMinusSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMultiplicationParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMultiplySymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNegativeParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisCloseSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisOpenSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
-import walkingkooka.spreadsheet.parser.SpreadsheetPercentSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPercentageParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPlusSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPowerParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPowerSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetRangeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetRowReferenceParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetSubtractionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetTextLiteralParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetTextParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetValueSeparatorSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetWhitespaceParserToken;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.ParentParserToken;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.visit.Visiting;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -81,7 +37,7 @@ import java.util.function.BiFunction;
  * A {@link SpreadsheetParserTokenVisitor} that handles visiting and updating {@link SpreadsheetCellReferenceParserToken}
  * so cell references after an insert or delete row/column are corrected.
  */
-final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor extends BasicSpreadsheetEngineSpreadsheetParserTokenVisitor {
 
     /**
      * Accepts a token tree and updates rows and columns.
@@ -111,327 +67,32 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellRefere
 
     private final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow;
 
-    @Override
-    protected Visiting startVisit(final SpreadsheetAdditionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetAdditionParserToken token) {
-        this.exit(token, SpreadsheetParserToken::addition);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetCellReferenceParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetCellReferenceParserToken token) {
-        this.exit(token, SpreadsheetParserToken::cellReference);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetDivisionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetDivisionParserToken token) {
-        this.exit(token, SpreadsheetParserToken::division);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetEqualsParserToken token) {
-        this.exit(token, SpreadsheetParserToken::equalsParserToken);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetFunctionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetFunctionParserToken token) {
-        this.exit(token, SpreadsheetParserToken::function);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGreaterThanParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGreaterThanParserToken token) {
-        this.exit(token, SpreadsheetParserToken::greaterThan);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
-        this.exit(token, SpreadsheetParserToken::greaterThanEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGroupParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGroupParserToken token) {
-        this.exit(token, SpreadsheetParserToken::group);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetLessThanParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetLessThanParserToken token) {
-        this.exit(token, SpreadsheetParserToken::lessThan);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetLessThanEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetLessThanEqualsParserToken token) {
-        this.exit(token, SpreadsheetParserToken::lessThanEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetMultiplicationParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetMultiplicationParserToken token) {
-        this.exit(token, SpreadsheetParserToken::multiplication);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetNegativeParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetNegativeParserToken token) {
-        this.exit(token, SpreadsheetParserToken::negative);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetNotEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetNotEqualsParserToken token) {
-        this.exit(token, SpreadsheetParserToken::notEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetPercentageParserToken token) {
-        this.exit(token, SpreadsheetParserToken::percentage);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetPowerParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetPowerParserToken token) {
-        this.exit(token, SpreadsheetParserToken::power);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetRangeParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetRangeParserToken token) {
-        this.exit(token, SpreadsheetParserToken::range);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetSubtractionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetSubtractionParserToken token) {
-        this.exit(token, SpreadsheetParserToken::subtraction);
-    }
-
     // leaf ......................................................................................................
 
     @Override
-    protected void visit(final SpreadsheetApostropheSymbolParserToken token) {
-        this.leaf(token);
+    Optional<SpreadsheetColumnReferenceParserToken> visitColumn(final SpreadsheetColumnReferenceParserToken token) {
+        return this.columnOrRow.fixCellReferencesWithinExpression(token);
     }
 
     @Override
-    protected void visit(final SpreadsheetBetweenSymbolParserToken token) {
-        this.leaf(token);
+    Optional<SpreadsheetRowReferenceParserToken> visitRow(final SpreadsheetRowReferenceParserToken token) {
+        return this.columnOrRow.fixCellReferencesWithinExpression(token);
     }
 
     @Override
-    protected void visit(final SpreadsheetColumnReferenceParserToken token) {
-        this.leaf(this.columnOrRow.fixCellReferencesWithinExpression(token));
-    }
-
-    @Override
-    protected void visit(final SpreadsheetDivideSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetDoubleQuoteSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetExpressionNumberParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetFunctionNameParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetGreaterThanSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLabelNameParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLessThanSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLessThanEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetMinusSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetMultiplySymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetParenthesisCloseSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetParenthesisOpenSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPercentSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPlusSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPowerSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetRowReferenceParserToken token) {
-        this.leaf(this.columnOrRow.fixCellReferencesWithinExpression(token));
-    }
-
-    @Override
-    protected void visit(final SpreadsheetTextParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetTextLiteralParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetValueSeparatorSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetWhitespaceParserToken token) {
-        this.leaf(token);
-    }
-
-    @SuppressWarnings("SameReturnValue")
-    private Visiting enter() {
-        this.previousChildren = this.previousChildren.push(this.children);
-        this.children = Lists.array();
+    void enter0() {
         this.invalidCellReference = false;
-
-        return Visiting.CONTINUE;
     }
 
-    private <P extends SpreadsheetParserToken & ParentParserToken> void exit(final P parent,
-                                                                             final BiFunction<List<ParserToken>, String, ParserToken> factory) {
-        final List<ParserToken> children = this.children;
-        this.children = this.previousChildren.peek();
-        this.previousChildren = this.previousChildren.pop();
-        this.add(
-                this.invalidCellReference ?
-                        this.cellReferenceDeleted(parent) :
-                        factory.apply(children, ParserToken.text(children)));
+    @Override
+    <PP extends SpreadsheetParserToken & ParentParserToken> SpreadsheetParserToken exit0(final PP parent,
+                                                                                         final List<ParserToken> children,
+                                                                                         final BiFunction<List<ParserToken>, String, PP> factory) {
+        final boolean invalidCellReference = this.invalidCellReference;
         this.invalidCellReference = false;
+        return invalidCellReference ?
+                this.cellReferenceDeleted(parent) :
+                factory.apply(children, ParserToken.text(children));
     }
 
     /**
@@ -454,7 +115,8 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellRefere
         return SpreadsheetParserToken.function(tokens, ParserToken.text(tokens));
     }
 
-    private void leaf(final Optional<SpreadsheetParserToken> token) {
+    @Override
+    void leaf(final Optional<? extends SpreadsheetParserToken> token) {
         if (token.isPresent()) {
             this.add(token.get());
         } else {
@@ -462,21 +124,8 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellRefere
         }
     }
 
-    private void leaf(final ParserToken token) {
-        this.add(token);
-    }
-
-    private void add(final ParserToken child) {
-        Objects.requireNonNull(child, "child");
-        this.children.add(child);
-    }
-
-    private Stack<List<ParserToken>> previousChildren = Stacks.arrayList();
-
-    private List<ParserToken> children = Lists.array();
-
     @Override
-    public final String toString() {
+    public String toString() {
         return this.children + "," + this.previousChildren;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
@@ -19,68 +19,26 @@ package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.Cast;
 import walkingkooka.NeverError;
-import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.stack.Stack;
-import walkingkooka.collect.stack.Stacks;
-import walkingkooka.spreadsheet.parser.SpreadsheetAdditionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetApostropheSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetBetweenSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetColumnReferenceParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDivideSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDivisionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetDoubleQuoteSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetExpressionNumberParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetFunctionNameParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetFunctionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetGroupParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLabelNameParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetLessThanSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMinusSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMultiplicationParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetMultiplySymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNegativeParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisCloseSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisOpenSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
-import walkingkooka.spreadsheet.parser.SpreadsheetPercentSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPercentageParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPlusSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPowerParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetPowerSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetRangeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetRowReferenceParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetSubtractionParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetTextParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetValueSeparatorSymbolParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetWhitespaceParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
+import walkingkooka.text.cursor.parser.ParentParserToken;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.visit.Visiting;
 
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 /**
  * A {@link SpreadsheetParserTokenVisitor} that handles visiting and updating {@link SpreadsheetCellReferenceParserToken}
  * so cell references during a fill operation.
  */
-final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor extends BasicSpreadsheetEngineSpreadsheetParserTokenVisitor {
 
     /**
      * Accepts a token tree and updates rows and columns.
@@ -118,191 +76,10 @@ final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsh
         this.yOffset = yOffset;
     }
 
-    @Override
-    protected Visiting startVisit(final SpreadsheetAdditionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetAdditionParserToken token) {
-        this.exit(SpreadsheetParserToken::addition);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetCellReferenceParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetCellReferenceParserToken token) {
-        this.exit(SpreadsheetParserToken::cellReference);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetDivisionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetDivisionParserToken token) {
-        this.exit(SpreadsheetParserToken::division);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetEqualsParserToken token) {
-        this.exit(SpreadsheetParserToken::equalsParserToken);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetFunctionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetFunctionParserToken token) {
-        this.exit(SpreadsheetParserToken::function);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGreaterThanParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGreaterThanParserToken token) {
-        this.exit(SpreadsheetParserToken::greaterThan);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
-        this.exit(SpreadsheetParserToken::greaterThanEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetGroupParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetGroupParserToken token) {
-        this.exit(SpreadsheetParserToken::group);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetLessThanParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetLessThanParserToken token) {
-        this.exit(SpreadsheetParserToken::lessThan);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetLessThanEqualsParserToken token) {
-        this.enter();
-        return super.startVisit(token);
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetLessThanEqualsParserToken token) {
-        this.exit(SpreadsheetParserToken::lessThanEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetMultiplicationParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetMultiplicationParserToken token) {
-        this.exit(SpreadsheetParserToken::multiplication);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetNegativeParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetNegativeParserToken token) {
-        this.exit(SpreadsheetParserToken::negative);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetNotEqualsParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetNotEqualsParserToken token) {
-        this.exit(SpreadsheetParserToken::notEquals);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetPercentageParserToken token) {
-        this.exit(SpreadsheetParserToken::percentage);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetPowerParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetPowerParserToken token) {
-        this.exit(SpreadsheetParserToken::power);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetRangeParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetRangeParserToken token) {
-        this.exit(SpreadsheetParserToken::range);
-    }
-
-    @Override
-    protected Visiting startVisit(final SpreadsheetSubtractionParserToken token) {
-        return this.enter();
-    }
-
-    @Override
-    protected void endVisit(final SpreadsheetSubtractionParserToken token) {
-        this.exit(SpreadsheetParserToken::subtraction);
-    }
-
     // leaf ......................................................................................................
 
     @Override
-    protected void visit(final SpreadsheetApostropheSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetBetweenSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetColumnReferenceParserToken token) {
+    Optional<SpreadsheetColumnReferenceParserToken> visitColumn(final SpreadsheetColumnReferenceParserToken token) {
         final SpreadsheetColumnReference reference = token.value();
 
         SpreadsheetColumnReferenceParserToken replacement;
@@ -320,7 +97,7 @@ final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsh
                 break;
         }
 
-        this.leaf(replacement);
+        return Optional.of(replacement);
     }
 
     private SpreadsheetColumnReferenceParserToken fixColumnReference(final SpreadsheetColumnReference reference) {
@@ -331,97 +108,7 @@ final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsh
     private final int xOffset;
 
     @Override
-    protected void visit(final SpreadsheetDivideSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetDoubleQuoteSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetExpressionNumberParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetFunctionNameParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetGreaterThanSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLabelNameParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLessThanSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetLessThanEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetMinusSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetMultiplySymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetParenthesisCloseSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetParenthesisOpenSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPercentSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPlusSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetPowerSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetRowReferenceParserToken token) {
+    Optional<SpreadsheetRowReferenceParserToken> visitRow(final SpreadsheetRowReferenceParserToken token) {
         final SpreadsheetRowReference reference = token.value();
 
         SpreadsheetRowReferenceParserToken replacement;
@@ -439,7 +126,7 @@ final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsh
                 break;
         }
 
-        this.leaf(replacement);
+        return Optional.of(replacement);
     }
 
     private SpreadsheetRowReferenceParserToken fixRowReference(final SpreadsheetRowReference reference) {
@@ -449,47 +136,26 @@ final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsh
 
     private final int yOffset;
 
-    @Override
-    protected void visit(final SpreadsheetTextParserToken token) {
-        this.leaf(token);
-    }
+    // helpers..........................................................................................................
 
     @Override
-    protected void visit(final SpreadsheetValueSeparatorSymbolParserToken token) {
-        this.leaf(token);
+    void enter0() {
+        // nop
     }
 
     @Override
-    protected void visit(final SpreadsheetWhitespaceParserToken token) {
-        this.leaf(token);
+    <PP extends SpreadsheetParserToken & ParentParserToken> SpreadsheetParserToken exit0(final PP parent,
+                                                                                         final List<ParserToken> children,
+                                                                                         final BiFunction<List<ParserToken>, String, PP> factory) {
+        return factory.apply(children, ParserToken.text(children));
     }
 
-    @SuppressWarnings("SameReturnValue")
-    private Visiting enter() {
-        this.previousChildren = this.previousChildren.push(this.children);
-        this.children = Lists.array();
-        return Visiting.CONTINUE;
+    @Override
+    void leaf(final Optional<? extends SpreadsheetParserToken> token) {
+        if (token.isPresent()) {
+            this.add(token.get());
+        }
     }
-
-    private void exit(final BiFunction<List<ParserToken>, String, SpreadsheetParserToken> factory) {
-        final List<ParserToken> children = this.children;
-        this.children = this.previousChildren.peek();
-        this.previousChildren = this.previousChildren.pop();
-        this.add(factory.apply(children, ParserToken.text(children)));
-    }
-
-    private void leaf(final SpreadsheetParserToken token) {
-        this.add(token);
-    }
-
-    private void add(final SpreadsheetParserToken child) {
-        Objects.requireNonNull(child, "child");
-        this.children.add(child);
-    }
-
-    private Stack<List<ParserToken>> previousChildren = Stacks.arrayList();
-
-    private List<ParserToken> children = Lists.array();
 
     @Override
     public final String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.stack.Stack;
+import walkingkooka.collect.stack.Stacks;
+import walkingkooka.spreadsheet.parser.SpreadsheetAdditionParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetApostropheSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetBetweenSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDivideSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDivisionParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDoubleQuoteSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetEqualsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetEqualsSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetExpressionNumberParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetFunctionNameParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetFunctionParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanEqualsSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGreaterThanSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGroupParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetLabelNameParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetLessThanEqualsSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetLessThanParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetLessThanSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetMinusSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetMultiplicationParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetMultiplySymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetNegativeParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetNotEqualsSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisCloseSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParenthesisOpenSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
+import walkingkooka.spreadsheet.parser.SpreadsheetPercentSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPercentageParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPlusSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPowerParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPowerSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetRangeParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetRowReferenceParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetSubtractionParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetTextLiteralParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetTextParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetValueSeparatorSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetWhitespaceParserToken;
+import walkingkooka.text.cursor.parser.ParentParserToken;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.visit.Visiting;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * A {@link SpreadsheetParserTokenVisitor} that captures some comment functionality required to visit and change a {@link SpreadsheetParserToken}
+ */
+abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+
+    /**
+     * Package private ctor use static method.
+     */
+    BasicSpreadsheetEngineSpreadsheetParserTokenVisitor() {
+        super();
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetAdditionParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetAdditionParserToken token) {
+        this.exit(token, SpreadsheetParserToken::addition);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetCellReferenceParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetCellReferenceParserToken token) {
+        this.exit(token, SpreadsheetParserToken::cellReference);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetDivisionParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetDivisionParserToken token) {
+        this.exit(token, SpreadsheetParserToken::division);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetEqualsParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetEqualsParserToken token) {
+        this.exit(token, SpreadsheetParserToken::equalsParserToken);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetFunctionParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetFunctionParserToken token) {
+        this.exit(token, SpreadsheetParserToken::function);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGreaterThanParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGreaterThanParserToken token) {
+        this.exit(token, SpreadsheetParserToken::greaterThan);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        this.exit(token, SpreadsheetParserToken::greaterThanEquals);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGroupParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGroupParserToken token) {
+        this.exit(token, SpreadsheetParserToken::group);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetLessThanParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetLessThanParserToken token) {
+        this.exit(token, SpreadsheetParserToken::lessThan);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        this.exit(token, SpreadsheetParserToken::lessThanEquals);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetMultiplicationParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetMultiplicationParserToken token) {
+        this.exit(token, SpreadsheetParserToken::multiplication);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetNegativeParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetNegativeParserToken token) {
+        this.exit(token, SpreadsheetParserToken::negative);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetNotEqualsParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetNotEqualsParserToken token) {
+        this.exit(token, SpreadsheetParserToken::notEquals);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetPercentageParserToken token) {
+        this.exit(token, SpreadsheetParserToken::percentage);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetPowerParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetPowerParserToken token) {
+        this.exit(token, SpreadsheetParserToken::power);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetRangeParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetRangeParserToken token) {
+        this.exit(token, SpreadsheetParserToken::range);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetSubtractionParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetSubtractionParserToken token) {
+        this.exit(token, SpreadsheetParserToken::subtraction);
+    }
+
+    // leaf ......................................................................................................
+
+    @Override
+    protected final void visit(final SpreadsheetApostropheSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetBetweenSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetColumnReferenceParserToken token) {
+        this.leaf(this.visitColumn(token));
+    }
+
+    abstract Optional<SpreadsheetColumnReferenceParserToken> visitColumn(final SpreadsheetColumnReferenceParserToken token);
+
+    @Override
+    protected final void visit(final SpreadsheetDivideSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetDoubleQuoteSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetExpressionNumberParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetFunctionNameParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetGreaterThanSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLabelNameParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLessThanSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLessThanEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetMinusSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetMultiplySymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetParenthesisCloseSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetParenthesisOpenSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPercentSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPlusSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPowerSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetRowReferenceParserToken token) {
+        this.leaf(this.visitRow(token));
+    }
+
+    abstract Optional<SpreadsheetRowReferenceParserToken> visitRow(final SpreadsheetRowReferenceParserToken token);
+
+    @Override
+    protected final void visit(final SpreadsheetTextParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetTextLiteralParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetValueSeparatorSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetWhitespaceParserToken token) {
+        this.leaf(token);
+    }
+
+    // helpers..........................................................................................................
+
+    @SuppressWarnings("SameReturnValue")
+    private Visiting enter() {
+        this.previousChildren = this.previousChildren.push(this.children);
+        this.children = Lists.array();
+        this.enter0();
+
+        return Visiting.CONTINUE;
+    }
+
+    abstract void enter0();
+
+    private <PP extends SpreadsheetParserToken & ParentParserToken> void exit(final PP parent,
+                                                                              final BiFunction<List<ParserToken>, String, PP> factory) {
+        final List<ParserToken> children = this.children;
+        this.children = this.previousChildren.peek();
+        this.previousChildren = this.previousChildren.pop();
+        this.add(this.exit0(parent, children, factory));
+    }
+
+    abstract <PP extends SpreadsheetParserToken & ParentParserToken> SpreadsheetParserToken exit0(final PP parent,
+                                                                                                  final List<ParserToken> children,
+                                                                                                  final BiFunction<List<ParserToken>, String, PP> factory);
+
+    abstract void leaf(final Optional<? extends SpreadsheetParserToken> token);
+
+    final void leaf(final ParserToken token) {
+        this.add(token);
+    }
+
+    final void add(final ParserToken child) {
+        Objects.requireNonNull(child, "child");
+        this.children.add(child);
+    }
+
+    Stack<List<ParserToken>> previousChildren = Stacks.arrayList();
+
+    List<ParserToken> children = Lists.array();
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
@@ -20,8 +20,7 @@ package walkingkooka.spreadsheet.engine;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitorTesting;
 
-public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest extends BasicSpreadsheetEngineTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor>
-        implements SpreadsheetParserTokenVisitorTesting<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> {
+public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest extends BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> {
 
     @Override
     public BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor createVisitor() {
@@ -31,12 +30,5 @@ public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCel
     @Override
     public Class<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> type() {
         return BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.class;
-    }
-
-    // TypeNameTesting..........................................................................
-
-    @Override
-    public String typeNameSuffix() {
-        return SpreadsheetParserTokenVisitor.class.getSimpleName();
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
@@ -32,7 +32,7 @@ import java.math.MathContext;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest implements SpreadsheetParserTokenVisitorTesting<BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> {
+public final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest extends BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase<BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> {
 
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
 
@@ -61,17 +61,7 @@ public final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerS
     }
 
     @Override
-    public String typeNamePrefix() {
-        return BasicSpreadsheetEngine.class.getSimpleName();
-    }
-
-    @Override
     public Class<BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> type() {
         return BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.class;
-    }
-
-    @Override
-    public JavaVisibility typeVisibility() {
-        return JavaVisibility.PACKAGE_PRIVATE;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
+
+public final class BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTest extends BasicSpreadsheetEngineTestCase<BasicSpreadsheetEngineSpreadsheetParserTokenVisitor> {
+
+    // Class............................................................................................................
+
+    @Override
+    public Class<BasicSpreadsheetEngineSpreadsheetParserTokenVisitor> type() {
+        return BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.class;
+    }
+
+    // TypeNameTesting..................................................................................................
+
+    @Override
+    public String typeNameSuffix() {
+        return SpreadsheetParserTokenVisitor.class.getSimpleName();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitor;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserTokenVisitorTesting;
+
+public abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase<V extends BasicSpreadsheetEngineSpreadsheetParserTokenVisitor>
+        extends  BasicSpreadsheetEngineTestCase<V>
+        implements SpreadsheetParserTokenVisitorTesting<V>  {
+
+    BasicSpreadsheetEngineSpreadsheetParserTokenVisitorTestCase() {
+        super();
+    }
+
+    // TypeNameTesting..........................................................................
+
+    @Override
+    public String typeNameSuffix() {
+        return SpreadsheetParserTokenVisitor.class.getSimpleName();
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1219
- Extract base class from BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor & BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor