### PR TITLE
SpreadsheetDateParserToken/SpreadsheetDateTimeParserToken.toXXX honou…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatterns.java
@@ -21,7 +21,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatDateParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetDateParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -66,9 +66,9 @@ public final class SpreadsheetDateParsePatterns extends SpreadsheetParsePatterns
     }
 
     @Override
-    LocalDate converterTransformer(final ParserToken token,
-                                   final ExpressionNumberConverterContext context) {
-        return token.cast(SpreadsheetDateParserToken.class).toLocalDate();
+    LocalDate converterTransformer0(final ParserToken token,
+                                    final ExpressionEvaluationContext context) {
+        return token.cast(SpreadsheetDateParserToken.class).toLocalDate(context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatterns.java
@@ -21,7 +21,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatDateTimeParserTok
 import walkingkooka.spreadsheet.parser.SpreadsheetDateTimeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -66,9 +66,9 @@ public final class SpreadsheetDateTimeParsePatterns extends SpreadsheetParsePatt
     }
 
     @Override
-    LocalDateTime converterTransformer(final ParserToken token,
-                                       final ExpressionNumberConverterContext context) {
-        return token.cast(SpreadsheetDateTimeParserToken.class).toLocalDateTime();
+    LocalDateTime converterTransformer0(final ParserToken token,
+                                        final ExpressionEvaluationContext context) {
+        return token.cast(SpreadsheetDateTimeParserToken.class).toLocalDateTime(context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2.java
@@ -29,6 +29,7 @@ import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.Parsers;
 import walkingkooka.text.cursor.parser.SequenceParserToken;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -70,11 +71,19 @@ abstract class SpreadsheetParsePatterns2<F extends SpreadsheetFormatParserToken,
         );
     }
 
+    private V converterTransformer(final ParserToken token,
+                                   final ExpressionNumberConverterContext context) {
+        return this.converterTransformer0(
+                token,
+                SpreadsheetParserPattern2ExpressionEvaluationContext.with(context)
+        );
+    }
+
     /**
      * Transforms the {@link SpreadsheetParserToken} into a {@link LocalDate} etc.
      */
-    abstract V converterTransformer(final ParserToken token,
-                                    final ExpressionNumberConverterContext context);
+    abstract V converterTransformer0(final ParserToken token,
+                                     final ExpressionEvaluationContext context);
 
     /**
      * The target {@link Class type} of the {@link Converter}.

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.pattern;
+
+import walkingkooka.Either;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.expression.FunctionExpressionName;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+
+import java.math.MathContext;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * A {@link ExpressionEvaluationContext} view of a {@link ExpressionNumberConverterContext}.
+ * Note a few methods throw {@link UnsupportedOperationException}.
+ */
+final class SpreadsheetParserPattern2ExpressionEvaluationContext implements ExpressionEvaluationContext {
+
+    static SpreadsheetParserPattern2ExpressionEvaluationContext with(final ExpressionNumberConverterContext context) {
+        return new SpreadsheetParserPattern2ExpressionEvaluationContext(context);
+    }
+
+    private SpreadsheetParserPattern2ExpressionEvaluationContext(final ExpressionNumberConverterContext context) {
+        super();
+        this.context = context;
+    }
+
+    @Override
+    public Object evaluate(final Expression expression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Expression> reference(final ExpressionReference expressionReference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionFunction<?, ExpressionFunctionContext> function(final FunctionExpressionName name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object evaluate(final FunctionExpressionName name,
+                           final List<Object> parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> target) {
+        return this.context.canConvert(value, target);
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> target) {
+        return this.context.convert(value, target);
+    }
+
+    @Override
+    public int twoDigitYear() {
+        return this.context.twoDigitYear();
+    }
+
+    @Override
+    public Locale locale() {
+        return this.context.locale();
+    }
+
+    @Override
+    public MathContext mathContext() {
+        return this.context.mathContext();
+    }
+
+    @Override
+    public ExpressionNumberKind expressionNumberKind() {
+        return null;
+    }
+
+    private final ExpressionNumberConverterContext context;
+
+    public String toString() {
+        return this.context.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatterns.java
@@ -21,7 +21,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTimeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetTimeParserToken;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -66,8 +66,8 @@ public final class SpreadsheetTimeParsePatterns extends SpreadsheetParsePatterns
     }
 
     @Override
-    LocalTime converterTransformer(final ParserToken token,
-                                   final ExpressionNumberConverterContext context) {
+    LocalTime converterTransformer0(final ParserToken token,
+                                    final ExpressionEvaluationContext context) {
         return token.cast(SpreadsheetTimeParserToken.class).toLocalTime();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserToken.java
@@ -16,7 +16,9 @@
  */
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.visit.Visiting;
 
 import java.time.LocalDate;
@@ -38,9 +40,9 @@ public final class SpreadsheetDateParserToken extends SpreadsheetParentParserTok
     /**
      * Creates a {@link LocalDate} from the components in this {@link SpreadsheetDateParserToken}.
      */
-    public LocalDate toLocalDate() {
+    public LocalDate toLocalDate(final ExpressionEvaluationContext context) {
         return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this)
-                .toLocalDate();
+                .toLocalDate(context);
     }
 
     // SpreadsheetParserTokenVisitor....................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserToken.java
@@ -16,7 +16,9 @@
  */
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.visit.Visiting;
 
 import java.time.LocalDateTime;
@@ -38,9 +40,9 @@ public final class SpreadsheetDateTimeParserToken extends SpreadsheetParentParse
     /**
      * Creates a {@link LocalDateTime} from the components in this {@link SpreadsheetDateTimeParserToken}.
      */
-    public LocalDateTime toLocalDateTime() {
+    public LocalDateTime toLocalDateTime(final ExpressionEvaluationContext context) {
         return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this)
-                .toLocalDateTime();
+                .toLocalDateTime(context);
     }
 
     // SpreadsheetParserTokenVisitor....................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTime.java
@@ -18,10 +18,13 @@
 package walkingkooka.spreadsheet.parser;
 
 import walkingkooka.ToStringBuilder;
+import walkingkooka.datetime.DateTimeContext;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 
 /**
  * A {@link SpreadsheetParserTokenVisitor} that accepts a {@link SpreadsheetParserToken} and after visiting may be used to create
@@ -100,6 +103,7 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
     @Override
     protected void visit(final SpreadsheetYearParserToken token) {
         this.year = token.value();
+        this.twoDigitYear = token.text().length() <= 2;
     }
 
     // toXXX ............................................................................................................
@@ -108,9 +112,13 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
      * Creates a {@link LocalDate} assuming defaults have been set and an entire {@link SpreadsheetDateParserToken} has
      * been visited.
      */
-    LocalDate toLocalDate() {
+    LocalDate toLocalDate(final ExpressionEvaluationContext context) {
+        Objects.requireNonNull(context, "context");
+
+        final int year = this.year;
+
         return LocalDate.of(
-                this.year,
+                this.twoDigitYear ? context.twoToFourDigitYear(year) : year,
                 this.month,
                 this.day
         );
@@ -133,9 +141,9 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
      * Creates a {@link LocalDateTime} assuming defaults have been set and an entire {@link SpreadsheetDateTimeParserToken} has
      * been visited.
      */
-    LocalDateTime toLocalDateTime() {
+    LocalDateTime toLocalDateTime(final ExpressionEvaluationContext context) {
         return LocalDateTime.of(
-                this.toLocalDate(),
+                this.toLocalDate(context),
                 this.toLocalTime()
         );
     }
@@ -143,6 +151,7 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
     private int day = 1;
     private int month = 1;
     private int year = 0; // https://github.com/mP1/walkingkooka-spreadsheet/issues/1309 Default year when parsing date or date/time
+    private boolean twoDigitYear = false;
 
     private int hour = 0;
     private int minute = 0;

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
@@ -93,7 +93,7 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
     protected void endVisit(final SpreadsheetDateParserToken token) {
         this.exit();
         this.add(
-                Expression.localDate(token.toLocalDate()),
+                Expression.localDate(token.toLocalDate(this.context)),
                 token
         );
     }
@@ -108,10 +108,12 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
     protected void endVisit(final SpreadsheetDateTimeParserToken token) {
         this.exit();
         this.add(
-                Expression.localDateTime(token.toLocalDateTime()),
+                Expression.localDateTime(token.toLocalDateTime(this.context)),
                 token
         );
     }
+
+    private final ExpressionEvaluationContext context;
 
     @Override
     protected Visiting startVisit(final SpreadsheetDivisionParserToken token) {
@@ -253,15 +255,11 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
                 Expression.divide(
                         parameter,
                         Expression.expressionNumber(
-                                this.context.expressionNumberKind()
-                                        .create(100L)
+                                this.context.expressionNumberKind().create(100L)
                         )
                 ),
-                token
-        );
+                token);
     }
-
-    private final ExpressionEvaluationContext context;
 
     @Override
     protected Visiting startVisit(final SpreadsheetPowerParserToken token) {

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
@@ -299,21 +299,21 @@ public final class SpreadsheetDateParsePatternsTest extends SpreadsheetParsePatt
     public void testConvertDateOnlyPatternTwoDigitYear2039() {
         this.convertAndCheck2("dd/mm/yy",
                 "31/12/39",
-                LocalDate.of(39, 12, 31));
+                LocalDate.of(1939, 12, 31));
     }
 
     @Test
     public void testConvertDateOnlyPatternTwoDigitYear2019() {
         this.convertAndCheck2("dd/mm/yy",
                 "31/12/19",
-                LocalDate.of(19, 12, 31));
+                LocalDate.of(2019, 12, 31));
     }
 
     @Test
     public void testConvertDateOnlyPatternTwoDigitYear1980() {
         this.convertAndCheck2("dd/mm/yy",
                 "31/12/80",
-                LocalDate.of(80, 12, 31));
+                LocalDate.of(1980, 12, 31));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContextTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.pattern;
+
+public final class SpreadsheetParserPattern2ExpressionEvaluationContextTest
+        extends SpreadsheetParsePatterns2TestCase<SpreadsheetParserPattern2ExpressionEvaluationContext> {
+    @Override
+    public Class<SpreadsheetParserPattern2ExpressionEvaluationContext> type() {
+        return SpreadsheetParserPattern2ExpressionEvaluationContext.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserTokenTest.java
@@ -19,8 +19,10 @@ package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
@@ -126,7 +128,47 @@ public final class SpreadsheetDateParserTokenTest extends SpreadsheetParentParse
         );
     }
 
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearBefore() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(2010, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(10, "10")
+        );
+    }
+
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearEqual() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(1920, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(20, "20")
+        );
+    }
+
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearAfter() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(1950, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(50, "50")
+        );
+    }
+
     private void toExpressionAndCheck2(final LocalDate expected,
+                                       final SpreadsheetParserToken...tokens) {
+        this.toExpressionAndCheck2(
+                this.expressionEvaluationContext(20),
+                expected,
+                tokens
+        );
+    }
+
+    private void toExpressionAndCheck2(final ExpressionEvaluationContext context,
+                                       final LocalDate expected,
                                        final SpreadsheetParserToken...tokens) {
         final List<ParserToken> tokensList = Lists.of(tokens);
 
@@ -137,7 +179,7 @@ public final class SpreadsheetDateParserTokenTest extends SpreadsheetParentParse
 
         assertEquals(
                 expected,
-                dateParserToken.toLocalDate(),
+                dateParserToken.toLocalDate(context),
                 () -> "toLocalDate() " + dateParserToken
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserTokenTest.java
@@ -19,8 +19,10 @@ package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
@@ -217,9 +219,64 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
         );
     }
 
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearBefore() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(2010, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(10, "10")
+        );
+    }
+
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearEqual() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(1920, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(20, "20")
+        );
+    }
+
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearAfter() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(1950, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(50, "50")
+        );
+    }
+
+    @Test
+    public void testToExpressionMonthNumberYearBeforeTwoDigitYearBefore2() {
+        this.toExpressionAndCheck2(
+                this.expressionEvaluationContext(50),
+                LocalDate.of(2040, MONTH, 1),
+                monthNumber(),
+                slashTextLiteral(),
+                SpreadsheetParserToken.year(40, "40")
+        );
+    }
+
     private void toExpressionAndCheck2(final LocalDate expected,
                                        final SpreadsheetParserToken... tokens) {
         this.toExpressionAndCheck2(
+                this.expressionEvaluationContext(20),
+                LocalDateTime.of(
+                        expected,
+                        LocalTime.of(0, 0)
+                ),
+                tokens
+        );
+    }
+
+    private void toExpressionAndCheck2(final ExpressionEvaluationContext context,
+                                       final LocalDate expected,
+                                       final SpreadsheetParserToken... tokens) {
+        this.toExpressionAndCheck2(
+                context,
                 LocalDateTime.of(
                         expected,
                         LocalTime.of(0, 0)
@@ -241,6 +298,16 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
 
     private void toExpressionAndCheck2(final LocalDateTime expected,
                                        final SpreadsheetParserToken... tokens) {
+        this.toExpressionAndCheck2(
+                this.expressionEvaluationContext(20),
+                expected,
+                tokens
+        );
+    }
+
+    private void toExpressionAndCheck2(final ExpressionEvaluationContext context,
+                                       final LocalDateTime expected,
+                                       final SpreadsheetParserToken... tokens) {
         final List<ParserToken> tokensList = Lists.of(tokens);
 
         final SpreadsheetDateTimeParserToken dateTimeParserToken = SpreadsheetDateTimeParserToken.with(
@@ -250,12 +317,13 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
 
         assertEquals(
                 expected,
-                dateTimeParserToken.toLocalDateTime(),
+                dateTimeParserToken.toLocalDateTime(context),
                 () -> "toLocalDateTime() " + dateTimeParserToken
         );
 
         this.toExpressionAndCheck(
                 dateTimeParserToken,
+                context,
                 Expression.localDateTime(expected)
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
@@ -19,11 +19,15 @@ package walkingkooka.spreadsheet.parser;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.datetime.DateTimeContext;
+import walkingkooka.datetime.FakeDateTimeContext;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberExpression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -218,5 +222,14 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
 
     final ExpressionNumberExpression expressionNumberExpression(final Number value) {
         return Expression.expressionNumber(this.expressionNumber(value));
+    }
+
+    final ExpressionEvaluationContext expressionEvaluationContext(final int twoDigitYear) {
+        return new FakeExpressionEvaluationContext() {
+            @Override
+            public int twoDigitYear() {
+                return twoDigitYear;
+            }
+        };
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenTestCase.java
@@ -150,11 +150,25 @@ public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParser
     }
 
     final void toExpressionAndCheck(final Expression expected) {
-        this.toExpressionAndCheck(this.createToken(), expected);
+        this.toExpressionAndCheck(
+                this.createToken(),
+                expected
+        );
     }
 
-    final void toExpressionAndCheck(final T token, final Expression expected) {
-        final Optional<Expression> node = token.toExpression(EXPRESSION_EVALUATION_CONTEXT);
+    final void toExpressionAndCheck(final T token,
+                                    final Expression expected) {
+        this.toExpressionAndCheck(
+                token,
+                EXPRESSION_EVALUATION_CONTEXT,
+                expected
+        );
+    }
+
+    final void toExpressionAndCheck(final T token,
+                                    final ExpressionEvaluationContext context,
+                                    final Expression expected) {
+        final Optional<Expression> node = token.toExpression(context);
         assertEquals(Optional.of(expected), node, "toExpression");
     }
 


### PR DESCRIPTION
…r DateTimeContext.twoDigitYear

- SpreadsheetParserPattern.converter updated to use YearContext.twoDigitYear

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1327
- SpreadsheetDateTimeParserToken.toLocalDateTime should accept DateTimeContext

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1326
- SpreadsheetDateParserToken.toLocalDate should accept DateTimeContext

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1325
- SpreadsheetDateTimeParsePatterns should use DateTimeContext.twoToFourDigitYear

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1324
- SpreadsheetDateParsePatterns should use DateTimeContext.twoToFourDigitYear