### PR TITLE
SpreadsheetTextParserToken extends SpreadsheetParentParserToken

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.engine;
 
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetCellBox;
@@ -43,6 +44,7 @@ import walkingkooka.spreadsheet.reference.store.SpreadsheetLabelStore;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetRangeStore;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
 import walkingkooka.text.cursor.parser.ParserException;
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.text.Length;
@@ -379,7 +381,14 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
     /**
      * This {@link SpreadsheetParserToken} is set upon {@link SpreadsheetFormula} when the {@link SpreadsheetFormula#text()} is empty.
      */
-    final static Optional<SpreadsheetParserToken> EMPTY_TOKEN = Optional.of(SpreadsheetParserToken.text("", ""));
+    final static Optional<SpreadsheetParserToken> EMPTY_TOKEN = Optional.of(
+            SpreadsheetParserToken.text(
+                    Lists.<ParserToken>of( // J2clTranspiler: Error:BasicSpreadsheetEngine.java:386: The method of(T...) of type Lists is not applicable as the formal varargs element type T is not accessible here
+                            SpreadsheetParserToken.apostropheSymbol("\"", "\""),
+                            SpreadsheetParserToken.textLiteral("", "")
+                    ),
+                    "\"")
+    );
 
     /**
      * This {@link Expression} is set upon {@link SpreadsheetFormula} when the {@link SpreadsheetFormula#text()} is empty.

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
@@ -110,7 +110,13 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowSpreadsheetCellRefere
 
         final List<ParserToken> tokens = Lists.of(SpreadsheetFormula.INVALID_CELL_REFERENCE_PARSER_TOKEN,
                 SpreadsheetParserToken.parenthesisOpenSymbol("(", "("),
-                SpreadsheetParserToken.text(text, CharSequences.quote(text).toString()),
+                SpreadsheetParserToken.text(
+                        Lists.<ParserToken>of( // J2clTranspiler: Error
+                                SpreadsheetParserToken.doubleQuoteSymbol("\"", "\""),
+                                SpreadsheetParserToken.textLiteral(text, text),
+                                SpreadsheetParserToken.doubleQuoteSymbol("\"", "\"")
+                        ), CharSequences.quote(text).toString()
+                ),
                 SpreadsheetParserToken.parenthesisCloseSymbol(")", ")"));
         return SpreadsheetParserToken.function(tokens, ParserToken.text(tokens));
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
@@ -283,6 +283,16 @@ abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitor extends Sprea
         this.exit(token, SpreadsheetParserToken::subtraction);
     }
 
+    @Override
+    protected final Visiting startVisit(final SpreadsheetTextParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetTextParserToken token) {
+        this.exit(token, SpreadsheetParserToken::text);
+    }
+
     // leaf ......................................................................................................
 
     @Override
@@ -466,11 +476,6 @@ abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitor extends Sprea
 
     @Override
     protected final void visit(final SpreadsheetSecondsParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected final void visit(final SpreadsheetTextParserToken token) {
         this.leaf(token);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDoubleQuotesParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDoubleQuotesParser.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorSavePoint;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A parser that handles double quoted strings within a formula, including support for embedding a double quote by inserting
+ * two double quotes.
+ * <a href="https://exceljet.net/formula/double-quotes-inside-a-formula">Double quotes inside a formula</a>
+ * <pre>
+ * Summary
+ * To include double quotes inside a formula, you can use additional double quotes. In the example shown, the formula in C5 is:
+ *
+ *  ="The movie """ &B5 &""" is good."
+ * </pre>
+ */
+final class SpreadsheetDoubleQuotesParser implements Parser<SpreadsheetParserContext> {
+
+    /**
+     * Singleton instance
+     */
+    static final SpreadsheetDoubleQuotesParser INSTANCE = new SpreadsheetDoubleQuotesParser();
+
+    private SpreadsheetDoubleQuotesParser() {
+        super();
+    }
+
+    @Override
+    public Optional<ParserToken> parse(final TextCursor cursor,
+                                       final SpreadsheetParserContext context) {
+        Objects.requireNonNull(cursor, "cursor");
+        Objects.requireNonNull(context, "context");
+
+        ParserToken token = null;
+
+        if (!cursor.isEmpty()) {
+            // expect double quote
+            final char first = cursor.at();
+            if (DOUBLE_QUOTE == first) {
+                final TextCursorSavePoint save = cursor.save();
+                cursor.next();
+                final StringBuilder content = new StringBuilder();
+
+                while(!cursor.isEmpty()){
+                    final char c = cursor.at();
+                    cursor.next();
+
+                    if (DOUBLE_QUOTE == c) {
+
+                        // check if a double quote follows.
+                        if (cursor.isEmpty()) {
+                            // double quote was a string terminator
+                            token = text(content, save);
+                            break;
+                        }
+
+                        // must be a double quote
+                        if (DOUBLE_QUOTE == cursor.at()) {
+                            content.append(c);
+                            cursor.next();
+                            continue;
+                        }
+
+                        // was actually a terminator
+                        token = text(content, save);
+                        break;
+                    }
+
+                    content.append(c);
+                }
+            }
+        }
+
+        return Optional.ofNullable(token);
+    }
+
+    final static char DOUBLE_QUOTE = '"';
+
+    /**
+     * Factory that creates a {@link SpreadsheetTextParserToken} with three text literals, the surrounding double quotes,
+     * and the content.
+     */
+    private static SpreadsheetParserToken text(final StringBuilder content, final TextCursorSavePoint save) {
+        final String text = save.textBetween().toString();
+        final String contentString = content.toString();
+
+        return SpreadsheetParserToken.text(
+                Lists.of(
+                        DOUBLE_QUOTE_TOKEN,
+                        SpreadsheetParserToken.textLiteral(
+                                contentString, text.substring(1, text.length() -1)
+                        ),
+                        DOUBLE_QUOTE_TOKEN
+                ),
+                text
+        );
+    }
+
+    final static SpreadsheetDoubleQuoteSymbolParserToken DOUBLE_QUOTE_TOKEN = SpreadsheetParserToken.doubleQuoteSymbol("\"", "\"");
+
+    @Override
+    public String toString() {
+        return "Text";
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
@@ -429,7 +429,7 @@ public abstract class SpreadsheetParserToken implements ParserToken {
     /**
      * {@see SpreadsheetTextParserToken}
      */
-    public static SpreadsheetTextParserToken text(final String value, final String text) {
+    public static SpreadsheetTextParserToken text(final List<ParserToken> value, final String text) {
         return SpreadsheetTextParserToken.with(value, text);
     }
 
@@ -1101,12 +1101,7 @@ public abstract class SpreadsheetParserToken implements ParserToken {
         registerLeafParserToken(
                 SpreadsheetSecondsParserToken.class,
                 SpreadsheetParserToken::unmarshallSeconds
-        );
-
-        registerLeafParserToken(
-                SpreadsheetTextParserToken.class,
-                SpreadsheetParserToken::unmarshallText
-        );
+        );;
 
         registerLeafParserToken(
                 SpreadsheetTextLiteralParserToken.class,
@@ -1276,16 +1271,6 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 Integer.class,
                 context,
                 SpreadsheetParserToken::seconds
-        );
-    }
-
-    static SpreadsheetTextParserToken unmarshallText(final JsonNode node,
-                                                     final JsonNodeUnmarshallContext context) {
-        return unmarshallLeafParserToken(
-                node,
-                String.class,
-                context,
-                SpreadsheetParserToken::text
         );
     }
 
@@ -1790,6 +1775,11 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 SpreadsheetPercentageParserToken.class,
                 SpreadsheetParserToken::unmarshallPercentage
         );
+
+        registerParentParserToken(
+                SpreadsheetTextParserToken.class,
+                SpreadsheetParserToken::unmarshallText
+        );
     }
 
     static SpreadsheetAdditionParserToken unmarshallAddition(final JsonNode node,
@@ -1897,6 +1887,15 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 node,
                 context,
                 SpreadsheetParserToken::subtraction
+        );
+    }
+
+    static SpreadsheetTextParserToken unmarshallText(final JsonNode node,
+                                                     final JsonNodeUnmarshallContext context) {
+        return unmarshallParentParserToken(
+                node,
+                context,
+                SpreadsheetParserToken::text
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor.java
@@ -254,6 +254,27 @@ final class SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor exte
         this.exitBinary(Expression::subtract, token);
     }
 
+    @Override
+    protected Visiting startVisit(final SpreadsheetTextParserToken token) {
+        this.text = new StringBuilder();
+        return this.enter();
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetTextParserToken token) {
+        this.exit();
+        this.add(
+                Expression.string(this.text.toString()),
+                token
+        );
+        this.text = null;
+    }
+
+    /**
+     * Collects the text within a {@link SpreadsheetTextParserToken}.
+     */
+    private StringBuilder text = new StringBuilder();
+    
     // visit....................................................................................................
     // ignore all SymbolParserTokens, dont bother to collect them.
 
@@ -268,13 +289,8 @@ final class SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor exte
     }
 
     @Override
-    protected void visit(final SpreadsheetTextParserToken token) {
-        this.add(Expression.string(token.value()), token);
-    }
-
-    @Override
     protected void visit(final SpreadsheetTextLiteralParserToken token) {
-        this.add(Expression.string(token.value()), token);
+        this.text.append(token.value());
     }
 
     // GENERAL PURPOSE .................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
@@ -203,6 +203,16 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
         // nop
     }
 
+    // SpreadsheetTextParserToken....................................................................................
+
+    protected Visiting startVisit(final SpreadsheetTextParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final SpreadsheetTextParserToken token) {
+        // nop
+    }
+
     // SpreadsheetLeafParserToken ....................................................................................
 
     protected void visit(final SpreadsheetAmPmParserToken token) {
@@ -346,10 +356,6 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
     }
 
     protected void visit(final SpreadsheetSecondsParserToken token) {
-        // nop
-    }
-
-    protected void visit(final SpreadsheetTextParserToken token) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
@@ -28,7 +28,6 @@ import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.BigDecimalParserToken;
 import walkingkooka.text.cursor.parser.CharacterParserToken;
-import walkingkooka.text.cursor.parser.DoubleQuotedParserToken;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserReporters;
@@ -384,21 +383,10 @@ public final class SpreadsheetParsers implements PublicStaticHelper {
     );
 
     /**
-     * Text
+     * Text, parses excel style double quoted text, including escaped (triple) double quotes.
      */
     public static Parser<ParserContext> text() {
-        return TEXT;
-    }
-
-    private final static Parser<ParserContext> TEXT = Parsers.doubleQuoted()
-            .transform(SpreadsheetParsers::transformText)
-            .setToString(SpreadsheetTextParserToken.class.getSimpleName());
-
-    private static ParserToken transformText(final ParserToken token, final ParserContext context) {
-        return SpreadsheetParserToken.text(
-                token.cast(DoubleQuotedParserToken.class).value(),
-                token.text()
-        );
+        return SpreadsheetDoubleQuotesParser.INSTANCE.cast();
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer.java
@@ -138,7 +138,7 @@ final class SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer implemen
     private static ParserToken apostropheString(final ParserToken token,
                                                 final ParserContext context) {
         return SpreadsheetParserToken.text(
-                ParserToken.text(clean(token)),
+                clean(token),
                 token.text()
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserToken.java
@@ -16,23 +16,24 @@
  */
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.visit.Visiting;
+
+import java.util.List;
 import java.util.Objects;
 
 import java.util.Objects;
 
 /**
- * Holds a text which may be empty
+ * Holds a text expression in both forms an apostrophe prefixed string literal and a double quoted string.
  */
-public final class SpreadsheetTextParserToken extends SpreadsheetNonSymbolParserToken<String> {
+public final class SpreadsheetTextParserToken extends SpreadsheetParentParserToken {
 
-    static SpreadsheetTextParserToken with(final String value, final String text) {
-        checkValue(value);
-        Objects.requireNonNull(text, "text"); // empty string is okay eg apostrophe string or empty string
-
-        return new SpreadsheetTextParserToken(value, text);
+    static SpreadsheetTextParserToken with(final List<ParserToken> value, final String text) {
+        return new SpreadsheetTextParserToken(copyAndCheckTokens(value), checkText(text));
     }
 
-    private SpreadsheetTextParserToken(final String value, final String text) {
+    private SpreadsheetTextParserToken(final List<ParserToken> value, final String text) {
         super(value, text);
     }
 
@@ -40,8 +41,13 @@ public final class SpreadsheetTextParserToken extends SpreadsheetNonSymbolParser
 
     @Override
     void accept(final SpreadsheetParserTokenVisitor visitor) {
-        visitor.visit(this);
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
+
+    // Object...........................................................................................................
 
     @Override
     boolean canBeEqual(final Object other) {

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet;
 import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
@@ -647,7 +648,14 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     private Optional<SpreadsheetParserToken> token(final String text) {
-        return Optional.of(SpreadsheetParserToken.text(text, text));
+        return Optional.of(
+                SpreadsheetParserToken.text(
+                        Lists.of(
+                                SpreadsheetParserToken.textLiteral(text, text)
+                        ),
+                        text
+                )
+        );
     }
 
     private void checkToken(final SpreadsheetFormula formula) {

--- a/src/test/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
@@ -208,6 +208,16 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
     }
 
     @Override
+    protected Visiting startVisit(final SpreadsheetTextParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetTextParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final SpreadsheetAmPmParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -384,11 +394,6 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
 
     @Override
     protected void visit(final SpreadsheetSecondsParserToken token) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void visit(final SpreadsheetTextParserToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDoubleQuotesParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDoubleQuotesParserTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserTesting2;
+
+public final class SpreadsheetDoubleQuotesParserTest implements ParserTesting2<SpreadsheetDoubleQuotesParser, SpreadsheetParserContext>,
+        ToStringTesting<SpreadsheetDoubleQuotesParser> {
+
+    @Test
+    public void testNotDoubleQuote() {
+        this.parseFailAndCheck("not a double quoted string/text");
+    }
+
+    @Test
+    public void testUnclosed() {
+        this.parseFailAndCheck("\"");
+    }
+
+    @Test
+    public void testUnclosed2() {
+        this.parseFailAndCheck("\"a");
+    }
+
+    @Test
+    public void testUnclosed3() {
+        this.parseFailAndCheck("\"abc");
+    }
+
+    @Test
+    public void testEmptyDoubleQuotedText() {
+        this.parseAndCheck2("" );
+    }
+
+    @Test
+    public void testSingleCharacter() {
+        this.parseAndCheck2("a" );
+    }
+
+    @Test
+    public void testSingleCharacter2() {
+        this.parseAndCheck2("b" );
+    }
+
+    @Test
+    public void testSeveralCharacters() {
+        this.parseAndCheck2("abc");
+    }
+
+    @Test
+    public void testDoubleQuote() {
+        this.parseAndCheck2("\"\"");
+    }
+
+    @Test
+    public void testIncludesDoubleQuote() {
+        this.parseAndCheck2("abc\"\"123");
+    }
+
+    @Test
+    public void testIncludesDoubleQuote2() {
+        this.parseAndCheck2("abc\"\"123\"\"xyz");
+    }
+
+    @Test
+    public void testIncludesDoubleQuote3() {
+        this.parseAndCheck2("abc\"\"\"\"xyz");
+    }
+
+    private void parseAndCheck2(final String content) {
+        this.parseAndCheck3(content, "");
+        this.parseAndCheck3(content, "*");
+    }
+
+    private void parseAndCheck3(final String content,
+                                final String after) {
+        final String quotes = "" + SpreadsheetDoubleQuotesParser.DOUBLE_QUOTE;
+        final String withQuotes = quotes + content + quotes;
+
+        this.parseAndCheck(
+                withQuotes + after,
+                SpreadsheetParserToken.text(
+                        Lists.of(
+                                SpreadsheetDoubleQuotesParser.DOUBLE_QUOTE_TOKEN,
+                                SpreadsheetParserToken.textLiteral(
+                                        content.replace(quotes + quotes, quotes),
+                                        content
+                                ),
+                                SpreadsheetDoubleQuotesParser.DOUBLE_QUOTE_TOKEN
+                        ),
+                        withQuotes
+                ),
+                withQuotes,
+                after
+        );
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createParser(), "Text");
+    }
+
+    @Override
+    public SpreadsheetDoubleQuotesParser createParser() {
+        return SpreadsheetDoubleQuotesParser.INSTANCE;
+    }
+
+    @Override
+    public SpreadsheetParserContext createContext() {
+        return SpreadsheetParserContexts.fake();
+    }
+
+    @Override
+    public Class<SpreadsheetDoubleQuotesParser> type() {
+        return SpreadsheetDoubleQuotesParser.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
@@ -35,8 +35,13 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
 
     final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
 
+    final static String APOSTROPHE = "\'";
+    final static String DOUBLE_QUOTE = "\"";
+
     final static String NUMBER1 = "1";
     final static String NUMBER2 = "22";
+
+    final static String TEXT = "abc123";
 
     final static String WHITESPACE = "   ";
 
@@ -89,6 +94,14 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
         assertEquals(value, token.value(), "value");
     }
 
+    final SpreadsheetApostropheSymbolParserToken apostropheSymbol() {
+        return SpreadsheetParserToken.apostropheSymbol(APOSTROPHE, APOSTROPHE);
+    }
+
+    final SpreadsheetDoubleQuoteSymbolParserToken doubleQuoteSymbol() {
+        return SpreadsheetParserToken.doubleQuoteSymbol(DOUBLE_QUOTE, DOUBLE_QUOTE);
+    }
+
     final SpreadsheetEqualsSymbolParserToken equalsSymbol() {
         return SpreadsheetParserToken.equalsSymbol("=", "=");
     }
@@ -111,6 +124,10 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
 
     final SpreadsheetPercentSymbolParserToken percentSymbol() {
         return SpreadsheetParserToken.percentSymbol("%", "%");
+    }
+
+    final SpreadsheetTextLiteralParserToken textLiteral() {
+        return SpreadsheetParserToken.textLiteral(TEXT, TEXT);
     }
 
     final SpreadsheetWhitespaceParserToken whitespace() {

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetTextLiteralParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetTextLiteralParserTokenTest.java
@@ -83,7 +83,7 @@ public final class SpreadsheetTextLiteralParserTokenTest extends SpreadsheetNonS
 
     @Test
     public void testToExpression() {
-        this.toExpressionAndCheck(Expression.string(this.text()));
+        this.toExpressionAndFail();
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ * Copyclose 2019 Miroslav Pokorny (github.com/mP1)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,96 +14,100 @@
  * limitations under the License.
  *
  */
+
 package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
-import walkingkooka.visit.Visiting;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import java.util.List;
 
-public final class SpreadsheetTextParserTokenTest extends SpreadsheetNonSymbolParserTokenTestCase<SpreadsheetTextParserToken, String> {
+public final class SpreadsheetTextParserTokenTest extends SpreadsheetParentParserTokenTestCase<SpreadsheetTextParserToken> {
 
     @Test
-    public void testWithEmptyString() {
-        final SpreadsheetTextParserToken token = this.createToken("");
-        this.textAndCheck(token, "");
+    public void testWithZeroTokensFails() {
+        this.createToken(DOUBLE_QUOTE + TEXT + DOUBLE_QUOTE);
     }
 
     @Test
-    public void testWithWhitespace() {
-        final SpreadsheetTextParserToken token = this.createToken("   ");
-        this.textAndCheck(token, "   ");
+    public void testWithApostrophe() {
+        final String text = APOSTROPHE + TEXT;
+
+        final SpreadsheetApostropheSymbolParserToken apostrophe = apostropheSymbol();
+        final SpreadsheetParserToken textLiteral = this.textLiteral();
+
+        final SpreadsheetTextParserToken token = this.createToken(text, apostrophe, textLiteral);
+        this.textAndCheck(token, text);
+        this.checkValue(token, apostrophe, textLiteral);
     }
 
     @Test
-    public void testAccept() {
-        final StringBuilder b = new StringBuilder();
-        final SpreadsheetTextParserToken token = this.createToken();
+    public void testWithDoubleQuote() {
+        final String text = DOUBLE_QUOTE + TEXT + DOUBLE_QUOTE;
 
-        new FakeSpreadsheetParserTokenVisitor() {
-            @Override
-            protected Visiting startVisit(final ParserToken t) {
-                assertSame(token, t);
-                b.append("1");
-                return Visiting.CONTINUE;
-            }
+        final SpreadsheetDoubleQuoteSymbolParserToken open = doubleQuoteSymbol();
+        final SpreadsheetParserToken textLiteral = this.textLiteral();
+        final SpreadsheetDoubleQuoteSymbolParserToken close = doubleQuoteSymbol();
 
-            @Override
-            protected void endVisit(final ParserToken t) {
-                assertSame(token, t);
-                b.append("2");
-            }
-
-            @Override
-            protected Visiting startVisit(final SpreadsheetParserToken t) {
-                assertSame(token, t);
-                b.append("3");
-                return Visiting.CONTINUE;
-            }
-
-            @Override
-            protected void endVisit(final SpreadsheetParserToken t) {
-                assertSame(token, t);
-                b.append("4");
-            }
-
-            @Override
-            protected void visit(final SpreadsheetTextParserToken t) {
-                assertSame(token, t);
-                b.append("5");
-            }
-        }.accept(token);
-        assertEquals("13542", b.toString());
+        final SpreadsheetTextParserToken token = this.createToken(text, open, textLiteral, close);
+        this.textAndCheck(token, text);
+        this.checkValue(token, open, textLiteral, close);
     }
 
     @Test
-    public void testToExpression() {
-        this.toExpressionAndCheck(Expression.string(this.text()));
+    public void testToExpressionApostrophe() {
+        this.toExpressionAndCheck(
+                SpreadsheetTextParserToken.with(
+                        Lists.of(
+                                apostropheSymbol(),
+                                textLiteral()
+                        ),
+                        APOSTROPHE + TEXT
+                ),
+                Expression.string(TEXT));
+    }
+
+    @Test
+    public void testToExpressionDoubleQuoted() {
+        this.toExpressionAndCheck(
+                SpreadsheetTextParserToken.with(
+                        Lists.of(
+                                doubleQuoteSymbol(),
+                                textLiteral(),
+                                doubleQuoteSymbol()
+                        ),
+                        DOUBLE_QUOTE + TEXT + DOUBLE_QUOTE
+                ),
+                Expression.string(TEXT));
+    }
+
+    @Override
+    SpreadsheetTextParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return SpreadsheetParserToken.text(tokens, text);
     }
 
     @Override
     public String text() {
-        return "'A'";
+        return DOUBLE_QUOTE + TEXT + DOUBLE_QUOTE;
     }
 
     @Override
-    String value() {
-        return this.text();
-    }
-
-    @Override
-    SpreadsheetTextParserToken createToken(final String value, final String text) {
-        return SpreadsheetTextParserToken.with(value, text);
+    List<ParserToken> tokens() {
+        return Lists.of(this.openParenthesisSymbol(), this.textLiteral(), this.closeParenthesisSymbol());
     }
 
     @Override
     public SpreadsheetTextParserToken createDifferentToken() {
-        return SpreadsheetTextParserToken.with("'different'", "'different'");
+        final String different = "different456";
+        return this.createToken(different,
+                doubleQuoteSymbol(),
+                SpreadsheetParserToken.textLiteral(different, different),
+                doubleQuoteSymbol()
+        );
     }
 
     @Override


### PR DESCRIPTION
- formula grammar now supports apostrophe, strings and double quoted strings, each producing a SpreadsheetTextParserToken which also contains
 a SpreadsheetTextLiteralParserToken.
- SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor.endVisit(SpreadsheetTextParserToken) fix
- Inserted "unnecessary type parameter" to stop J2clTranspiler complaining.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1226
- SpreadsheetTextParserToken: child tokens required apostrophe, double quote, escaped, text-literal