### PR TITLE
SpreadsheetNumberParserToken was SpreadsheetExpressionNumberParserToken

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetParserTokenVisitor.java
@@ -270,6 +270,16 @@ abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitor extends Sprea
     }
 
     @Override
+    protected final Visiting startVisit(final SpreadsheetNumberParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetNumberParserToken token) {
+        this.exit(token, SpreadsheetParserToken::number);
+    }
+
+    @Override
     protected final Visiting startVisit(final SpreadsheetPercentageParserToken token) {
         return this.enter();
     }
@@ -485,11 +495,6 @@ abstract class BasicSpreadsheetEngineSpreadsheetParserTokenVisitor extends Sprea
 
     @Override
     protected final void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        this.leaf(token);
-    }
-
-    @Override
-    protected final void visit(final SpreadsheetNumberParserToken token) {
         this.leaf(token);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatterns.java
@@ -18,6 +18,8 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatNumberParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
+import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
@@ -74,7 +76,23 @@ public final class SpreadsheetNumberParsePatterns extends SpreadsheetParsePatter
 
     @Override
     SpreadsheetNumberParsePatternsParser createParser() {
-        return SpreadsheetNumberParsePatternsParser.with(this);
+        return SpreadsheetNumberParsePatternsParser.with(this, SpreadsheetNumberParsePatternsMode.VALUE);
+    }
+
+    /**
+     * Returns a {@link Parser} which will try all the patterns.
+     */
+    public Parser<SpreadsheetParserContext> expresionParser() {
+        if (null == this.expressionParser) {
+            this.expressionParser = this.createExpressionParser();
+        }
+        return this.expressionParser;
+    }
+
+    private Parser<SpreadsheetParserContext> expressionParser;
+
+    private SpreadsheetNumberParsePatternsParser createExpressionParser() {
+        return SpreadsheetNumberParsePatternsParser.with(this, SpreadsheetNumberParsePatternsMode.EXPRESSION);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponent2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponent2.java
@@ -26,16 +26,11 @@ abstract class SpreadsheetNumberParsePatternsComponent2 extends SpreadsheetNumbe
         super();
     }
 
-    @Override
-    final SpreadsheetNumberParsePatternsComponent lastDecimal() {
-        throw new UnsupportedOperationException();
-    }
-
     /**
-     * All non digit components are required.
+     * This method should never be invoked on non digit components.
      */
     @Override
-    final boolean isRequired() {
-        return true;
+    final SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrency.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrency.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
@@ -34,11 +36,16 @@ final class SpreadsheetNumberParsePatternsComponentCurrency extends SpreadsheetN
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
-        this.parseToken(cursor,
+        return this.parseToken(
+                cursor,
                 request.context.currencySymbol(),
-                request);
+                CaseSensitivity.INSENSITIVE,
+                SpreadsheetParserToken::currencySymbol,
+                null, // dont update mode
+                request
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparator.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
@@ -34,15 +35,24 @@ final class SpreadsheetNumberParsePatternsComponentDecimalSeparator extends Spre
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
+        boolean completed = false;
+
         if (false == cursor.isEmpty()) {
-            if (request.context.decimalSeparator() == cursor.at()) {
-                request.mode.onDecimalSeparator(request);
+            final char decimal = request.context.decimalSeparator();
+            if (decimal == cursor.at()) {
+                final String decimalString = Character.toString(decimal);
+                request.add(SpreadsheetParserToken.decimalSeparatorSymbol(decimalString, decimalString));
+
+                request.digitMode.onDecimalSeparator(request);
                 cursor.next();
-                request.nextComponent(cursor);
+
+                completed = request.nextComponent(cursor);
             }
         }
+
+        return completed;
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitDigit.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitDigit.java
@@ -19,23 +19,19 @@ package walkingkooka.spreadsheet.format.pattern;
 
 final class SpreadsheetNumberParsePatternsComponentDigitDigit extends SpreadsheetNumberParsePatternsComponentDigit {
 
-    static SpreadsheetNumberParsePatternsComponentDigitDigit with(final int max) {
-        return new SpreadsheetNumberParsePatternsComponentDigitDigit(max);
+    static SpreadsheetNumberParsePatternsComponentDigitDigit with(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                                  final int max) {
+        return new SpreadsheetNumberParsePatternsComponentDigitDigit(mode, max);
     }
 
-    private SpreadsheetNumberParsePatternsComponentDigitDigit(final int max) {
-        super(max);
-    }
-
-    @Override
-    SpreadsheetNumberParsePatternsComponent lastDecimal() {
-        return new SpreadsheetNumberParsePatternsComponentDigitDigit(Integer.MAX_VALUE);
+    private SpreadsheetNumberParsePatternsComponentDigitDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                              final int max) {
+        super(mode, max);
     }
 
     @Override
-    boolean handle(final char c,
-                   final SpreadsheetNumberParsePatternsRequest request) {
-        return this.handleDigit(c, request);
+    SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        return new SpreadsheetNumberParsePatternsComponentDigitDigit(mode, Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitMode.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.pattern;
+
+import walkingkooka.math.DecimalNumberContext;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.text.cursor.TextCursor;
+
+/**
+ * Determines how individual digits with a number are handled.
+ */
+enum SpreadsheetNumberParsePatternsComponentDigitMode {
+
+    /**
+     * Digits before any decimal separator.
+     */
+    INTEGER_OR_SIGN {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return INTEGER;
+        }
+    },
+
+    /**
+     * Digits before any decimal separator.
+     */
+    INTEGER {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return INTEGER;
+        }
+    },
+
+    /**
+     * Digits after a decimal separator
+     */
+    DECIMAL_FIRST {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return DECIMAL;
+        }
+
+    },
+
+    /**
+     * Digits after a decimal separator
+     */
+    DECIMAL {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return DECIMAL;
+        }
+    },
+
+    /**
+     * Digits or sign
+     */
+    EXPONENT_OR_SIGN {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return EXPONENT;
+        }
+    },
+
+    /**
+     * Digits belong to an exponent.
+     */
+    EXPONENT {
+
+        @Override
+        SpreadsheetNumberParsePatternsComponentDigitMode next() {
+            return EXPONENT;
+        }
+    };
+
+    /**
+     * Returns true if this is the first digit in sequence.
+     */
+    final boolean isFirst() {
+        return this.isSign() || this == DECIMAL_FIRST;
+    }
+
+    boolean isSign() {
+        return this == INTEGER_OR_SIGN || this == EXPONENT_OR_SIGN;
+    }
+
+    final boolean isDecimal() {
+        return this == DECIMAL_FIRST || this == DECIMAL;
+    }
+
+    final void tryParseSign(final TextCursor cursor,
+                            final SpreadsheetNumberParsePatternsRequest request) {
+        if (this.isSign()) {
+            final DecimalNumberContext context = request.context;
+
+            final char c = cursor.at();
+            if (context.positiveSign() == c) {
+                final String plusSign = Character.toString(c);
+                request.add(SpreadsheetParserToken.plusSymbol(plusSign, plusSign));
+                request.setDigitMode(this.next());
+                cursor.next();
+            } else {
+                if (context.negativeSign() == c) {
+                    final String minusSign = Character.toString(c);
+                    request.add(SpreadsheetParserToken.minusSymbol(minusSign, minusSign));
+                    request.setDigitMode(this.next());
+                    cursor.next();
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Advances a mode to the unsigned form.
+     */
+    abstract SpreadsheetNumberParsePatternsComponentDigitMode next();
+
+    /**
+     * Handles a decimal separator, possibly switching onDigit mode.
+     */
+    final void onDecimalSeparator(final SpreadsheetNumberParsePatternsRequest context) {
+        if(this == INTEGER_OR_SIGN || this == INTEGER) {
+            context.setDigitMode(SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST);
+        }
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitSpace.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitSpace.java
@@ -19,23 +19,18 @@ package walkingkooka.spreadsheet.format.pattern;
 
 final class SpreadsheetNumberParsePatternsComponentDigitSpace extends SpreadsheetNumberParsePatternsComponentDigit {
 
-    static SpreadsheetNumberParsePatternsComponentDigitSpace with(final int max) {
-        return new SpreadsheetNumberParsePatternsComponentDigitSpace(max);
+    static SpreadsheetNumberParsePatternsComponentDigitSpace with(final SpreadsheetNumberParsePatternsComponentDigitMode mode, final int max) {
+        return new SpreadsheetNumberParsePatternsComponentDigitSpace(mode, max);
     }
 
-    private SpreadsheetNumberParsePatternsComponentDigitSpace(final int max) {
-        super(max);
-    }
-
-    @Override
-    SpreadsheetNumberParsePatternsComponent lastDecimal() {
-        return new SpreadsheetNumberParsePatternsComponentDigitSpace(Integer.MAX_VALUE);
+    private SpreadsheetNumberParsePatternsComponentDigitSpace(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                              final int max) {
+        super(mode, max);
     }
 
     @Override
-    boolean handle(final char c,
-                   final SpreadsheetNumberParsePatternsRequest request) {
-        return Character.isWhitespace(c) || this.handleDigit(c, request);
+    SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        return new SpreadsheetNumberParsePatternsComponentDigitSpace(mode, Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitZero.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitZero.java
@@ -19,23 +19,19 @@ package walkingkooka.spreadsheet.format.pattern;
 
 final class SpreadsheetNumberParsePatternsComponentDigitZero extends SpreadsheetNumberParsePatternsComponentDigit {
 
-    static SpreadsheetNumberParsePatternsComponentDigitZero with(final int max) {
-        return new SpreadsheetNumberParsePatternsComponentDigitZero(max);
+    static SpreadsheetNumberParsePatternsComponentDigitZero with(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                                 final int max) {
+        return new SpreadsheetNumberParsePatternsComponentDigitZero(mode, max);
     }
 
-    private SpreadsheetNumberParsePatternsComponentDigitZero(final int max) {
-        super(max);
-    }
-
-    @Override
-    SpreadsheetNumberParsePatternsComponent lastDecimal() {
-        return new SpreadsheetNumberParsePatternsComponentDigitZero(Integer.MAX_VALUE);
+    private SpreadsheetNumberParsePatternsComponentDigitZero(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                             final int max) {
+        super(mode, max);
     }
 
     @Override
-    boolean handle(final char c,
-                   final SpreadsheetNumberParsePatternsRequest request) {
-        return this.handleDigit(c, request);
+    SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        return new SpreadsheetNumberParsePatternsComponentDigitZero(mode, Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentExponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentExponent.java
@@ -17,7 +17,7 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
-import walkingkooka.math.DecimalNumberContext;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
 
@@ -39,49 +39,16 @@ final class SpreadsheetNumberParsePatternsComponentExponent extends SpreadsheetN
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
-
-        final DecimalNumberContext context = request.context;
-        Loop:
-        //
-        do {
-            final String exponentSymbol = context.exponentSymbol();
-            int exponentSymbolIndex = 0;
-
-            // E
-            do {
-                if (cursor.isEmpty()) {
-                    break Loop;
-                }
-                if (0 != CaseSensitivity.INSENSITIVE.compare(cursor.at(), exponentSymbol.charAt(exponentSymbolIndex))) {
-                    break Loop;
-                }
-                cursor.next();
-                exponentSymbolIndex++;
-            } while (exponentSymbolIndex < exponentSymbol.length());
-
-            boolean negativeExponent = false;
-
-            if (false == cursor.isEmpty()) {
-                final char sign = cursor.at();
-
-                // E+
-                if (context.positiveSign() == sign) {
-                    cursor.next();
-                    negativeExponent = false;
-                } else {
-                    // E-
-                    if (context.negativeSign() == sign) {
-                        cursor.next();
-                        negativeExponent = true;
-                    }
-                }
-            }
-            request.mode = SpreadsheetNumberParsePatternsMode.EXPONENT;
-            request.negativeExponent = negativeExponent;
-            request.nextComponent(cursor);
-        } while (false);
+        return this.parseToken(
+                cursor,
+                request.context.exponentSymbol(),
+                CaseSensitivity.INSENSITIVE,
+                SpreadsheetParserToken::exponentSymbol,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                request
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercent.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercent.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
@@ -34,15 +36,17 @@ final class SpreadsheetNumberParsePatternsComponentPercent extends SpreadsheetNu
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
-        if (false == cursor.isEmpty()) {
-            if (request.context.percentageSymbol() == cursor.at()) {
-                request.percentage = true;
-                cursor.next();
-                request.nextComponent(cursor);
-            }
-        }
+        final char percentSymbol = request.context.percentageSymbol();
+        return this.parseToken(
+                cursor,
+                Character.toString(percentSymbol),
+                CaseSensitivity.SENSITIVE,
+                SpreadsheetParserToken::percentSymbol,
+                null, // dont update mode
+                request
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteral.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteral.java
@@ -20,7 +20,7 @@ package walkingkooka.spreadsheet.format.pattern;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
- * A component within a number that requires each and every character in the given text to be matched with case being important.
+ * Text literals within a parse number pattern are not required and ignored
  */
 final class SpreadsheetNumberParsePatternsComponentTextLiteral extends SpreadsheetNumberParsePatternsComponent2 {
 
@@ -34,9 +34,10 @@ final class SpreadsheetNumberParsePatternsComponentTextLiteral extends Spreadshe
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
-        this.parseToken(cursor, this.text, request);
+        // not consumed
+        return request.nextComponent(cursor);
     }
 
     private final String text;

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespace.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespace.java
@@ -34,14 +34,10 @@ final class SpreadsheetNumberParsePatternsComponentWhitespace extends Spreadshee
     }
 
     @Override
-    void parse(final TextCursor cursor,
+    boolean parse(final TextCursor cursor,
                final SpreadsheetNumberParsePatternsRequest request) {
-        if (false == cursor.isEmpty()) {
-            if (Character.isWhitespace(cursor.at())) {
-                cursor.next();
-                request.nextComponent(cursor);
-            }
-        }
+        // not consumed
+        return request.nextComponent(cursor);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.pattern;
+
+import walkingkooka.Either;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.expression.FunctionExpressionName;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+
+import java.math.MathContext;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+final class SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext implements ExpressionEvaluationContext {
+
+    // used only by SpreadsheetNumberParsePatternsConverter
+    static SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext with(final ExpressionNumberConverterContext context) {
+        return new SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext(context);
+    }
+
+    private SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext(final ExpressionNumberConverterContext context) {
+        super();
+        this.context = context;
+    }
+
+    @Override
+    public Object evaluate(final Expression expression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Expression> reference(final ExpressionReference expressionReference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionFunction<?, ExpressionFunctionContext> function(final FunctionExpressionName name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object evaluate(final FunctionExpressionName name,
+                           final List<Object> parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        return this.context.canConvert(value, type);
+    }
+
+    @Override
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> target) {
+        return this.context.convert(value, target);
+    }
+
+    @Override
+    public int twoDigitYear() {
+        return this.context.twoDigitYear();
+    }
+
+    @Override
+    public Locale locale() {
+        return this.context.locale();
+    }
+
+    @Override
+    public MathContext mathContext() {
+        return this.context.mathContext();
+    }
+
+    @Override
+    public ExpressionNumberKind expressionNumberKind() {
+        return this.context.expressionNumberKind();
+    }
+
+    private final ExpressionNumberConverterContext context;
+
+    public String toString() {
+        return this.context.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsMode.java
@@ -17,77 +17,25 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
+import walkingkooka.math.DecimalNumberContext;
 
 /**
- * Determines how individual digits with a number are handled.
+ * Internal enum that is used hen creating a {@link SpreadsheetNumberParsePatternsParser} to differentiate between
+ * a number that parses a value and numbers within an expression.
  */
 enum SpreadsheetNumberParsePatternsMode {
-
-    /**
-     * Digits before any decimal separator.
-     */
-    INTEGER {
+    EXPRESSION {
         @Override
-        void onDigit(final int digit,
-                     final SpreadsheetNumberParsePatternsRequest context) {
-            final MathContext mathContext = context.context.mathContext();
-
-            context.mantissa = context.mantissa.multiply(BigDecimal.TEN, mathContext)
-                    .add(BigDecimal.valueOf(digit), mathContext);
-        }
-
-        @Override
-        void onDecimalSeparator(final SpreadsheetNumberParsePatternsRequest context) {
-            context.mode = DECIMAL;
+        boolean isGroupSeparator(final char c, final DecimalNumberContext context) {
+            return false;
         }
     },
-
-    /**
-     * Digits after a decimal separator
-     */
-    DECIMAL {
+    VALUE{
         @Override
-        void onDigit(final int digit,
-                     final SpreadsheetNumberParsePatternsRequest context) {
-            final MathContext mathContext = context.context.mathContext();
-
-            context.mantissa = context.mantissa.multiply(BigDecimal.TEN, mathContext)
-                    .add(BigDecimal.valueOf(digit), mathContext);
-            context.exponent--;
-        }
-
-        @Override
-        void onDecimalSeparator(final SpreadsheetNumberParsePatternsRequest context) {
-            // ignored
-        }
-    },
-
-    /**
-     * Digits belong to an exponent.
-     */
-    EXPONENT {
-        @Override
-        void onDigit(final int digit,
-                     final SpreadsheetNumberParsePatternsRequest context) {
-            context.exponent = context.exponent * 10 + digit;
-        }
-
-        @Override
-        void onDecimalSeparator(final SpreadsheetNumberParsePatternsRequest context) {
-            // ignored
+        boolean isGroupSeparator(final char c, final DecimalNumberContext context) {
+            return c == context.groupingSeparator();
         }
     };
 
-    /**
-     * Handles a onDigit with a number
-     */
-    abstract void onDigit(final int digit,
-                          final SpreadsheetNumberParsePatternsRequest context);
-
-    /**
-     * Handles a decimal separator, possibly switching onDigit mode.
-     */
-    abstract void onDecimalSeparator(final SpreadsheetNumberParsePatternsRequest context);
+    abstract boolean isGroupSeparator(final char c, final DecimalNumberContext context);
 }

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetNumberParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetNumberParserToken.java
@@ -16,29 +16,44 @@
  */
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionNumber;
+import walkingkooka.visit.Visiting;
+
+import java.util.List;
 
 /**
- * Holds a single {@link ExpressionNumber} number.
+ * Holds a {@link walkingkooka.tree.expression.ExpressionNumber} value along with the components and original text.
  */
-public final class SpreadsheetNumberParserToken extends SpreadsheetNonSymbolParserToken<ExpressionNumber> {
+public final class SpreadsheetNumberParserToken extends SpreadsheetParentParserToken {
 
-    static SpreadsheetNumberParserToken with(final ExpressionNumber value, final String text) {
-        checkValueAndText(value, text);
-
-        return new SpreadsheetNumberParserToken(value, text);
+    static SpreadsheetNumberParserToken with(final List<ParserToken> value, final String text) {
+        return new SpreadsheetNumberParserToken(copyAndCheckTokens(value), checkText(text));
     }
 
-    private SpreadsheetNumberParserToken(final ExpressionNumber value, final String text) {
+    private SpreadsheetNumberParserToken(final List<ParserToken> value, final String text) {
         super(value, text);
+    }
+
+    /**
+     * Creates a {@link ExpressionNumber} from the components in this {@link SpreadsheetNumberParserToken}.
+     */
+    public ExpressionNumber toNumber(final ExpressionEvaluationContext context) {
+        return SpreadsheetParserTokenVisitorExpressionNumber.toExpressionNumber(this, context);
     }
 
     // SpreadsheetParserTokenVisitor....................................................................................
 
     @Override
     void accept(final SpreadsheetParserTokenVisitor visitor) {
-        visitor.visit(this);
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
+
+    // Object...........................................................................................................
 
     @Override
     boolean canBeEqual(final Object other) {

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
@@ -27,7 +27,6 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenVisitor;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
-import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonNodeException;
 import walkingkooka.tree.json.JsonPropertyName;
@@ -379,7 +378,7 @@ public abstract class SpreadsheetParserToken implements ParserToken {
     /**
      * {@see SpreadsheetNumberParserToken}
      */
-    public static SpreadsheetNumberParserToken number(final ExpressionNumber value, final String text) {
+    public static SpreadsheetNumberParserToken number(final List<ParserToken> value, final String text) {
         return SpreadsheetNumberParserToken.with(value, text);
     }
 
@@ -1182,11 +1181,6 @@ public abstract class SpreadsheetParserToken implements ParserToken {
         );
 
         registerLeafParserToken(
-                SpreadsheetNumberParserToken.class,
-                SpreadsheetParserToken::unmarshallNumber
-        );
-
-        registerLeafParserToken(
                 SpreadsheetRowReferenceParserToken.class,
                 SpreadsheetParserToken::unmarshallRowReference
         );
@@ -1354,16 +1348,6 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 Integer.class,
                 context,
                 SpreadsheetParserToken::monthNumber
-        );
-    }
-
-    static SpreadsheetNumberParserToken unmarshallNumber(final JsonNode node,
-                                                         final JsonNodeUnmarshallContext context) {
-        return unmarshallLeafParserToken(
-                node,
-                ExpressionNumber.class,
-                context,
-                SpreadsheetParserToken::number
         );
     }
 
@@ -1869,6 +1853,11 @@ public abstract class SpreadsheetParserToken implements ParserToken {
         );
 
         registerParentParserToken(
+                SpreadsheetNumberParserToken.class,
+                SpreadsheetParserToken::unmarshallNumber
+        );
+
+        registerParentParserToken(
                 SpreadsheetPowerParserToken.class,
                 SpreadsheetParserToken::unmarshallPower
         );
@@ -2020,6 +2009,15 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 node,
                 context,
                 SpreadsheetParserToken::notEquals
+        );
+    }
+
+    static SpreadsheetNumberParserToken unmarshallNumber(final JsonNode node,
+                                                         final JsonNodeUnmarshallContext context) {
+        return unmarshallParentParserToken(
+                node,
+                context,
+                SpreadsheetParserToken::number
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
@@ -183,6 +183,16 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
         // nop
     }
 
+    // SpreadsheetNumberParserToken.....................................................................................
+
+    protected Visiting startVisit(final SpreadsheetNumberParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final SpreadsheetNumberParserToken token) {
+        // nop
+    }
+
     // SpreadsheetPercentageParserToken....................................................................................
 
     protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
@@ -366,10 +376,6 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
     }
 
     protected void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        // nop
-    }
-
-    protected void visit(final SpreadsheetNumberParserToken token) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorExpressionNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorExpressionNumber.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.ToStringBuilder;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumber;
+import walkingkooka.tree.expression.ExpressionNumberKind;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * A {@link SpreadsheetParserTokenVisitor} that accepts a {@link SpreadsheetNumberParserToken} and creates a {@link ExpressionNumber}
+ */
+final class SpreadsheetParserTokenVisitorExpressionNumber extends SpreadsheetParserTokenVisitor {
+
+    /**
+     * Creates a {@link SpreadsheetParserTokenVisitorExpressionNumber}, that collects and translates symbols into a {@link String}
+     * which is then parsed by {@link ExpressionNumberKind#parse(String)}.
+     */
+    static ExpressionNumber toExpressionNumber(final SpreadsheetParentParserToken token,
+                                               final ExpressionEvaluationContext context) {
+        Objects.requireNonNull(context, "context");
+
+        final SpreadsheetParserTokenVisitorExpressionNumber visitor = new SpreadsheetParserTokenVisitorExpressionNumber();
+        visitor.accept(token);
+        return context.expressionNumberKind().parse(visitor.number.toString());
+    }
+
+    // @VisibleForTesting
+    SpreadsheetParserTokenVisitorExpressionNumber() {
+        super();
+    }
+
+    // visit....................................................................................................
+    // ignore all SymbolParserTokens, dont bother to collect them.
+
+    @Override
+    protected void visit(final SpreadsheetDecimalSeparatorSymbolParserToken token) {
+        this.number.append('.');
+    }
+
+    @Override
+    protected void visit(final SpreadsheetDigitsParserToken token) {
+        this.number.append(token.text());
+    }
+
+    @Override
+    protected void visit(final SpreadsheetExponentSymbolParserToken token) {
+        this.number.append('E');
+    }
+
+    @Override
+    protected void visit(final SpreadsheetMinusSymbolParserToken token) {
+        this.number.append('-');
+    }
+
+    @Override
+    protected void visit(final SpreadsheetPlusSymbolParserToken token) {
+        this.number.append('+');
+    }
+
+    /**
+     * Aggregates all the number important characters digits, signs, exponent etc, this will be parsed by {@link BigDecimal}.
+     */
+    private final StringBuilder number = new StringBuilder();
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.empty()
+                .build();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
@@ -240,6 +240,20 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
     }
 
     @Override
+    protected Visiting startVisit(final SpreadsheetNumberParserToken token) {
+        return this.enter();
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetNumberParserToken token) {
+        this.exit();
+        this.add(
+                Expression.expressionNumber(token.toNumber(this.context)),
+                token
+        );
+    }
+
+    @Override
     protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
         return this.enter();
     }
@@ -333,11 +347,6 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
     @Override
     protected void visit(final SpreadsheetLabelNameParserToken token) {
         this.addReference(token.value(), token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetNumberParserToken token) {
-        this.add(Expression.expressionNumber(token.value()), token);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.Either;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.expression.FunctionExpressionName;
+import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+
+import java.math.MathContext;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+final class SpreadsheetParsersExpressionEvaluationContext implements ExpressionEvaluationContext {
+
+    static SpreadsheetParsersExpressionEvaluationContext with(final SpreadsheetParserContext context) {
+        return new SpreadsheetParsersExpressionEvaluationContext(context);
+    }
+
+    private SpreadsheetParsersExpressionEvaluationContext(final SpreadsheetParserContext context) {
+        super();
+        this.context = context;
+    }
+
+    @Override
+    public Object evaluate(final Expression expression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Expression> reference(final ExpressionReference reference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExpressionFunction<?, ExpressionFunctionContext> function(final FunctionExpressionName name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object evaluate(final FunctionExpressionName name,
+                           final List<Object> parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean canConvert(final Object value, final Class<?> type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Either<T, String> convert(Object value, Class<T> target) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int twoDigitYear() {
+        return this.context.twoDigitYear();
+    }
+
+    @Override
+    public Locale locale() {
+        return this.context.locale();
+    }
+
+    @Override
+    public MathContext mathContext() {
+        return this.context.mathContext();
+    }
+
+    @Override
+    public ExpressionNumberKind expressionNumberKind() {
+        return this.context.expressionNumberKind();
+    }
+
+    private final SpreadsheetParserContext context;
+
+    public String toString() {
+        return this.context.toString();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -252,10 +252,25 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
     @Test
     public void testParseFormula() {
         this.parseFormulaAndCheck("1+2",
-                SpreadsheetParserToken.addition(Lists.of(SpreadsheetParserToken.number(this.number(1), "1"),
-                        SpreadsheetParserToken.plusSymbol("+", "+"),
-                        SpreadsheetParserToken.number(this.number(2), "2")),
-                        "1+2"));
+                SpreadsheetParserToken.addition(
+                        Lists.of(
+                                SpreadsheetParserToken.number(
+                                        Lists.of(
+                                                SpreadsheetParserToken.digits("1", "1")
+                                        ),
+                                        "1"
+                                ),
+                                SpreadsheetParserToken.plusSymbol("+", "+"),
+                                SpreadsheetParserToken.number(
+                                        Lists.of(
+                                                SpreadsheetParserToken.digits("2", "2")
+                                        ),
+                                        "2"
+                                )
+                        ),
+                        "1+2"
+                )
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.engine;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
@@ -51,8 +52,14 @@ public final class BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerS
     @Test
     public void testToString() {
         final BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor visitor = new BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor(12, 34);
-        visitor.visit(SpreadsheetParserToken.number(EXPRESSION_NUMBER_KIND.create(1.24), "1.24"));
-        this.toStringAndCheck(visitor, "12,34 [1.24], []");
+        visitor.startVisit(
+                SpreadsheetParserToken.number(
+                        Lists.of(
+                                SpreadsheetParserToken.digits("1", "1")
+                        ),
+                        "1")
+        );
+        this.toStringAndCheck(visitor, "12,34 [], [[]]");
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
@@ -126,7 +126,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSecondsDecimal() {
         this.parseAndCheck2(
                 "hh:mm:ss.",
-                "11:58:59.",
+                "11:58:59" + DECIMAL,
                 hour11(),
                 colon(),
                 minute58(),
@@ -140,7 +140,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSecondsMillis() {
         this.parseAndCheck2(
                 "hh:mm:ss.0",
-                "11:58:59.1",
+                "11:58:59" + DECIMAL + "1",
                 hour11(),
                 colon(),
                 minute58(),
@@ -155,7 +155,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSeconds2Millis() {
         this.parseAndCheck2(
                 "hh:mm:ss.00",
-                "11:58:59.12",
+                "11:58:59" + DECIMAL + "12",
                 hour11(),
                 colon(),
                 minute58(),
@@ -170,7 +170,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSeconds3Millis() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.123",
+                "11:58:59" + DECIMAL + "123",
                 hour11(),
                 colon(),
                 minute58(),
@@ -185,7 +185,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSeconds3Millis2() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.12",
+                "11:58:59" + DECIMAL + "12",
                 hour11(),
                 colon(),
                 minute58(),
@@ -200,7 +200,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSeconds3Millis3() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.1",
+                "11:58:59" + DECIMAL + "1",
                 hour11(),
                 colon(),
                 minute58(),
@@ -215,7 +215,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSeconds3Millis4() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.",
+                "11:58:59" + DECIMAL,
                 hour11(),
                 colon(),
                 minute58(),
@@ -244,7 +244,7 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testParseHourMinutesSecondsMillisAmpm() {
         this.parseAndCheck2(
                 "hh:mm:ss.0 AM/PM",
-                "11:58:59.1 PM",
+                "11:58:59" + DECIMAL + "1 PM",
                 hour11(),
                 colon(),
                 minute58(),

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrencyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrencyTest.java
@@ -18,38 +18,89 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public final class SpreadsheetNumberParsePatternsComponentCurrencyTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentCurrency> {
 
     @Test
     public void testIncomplete() {
-        this.parseFails(CURRENCY.substring(0, CURRENCY.length() - 1), "");
+        this.parseFails(CURRENCY.substring(0, 1));
     }
 
     @Test
-    public void testDifferentCase() {
-        assertNotEquals(CURRENCY, CURRENCY.toUpperCase(), "currency upper case should be different");
-        this.parseFails(CURRENCY.toUpperCase());
+    public void testIncomplete2() {
+        this.parseFails(CURRENCY.substring(0, 1) + "!");
     }
 
     @Test
-    public void testToken() {
-        this.parseAndCheck(CURRENCY,
-                "",
-                null,
-                true);
+    public void testIncomplete3() {
+        this.parseFails(CURRENCY.substring(0, 2));
+    }
+
+    @Test
+    public void testIncomplete4() {
+        this.parseFails(CURRENCY.substring(0, 2) + "!");
+    }
+
+    @Test
+    public void testToken1() {
+        assertEquals(CURRENCY.toUpperCase(), CURRENCY);
+
+        this.parseAndCheck2(
+                CURRENCY,
+                ""
+        );
     }
 
     @Test
     public void testToken2() {
-        final String after = "123";
+        assertEquals(CURRENCY.toUpperCase(), CURRENCY);
 
-        this.parseAndCheck(CURRENCY + after,
-                after,
-                null,
-                true);
+        this.parseAndCheck2(
+                CURRENCY,
+                "!"
+        );
+    }
+
+    @Test
+    public void testToken3() {
+        assertNotEquals(CURRENCY.toLowerCase(), CURRENCY);
+
+        this.parseAndCheck2(
+                CURRENCY.toLowerCase(),
+                ""
+        );
+    }
+
+    @Test
+    public void testToken4() {
+        assertNotEquals(CURRENCY.toLowerCase(), CURRENCY);
+
+        this.parseAndCheck2(
+                CURRENCY.toLowerCase(),
+                "!"
+        );
+    }
+
+    @Test
+    public void testCaseUnimportant() {
+        this.parseAndCheck2(
+                CURRENCY.toLowerCase().substring(0, 1) + CURRENCY.toUpperCase().substring(1),
+                ""
+        );
+    }
+
+    final void parseAndCheck2(final String text,
+                              final String textAfter) {
+        this.parseAndCheck2(
+                text,
+                textAfter,
+                NEXT_CALLED,
+                SpreadsheetParserToken.currencySymbol(text, text)
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparatorTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,26 +26,47 @@ public final class SpreadsheetNumberParsePatternsComponentDecimalSeparatorTest e
 
     @Test
     public void testDecimal() {
-        this.parseAndCheck2("D",
-                "");
+        assertEquals(DECIMAL, 'd');
+
+        this.parseAndCheck2(
+                DECIMAL,
+                ""
+        );
     }
 
     @Test
     public void testDecimalCharacter() {
-        this.parseAndCheck2("D!", "!");
+        this.parseAndCheck2(
+                DECIMAL ,
+                "!"
+        );
     }
 
-    final void parseAndCheck2(final String text,
+    @Test
+    public void testDecimalTwice() {
+        this.parseAndCheck2(
+                DECIMAL,
+                DECIMAL + ""
+        );
+    }
+
+    @Test
+    public void testDecimalTwiceCharacter() {
+        this.parseAndCheck2(
+                DECIMAL,
+                DECIMAL + "!"
+        );
+    }
+
+    final void parseAndCheck2(final char c,
                               final String textAfter) {
-        final SpreadsheetNumberParsePatternsRequest context = this.createRequest();
-        this.parseAndCheck(this.createComponent(),
+        final String text = "" + c;
+        this.parseAndCheck2(
                 text,
-                context,
                 textAfter,
-                VALUE_WITHOUT,
-                NEXT_CALLED);
-        this.checkMode(context, SpreadsheetNumberParsePatternsMode.DECIMAL);
-        assertEquals(false, context.percentage, "percentage");
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                NEXT_CALLED,
+                SpreadsheetParserToken.decimalSeparatorSymbol(text, text));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitDigitTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitDigitTest.java
@@ -22,42 +22,25 @@ import org.junit.jupiter.api.Test;
 public final class SpreadsheetNumberParsePatternsComponentDigitDigitTest extends SpreadsheetNumberParsePatternsComponentDigitTestCase<SpreadsheetNumberParsePatternsComponentDigitDigit> {
 
     @Test
-    public void testSpace() {
-        this.parseAndCheck2(" ",
-                " ",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
-    }
-
-    @Test
-    public void testSpaceLetter() {
-        this.parseAndCheck2(" A",
-                " A",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
-    }
-
-    @Test
-    public void testSpaceDigit() {
-        this.parseAndCheck2(" 1",
-                " 1",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
-    }
-
-    @Test
     public void testToString() {
         this.toStringAndCheck(this.createComponent(), "#");
     }
 
     @Test
     public void testToString2() {
-        this.toStringAndCheck(SpreadsheetNumberParsePatternsComponentDigitDigit.with(1), "#");
+        this.toStringAndCheck(
+                SpreadsheetNumberParsePatternsComponentDigitDigit.with(
+                        SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                        1
+                ),
+                "#"
+        );
     }
 
     @Override
-    SpreadsheetNumberParsePatternsComponentDigitDigit createComponent(final int max) {
-        return SpreadsheetNumberParsePatternsComponentDigitDigit.with(max);
+    SpreadsheetNumberParsePatternsComponentDigitDigit createComponent(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                                      final int max) {
+        return SpreadsheetNumberParsePatternsComponentDigitDigit.with(mode, max);
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitModeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitModeTest.java
@@ -17,13 +17,13 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
-public final class SpreadsheetNumberParsePatternsModeTest extends SpreadsheetNumberParsePatternsTestCase2<SpreadsheetNumberParsePatternsMode> {
+public final class SpreadsheetNumberParsePatternsComponentDigitModeTest extends SpreadsheetNumberParsePatternsTestCase2<SpreadsheetNumberParsePatternsComponentDigitMode> {
 
     // ClassTesting.....................................................................................................
 
     @Override
-    public Class<SpreadsheetNumberParsePatternsMode> type() {
-        return SpreadsheetNumberParsePatternsMode.class;
+    public Class<SpreadsheetNumberParsePatternsComponentDigitMode> type() {
+        return SpreadsheetNumberParsePatternsComponentDigitMode.class;
     }
 
     // TypeNameTesting..................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitSpaceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitSpaceTest.java
@@ -18,65 +18,65 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 public final class SpreadsheetNumberParsePatternsComponentDigitSpaceTest extends SpreadsheetNumberParsePatternsComponentDigitTestCase<SpreadsheetNumberParsePatternsComponentDigitSpace> {
 
+
+    // space.............................................................................................................
+
     @Test
-    public void testDigitsSpace() {
-        this.parseAndCheck("12 Z",
-                "Z",
-                BigDecimal.valueOf(12),
-                NEXT_CALLED);
+    public  void testSpaceIntegerOrSign() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN
+        );
     }
 
     @Test
-    public void testSpaceDigitDigit() {
-        this.parseAndCheck2(" 12",
-                "",
-                BigDecimal.valueOf(12),
-                NEGATIVE_POSITIVE_MISSING);
+    public  void testSpaceInteger() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
     }
 
     @Test
-    public void testSpacePlusDigitDigit() {
-        this.parseAndCheck2(" Q12",
-                "",
-                BigDecimal.valueOf(12),
-                POSITIVE);
+    public  void testSpaceDecimalFirst() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST
+        );
     }
 
     @Test
-    public void testSpaceMinusDigitDigit() {
-        this.parseAndCheck2(" N12",
-                "",
-                BigDecimal.valueOf(-12),
-                NEGATIVE);
+    public  void testSpaceDecimal() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
     }
 
     @Test
-    public void testSpaceMinusDigitDigitLetter() {
-        this.parseAndCheck2(" N12!",
-                "!",
-                BigDecimal.valueOf(-12),
-                NEGATIVE);
+    public  void testSpaceExponentOrSign() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN
+        );
     }
 
     @Test
-    public void testMaximumSpaces() {
-        this.parseAndCheck2("    ",
+    public  void testSpaceExponent() {
+        this.testSpace(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testSpace(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        this.parseAndCheck3(
+                1,
+                mode,
                 " ",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
-    }
-
-    @Test
-    public void testMaximumSpaceDigit() {
-        this.parseAndCheck2("   4",
-                "4",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
+                "",
+                mode,
+                NEXT_SKIPPED,
+                SpreadsheetParserToken.whitespace(" ", " ")
+        );
     }
 
     @Test
@@ -86,12 +86,18 @@ public final class SpreadsheetNumberParsePatternsComponentDigitSpaceTest extends
 
     @Test
     public void testToString2() {
-        this.toStringAndCheck(SpreadsheetNumberParsePatternsComponentDigitSpace.with(1), "?");
+        this.toStringAndCheck(
+                SpreadsheetNumberParsePatternsComponentDigitSpace.with(
+                        SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                        1
+                ),
+                "?");
     }
 
     @Override
-    SpreadsheetNumberParsePatternsComponentDigitSpace createComponent(final int max) {
-        return SpreadsheetNumberParsePatternsComponentDigitSpace.with(max);
+    SpreadsheetNumberParsePatternsComponentDigitSpace createComponent(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                                      final int max) {
+        return SpreadsheetNumberParsePatternsComponentDigitSpace.with(mode, max);
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitTestCase.java
@@ -18,144 +18,742 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class SpreadsheetNumberParsePatternsComponentDigitTestCase<C extends SpreadsheetNumberParsePatternsComponentDigit> extends SpreadsheetNumberParsePatternsComponentTestCase<C> {
 
+    private final static String TEXT5 = "5";
+    private final static String VALUE5 = TEXT5;
+
+    private final static String TEXT6 = "6";
+    private final static String VALUE6 = TEXT6;
+
     SpreadsheetNumberParsePatternsComponentDigitTestCase() {
     }
 
-    final static Boolean NEGATIVE = true;
-    final static Boolean POSITIVE = false;
-    final static Boolean NEGATIVE_POSITIVE_MISSING = null;
+    // grouping.............................................................................................................
 
     @Test
-    public final void testGroupingSeparatorNonDigit() {
-        this.parseAndCheck2("GA",
-                "A",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testGroupingIntegerOrSign() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN
+        );
     }
 
     @Test
-    public final void testGroupingSeparatorDigit() {
-        this.parseAndCheck2("G0A",
-                "A",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testGroupingInteger() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
     }
 
     @Test
-    public final void testDigits() {
-        final String after = "abc";
-
-        this.parseAndCheck2("123" + after,
-                after,
-                BigDecimal.valueOf(123),
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testGroupingDecimalFirst() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST
+        );
     }
 
     @Test
-    public final void testMaximumDigits() {
-        this.parseAndCheck2("123",
+    public final void testGroupingDecimal() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testGroupingExponentOrSign() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN
+        );
+    }
+
+    @Test
+    public final void testGroupingExponent() {
+        this.testGrouping(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testGrouping(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        this.parseAndCheck3(
+                1,
+                mode,
+                "" + GROUP,
                 "",
-                BigDecimal.valueOf(123),
-                NEGATIVE_POSITIVE_MISSING);
+                mode,
+                NEXT_SKIPPED,
+                SpreadsheetParserToken.groupingSeparatorSymbol("" + GROUP, "" + GROUP)
+        );
+    }
+
+    // plus.............................................................................................................
+
+    @Test
+    public final void testPlusIntegerOrSign() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN
+        );
     }
 
     @Test
-    public final void testMaximumDigitsLetter() {
-        this.parseAndCheck2("123A",
-                "A",
-                BigDecimal.valueOf(123),
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testPlusInteger() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
     }
 
     @Test
-    public final void testMaximumDigitsDigit() {
-        this.parseAndCheck2("123456",
-                "456",
-                BigDecimal.valueOf(123),
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testPlusDecimalFirst() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST
+        );
     }
 
     @Test
-    public final void testPlusDigit() {
-        this.parseAndCheck2("Q123456",
-                "456",
-                BigDecimal.valueOf(123),
-                POSITIVE);
+    public final void testPlusDecimal() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
     }
 
     @Test
-    public final void testMinusDigit() {
-        this.parseAndCheck2("N123456",
-                "456",
-                BigDecimal.valueOf(-123),
-                NEGATIVE);
+    public final void testPlusExponentOrSign() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN
+        );
     }
 
     @Test
-    public final void testDigitPlusDigit() {
-        this.parseAndCheck2("12Q345",
-                "45",
-                BigDecimal.valueOf(123),
-                POSITIVE);
+    public final void testPlusExponent() {
+        this.testPlus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+    
+    private void testPlus(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        final String text = "" + PLUS;
+
+        if(mode.isSign()) {
+            this.parseAndCheck3(
+                    1,
+                    mode,
+                    text,
+                    "",
+                    mode.next(),
+                    NEXT_SKIPPED,
+                    SpreadsheetParserToken.plusSymbol(text, text)
+            );
+        } else {
+            this.parseAndCheck3(
+                    1,
+                    mode,
+                    "",
+                    text,
+                    mode,
+                    NEXT_SKIPPED
+            );
+        }
+    }
+
+    // minus.............................................................................................................
+
+    @Test
+    public final void testMinusIntegerOrSign() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN
+        );
     }
 
     @Test
-    public final void testDigitMinusDigit() {
-        this.parseAndCheck2("12N345",
-                "45",
-                BigDecimal.valueOf(-123),
-                NEGATIVE);
+    public final void testMinusInteger() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
     }
 
     @Test
-    public final void testDigitGroupingSeparatorDigit() {
-        this.parseAndCheck2("1G2",
+    public final void testMinusDecimalFirst() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST
+        );
+    }
+
+    @Test
+    public final void testMinusDecimal() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testMinusExponentOrSign() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN
+        );
+    }
+
+    @Test
+    public final void testMinusExponent() {
+        this.testMinus(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testMinus(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
+        final String text = "" + MINUS;
+
+        if(mode.isSign()) {
+            this.parseAndCheck3(
+                    1,
+                    mode,
+                    text,
+                    "",
+                    mode.next(),
+                    NEXT_SKIPPED,
+                    SpreadsheetParserToken.minusSymbol(text, text)
+            );
+        } else {
+            this.parseAndCheck3(
+                    1,
+                    mode,
+                    "",
+                    text,
+                    mode,
+                    NEXT_SKIPPED
+            );
+        }
+    }
+    
+    // digits 1, max=1..................................................................................................
+
+    @Test
+    public final void testDigit1Max1IntegerOrSign() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testDigit1Max1Integer() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testDigit1Max1DecimalFirst() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testDigit1Max1Decimal() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testDigit1Max1ExponentOrSign() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testDigit1Max1Exponent() {
+        this.testDigit1Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testDigit1Max1(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        this.parseAndCheck3(
+                1,
+                mode,
+                TEXT5,
                 "",
-                BigDecimal.valueOf(12),
-                NEGATIVE_POSITIVE_MISSING);
+                expectedMode,
+                NEXT_CALLED,
+                SpreadsheetParserToken.digits(VALUE5, TEXT5)
+        );
+    }
+
+    // 1x digit, text max=1
+
+    @Test
+    public final void testDigit1TextMax1IntegerOrSign() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
     }
 
     @Test
-    public final void testDigitGroupingSeparatorLetter() {
-        this.parseAndCheck2("1GA",
-                "A",
-                BigDecimal.valueOf(1),
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testDigit1TextMax1Integer() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
     }
 
     @Test
-    public final void testDigitGroupingSeparatorDigitMaximum() {
-        this.parseAndCheck2("1G234",
-                "4",
-                BigDecimal.valueOf(123),
-                NEGATIVE_POSITIVE_MISSING);
+    public final void testDigit1TextMax1DecimalFirst() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
     }
 
-    final void parseAndCheck2(final String text,
+    @Test
+    public final void testDigit1TextMax1Decimal() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testDigit1TextMax1ExponentOrSign() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testDigit1TextMax1Exponent() {
+        this.testDigit1TextMax1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testDigit1TextMax1(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                    final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        this.parseAndCheck3(
+                1,
+                mode,
+                TEXT5,
+                "a",
+                expectedMode,
+                NEXT_CALLED,
+                SpreadsheetParserToken.digits(VALUE5, TEXT5)
+        );
+    }
+
+    // 1x digit, digit max=1
+
+    @Test
+    public final void testDigit2Max1IntegerOrSign() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testDigit2Max1Integer() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testDigit2Max1DecimalFirst() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testDigit2Max1Decimal() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testDigit2Max1ExponentOrSign() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testDigit2Max1Exponent() {
+        this.testDigit2Max1(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testDigit2Max1(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        this.parseAndCheck3(
+                1,
+                mode,
+                TEXT5,
+                "a",
+                expectedMode,
+                NEXT_CALLED,
+                SpreadsheetParserToken.digits(VALUE5, TEXT5)
+        );
+    }
+
+    // digits2, max=2..................................................................................................
+
+    @Test
+    public final void testDigit2Max2IntegerOrSign() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testDigit2Max2Integer() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testDigit2Max2DecimalFirst() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testDigit2Max2Decimal() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testDigit2Max2ExponentOrSign() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testDigit2Max2Exponent() {
+        this.testDigit2Max2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testDigit2Max2(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                     final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        final String text = TEXT5 + TEXT6;
+        this.parseAndCheck3(
+                2,
+                mode,
+                text,
+                "",
+                expectedMode,
+                NEXT_CALLED,
+                SpreadsheetParserToken.digits(text, text)
+        );
+    }
+
+    // digits2, text max=2..................................................................................................
+
+    @Test
+    public final void testDigit2TextMax2IntegerOrSign() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testDigit2TextMax2Integer() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testDigit2TextMax2DecimalFirst() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testDigit2TextMax2Decimal() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testDigit2TextMax2ExponentOrSign() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testDigit2TextMax2Exponent() {
+        this.testDigit2TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testDigit2TextMax2(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                         final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        final String text = TEXT5 + TEXT6;
+        this.parseAndCheck3(
+                2,
+                mode,
+                text,
+                "!",
+                expectedMode,
+                NEXT_CALLED,
+                SpreadsheetParserToken.digits(text, text)
+        );
+    }
+
+    // plus, digits, text max=2..................................................................................................
+
+    @Test
+    public final void testPlusDigit1TextMax2IntegerOrSign() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testPlusDigit1TextMax2Integer() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testPlusDigit1TextMax2DecimalFirst() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testPlusDigit1TextMax2Decimal() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testPlusDigit1TextMax2ExponentOrSign() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testPlusDigit1TextMax2Exponent() {
+        this.testPlusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testPlusDigit1TextMax2(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                        final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        final String text = TEXT5;
+        final String plusText = PLUS + text;
+
+        if(mode.isSign()) {
+            this.parseAndCheck3(
+                    2,
+                    mode,
+                    plusText,
+                    "",
+                    expectedMode,
+                    NEXT_CALLED,
+                    SpreadsheetParserToken.plusSymbol("" + PLUS, "" + PLUS),
+                    SpreadsheetParserToken.digits(text, text)
+            );
+        } else {
+            this.parseAndCheck3(
+                    2,
+                    mode,
+                    "",
+                    plusText,
+                    mode,
+                    NEXT_SKIPPED
+            );
+        }
+    }
+
+
+    // sign, digits, text max=2..................................................................................................
+
+    @Test
+    public final void testMinusDigit1TextMax2IntegerOrSign() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+
+    }
+
+    @Test
+    public final void testMinusDigit1TextMax2Integer() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER
+        );
+    }
+
+    @Test
+    public final void testMinusDigit1TextMax2DecimalFirst() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+
+    }
+
+    @Test
+    public final void testMinusDigit1TextMax2Decimal() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL,
+                SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL
+        );
+    }
+
+    @Test
+    public final void testMinusDigit1TextMax2ExponentOrSign() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    @Test
+    public final void testMinusDigit1TextMax2Exponent() {
+        this.testMinusDigit1TextMax2(
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT,
+                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT
+        );
+    }
+
+    private void testMinusDigit1TextMax2(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                         final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode) {
+        final String text = TEXT5;
+        final String minusText = MINUS + text;
+
+        if(mode.isSign()) {
+            this.parseAndCheck3(
+                    2,
+                    mode,
+                    minusText,
+                    "",
+                    expectedMode,
+                    NEXT_CALLED,
+                    SpreadsheetParserToken.minusSymbol("" + MINUS, "" + MINUS),
+                    SpreadsheetParserToken.digits(text, text)
+            );
+        } else {
+            this.parseAndCheck3(
+                    2,
+                    mode,
+                    "",
+                    minusText,
+                    mode,
+                    NEXT_SKIPPED
+            );
+        }
+    }
+
+    // helpers...........................................................................................................
+
+    final void parseAndCheck3(final int max,
+                              final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                              final String text,
                               final String textAfter,
-                              final BigDecimal value,
-                              final Boolean negative) {
-        final SpreadsheetNumberParsePatternsRequest context = this.createRequest();
-        this.parseAndCheck(text,
-                context,
+                              final SpreadsheetNumberParsePatternsComponentDigitMode expectedMode,
+                              final boolean hasNext,
+                              final SpreadsheetParserToken... tokens) {
+        final SpreadsheetNumberParsePatternsRequest request = this.createRequest(hasNext);
+        request.digitMode = mode;
+
+        this.parseAndCheck2(
+                this.createComponent(mode, max),
+                text,
                 textAfter,
-                value,
-                NEXT_CALLED);
-        assertEquals(negative, context.negativeMantissa, "negativeMantissa");
-        this.checkMode(context, SpreadsheetNumberParsePatternsMode.INTEGER);
+                request,
+                hasNext,
+                tokens
+        );
+
+        assertEquals(
+                "",
+                request.digits.toString(),
+                () -> "digits\nrequest: " + request
+        );
+
+        assertEquals(
+                expectedMode,
+                request.digitMode,
+                () -> "mode\nrequest: " + request
+        );
     }
 
     @Override
     final C createComponent() {
-        return this.createComponent(3);
+        return this.createComponent(SpreadsheetNumberParsePatternsComponentDigitMode.DECIMAL_FIRST, 3);
     }
 
-    abstract C createComponent(final int max);
+    abstract C createComponent(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                               final int max);
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitZeroTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigitZeroTest.java
@@ -22,26 +22,23 @@ import org.junit.jupiter.api.Test;
 public final class SpreadsheetNumberParsePatternsComponentDigitZeroTest extends SpreadsheetNumberParsePatternsComponentDigitTestCase<SpreadsheetNumberParsePatternsComponentDigitZero> {
 
     @Test
-    public void testSpace() {
-        this.parseAndCheck2(" ",
-                " ",
-                VALUE_WITHOUT,
-                NEGATIVE_POSITIVE_MISSING);
-    }
-
-    @Test
     public void testToString() {
         this.toStringAndCheck(this.createComponent(), "0");
     }
 
     @Test
     public void testToString2() {
-        this.toStringAndCheck(SpreadsheetNumberParsePatternsComponentDigitZero.with(1), "0");
+        this.toStringAndCheck(
+                SpreadsheetNumberParsePatternsComponentDigitZero.with(
+                        SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER,
+                        1),
+                "0");
     }
 
     @Override
-    SpreadsheetNumberParsePatternsComponentDigitZero createComponent(final int max) {
-        return SpreadsheetNumberParsePatternsComponentDigitZero.with(max);
+    SpreadsheetNumberParsePatternsComponentDigitZero createComponent(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
+                                                                     final int max) {
+        return SpreadsheetNumberParsePatternsComponentDigitZero.with(mode, max);
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentExponentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentExponentTest.java
@@ -18,117 +18,89 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.list.Lists;
-import walkingkooka.math.DecimalNumberContexts;
-
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.Locale;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public final class SpreadsheetNumberParsePatternsComponentExponentTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentExponent> {
 
     @Test
-    public void testLowerCaseExponent() {
-        this.parseAndCheck2("x",
-                "",
-                false);
+    public void testIncomplete() {
+        this.parseFails(EXPONENT.substring(0, 1));
     }
 
     @Test
-    public void testLowerCaseExponent2() {
-        this.parseAndCheck2("x!",
-                "!",
-                false);
+    public void testIncomplete2() {
+        this.parseFails(EXPONENT.substring(0, 1) + "!");
     }
 
     @Test
-    public void testLowerCaseExponentPositive() {
-        this.parseAndCheck2("xQ",
-                "",
-                false);
+    public void testIncomplete3() {
+        this.parseFails(EXPONENT.substring(0, 2));
     }
 
     @Test
-    public void testLowerCaseExponentPositive2() {
-        this.parseAndCheck2("xQ!",
-                "!",
-                false);
+    public void testIncomplete4() {
+        this.parseFails(EXPONENT.substring(0, 2) + "!");
     }
 
     @Test
-    public void testUpperCaseExponent() {
-        this.parseAndCheck2("X!",
-                "!",
-                false);
+    public void testToken1() {
+        assertEquals(EXPONENT.toUpperCase(), EXPONENT);
+
+        this.parseAndCheck2(
+                EXPONENT,
+                ""
+        );
     }
 
     @Test
-    public void testUpperCaseExponentNegativeSymbol() {
-        this.parseAndCheck2("XN",
-                "",
-                true);
+    public void testToken2() {
+        assertEquals(EXPONENT.toUpperCase(), EXPONENT);
+
+        this.parseAndCheck2(
+                EXPONENT,
+                "!"
+        );
     }
 
     @Test
-    public void testUpperCaseExponentNegativeSymbol2() {
-        this.parseAndCheck2("XN!",
-                "!",
-                true);
+    public void testToken3() {
+        assertNotEquals(EXPONENT.toLowerCase(), EXPONENT);
+
+        this.parseAndCheck2(
+                EXPONENT.toLowerCase(),
+                ""
+        );
+    }
+
+    @Test
+    public void testToken4() {
+        assertNotEquals(EXPONENT.toLowerCase(), EXPONENT);
+
+        this.parseAndCheck2(
+                EXPONENT.toLowerCase(),
+                "!"
+        );
+    }
+
+    @Test
+    public void testCaseUnimportant() {
+        this.parseAndCheck2(
+                EXPONENT.toLowerCase().substring(0, 1) + EXPONENT.toUpperCase().substring(1),
+                ""
+        );
     }
 
     final void parseAndCheck2(final String text,
-                              final String textAfter,
-                              final boolean negativeExponent) {
-        final SpreadsheetNumberParsePatternsRequest context = this.createRequest();
-        this.parseAndCheck(text,
-                context,
+                              final String textAfter) {
+        this.parseAndCheck2(
+                text,
                 textAfter,
-                BigDecimal.ZERO,
-                true);
-        this.checkMode(context, SpreadsheetNumberParsePatternsMode.EXPONENT);
-        assertEquals(negativeExponent, context.negativeExponent, "negativeExponent");
-    }
-
-    @Test
-    public void testMultiCharacterSymbol() {
-        this.parseAndCheck3("XYZ!",
-                "!",
-                false);
-    }
-
-    @Test
-    public void testMultiCharacterSymbolPositive() {
-        this.parseAndCheck3("XYZQ!",
-                "!",
-                false);
-    }
-
-    @Test
-    public void testMultiCharacterSymbolNegative() {
-        this.parseAndCheck3("XYZN!",
-                "!",
-                true);
-    }
-
-    private void parseAndCheck3(final String text,
-                                final String textAfter,
-                                final boolean negativeExponent) {
-        final SpreadsheetNumberParsePatternsRequest request = SpreadsheetNumberParsePatternsRequest.with(Lists.of(SpreadsheetNumberParsePatternsComponent.textLiteral("@")).iterator(),
-                DecimalNumberContexts.basic(CURRENCY, 'D', "XYZ", 'G', 'N', 'P', 'Q', Locale.ENGLISH, MathContext.UNLIMITED));
-        this.parseAndCheck(text,
-                request,
-                textAfter,
-                BigDecimal.ZERO,
-                true);
-        this.checkMode(request, SpreadsheetNumberParsePatternsMode.EXPONENT);
-        assertEquals(negativeExponent, request.negativeExponent, "negativeExponent");
-    }
-
-    @Test
-    public void testNonSpaceFails() {
-        this.parseFails("AB");
+                NEXT_CALLED,
+                SpreadsheetParserToken.exponentSymbol(text, text)
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercentTest.java
@@ -18,39 +18,57 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
-import java.math.BigDecimal;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public final class SpreadsheetNumberParsePatternsComponentPercentTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentPercent> {
 
     @Test
-    public void testPercentSymbol() {
-        this.parseAndCheck2("P", "");
+    public void testFails() {
+        final String text = "A";
+        assertNotEquals("" + PERCENT, text);
+
+        this.parseFails(
+                text
+        );
     }
 
     @Test
-    public void testPercentSymbolCharacter() {
-        this.parseAndCheck2("P!", "!");
+    public void testToken1() {
+        this.parseAndCheck2(
+                PERCENT,
+                ""
+        );
     }
 
     @Test
-    public void testPercentSymbolPercentSymbol() {
-        this.parseAndCheck2("P", "");
+    public void testToken2() {
+        this.parseAndCheck2(
+                PERCENT,
+                "!"
+        );
     }
 
-    final void parseAndCheck2(final String text,
+    @Test
+    public void testTokenTwice() {
+        this.parseAndCheck2(
+                PERCENT,
+                PERCENT + "!"
+        );
+    }
+
+    final void parseAndCheck2(final char c,
                               final String textAfter) {
-        final SpreadsheetNumberParsePatternsRequest context = this.createRequest();
-        this.parseAndCheck(text,
-                context,
+        final String textString = "" + c;
+        this.parseAndCheck2(
+                textString,
                 textAfter,
-                BigDecimal.ZERO,
-                true);
-        assertEquals(true, context.percentage, "percentage");
+                NEXT_CALLED,
+                SpreadsheetParserToken.percentSymbol(textString, textString)
+        );
     }
-
+    
     @Test
     public void testToString() {
         this.toStringAndCheck(this.createComponent(), ".");

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteralTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteralTest.java
@@ -19,53 +19,26 @@ package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-
 public final class SpreadsheetNumberParsePatternsComponentTextLiteralTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentTextLiteral> {
 
     private final static String TOKEN = "ghi";
 
     @Test
     public void testDifferentCase() {
-        this.parseFails(TOKEN.toUpperCase());
-    }
-
-    @Test
-    public void testIncomplete() {
-        this.parseAndCheck("gh1",
-                "1",
-                BigDecimal.ZERO,
-                false);
-    }
-
-    @Test
-    public void testToken() {
-        this.parseAndCheck(TOKEN,
+        this.parseAndCheck2(
                 "",
-                BigDecimal.ZERO,
-                true);
+                TOKEN.toUpperCase(),
+                NEXT_CALLED
+        );
     }
 
     @Test
-    public void testToken2() {
-        final String after = "123";
-
-        this.parseAndCheck(TOKEN + after,
-                after,
-                NEXT_CALLED);
-    }
-
-    @Test
-    public void testToken3() {
-        final String after = "123";
-        final String token = "A";
-
-        this.parseAndCheck(SpreadsheetNumberParsePatternsComponentTextLiteral.with(token),
-                token + after,
-                this.createRequest(),
-                after,
-                VALUE_WITHOUT,
-                NEXT_CALLED);
+    public void testMatchingCase() {
+        this.parseAndCheck2(
+                "",
+                TOKEN,
+                NEXT_CALLED
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespaceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespaceTest.java
@@ -19,28 +19,24 @@ package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-
 public final class SpreadsheetNumberParsePatternsComponentWhitespaceTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentWhitespace> {
 
     @Test
     public void testSpace() {
-        this.parseAndCheck(" A",
-                "A", BigDecimal.ZERO,
-                true);
+        this.parseAndCheck2(
+                "",
+                " ",
+                NEXT_CALLED
+        );
     }
 
     @Test
     public void testTab() {
-        this.parseAndCheck("\tA",
-                "A",
-                BigDecimal.ZERO,
-                true);
-    }
-
-    @Test
-    public void testNonSpace() {
-        this.parseFails("AB");
+        this.parseAndCheck2(
+                "",
+                "\t",
+                NEXT_CALLED
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterTest.java
@@ -23,6 +23,7 @@ import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
@@ -43,79 +44,101 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
 
     @Test
     public void testHashBigDecimalZero() {
-        this.convertAndCheck2("#",
+        this.convertAndCheck2(
+                "#",
                 "0",
-                BigDecimal.valueOf(0));
+                BigDecimal.valueOf(0)
+        );
     }
 
     @Test
     public void testHashBigDecimalPlusInteger() {
-        this.convertAndCheck2("#",
-                "Q1",
-                BigDecimal.valueOf(1));
+        this.convertAndCheck2(
+                "#",
+                PLUS + "1",
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashBigDecimalPlusInteger2() {
-        this.convertAndCheck2("#",
-                "Q23",
-                BigDecimal.valueOf(23));
+        this.convertAndCheck2(
+                "#",
+                PLUS + "23",
+                BigDecimal.valueOf(23)
+        );
     }
 
     @Test
     public void testHashBigDecimalPlusInteger3() {
-        this.convertAndCheck2("#",
-                "Q456",
-                BigDecimal.valueOf(456));
+        this.convertAndCheck2(
+                "#",
+                PLUS + "456",
+                BigDecimal.valueOf(456)
+        );
     }
 
     @Test
     public void testHashBigDecimalMinusInteger() {
-        this.convertAndCheck2("#",
-                "N1",
-                BigDecimal.valueOf(-1));
+        this.convertAndCheck2(
+                "#",
+                MINUS + "1",
+                BigDecimal.valueOf(-1)
+        );
     }
 
     @Test
     public void testHashBigDecimalMinusInteger2() {
-        this.convertAndCheck2("#",
-                "N23",
-                BigDecimal.valueOf(-23));
+        this.convertAndCheck2(
+                "#",
+                MINUS + "23",
+                BigDecimal.valueOf(-23)
+        );
     }
 
     @Test
     public void testHashBigDecimalMinusInteger3() {
-        this.convertAndCheck2("#",
-                "N456",
-                BigDecimal.valueOf(-456));
+        this.convertAndCheck2(
+                "#",
+                MINUS + "456",
+                BigDecimal.valueOf(-456)
+        );
     }
 
     @Test
     public void testHashBigDecimalLeadingZeroInteger() {
-        this.convertAndCheck2("#",
-                "N0789",
-                BigDecimal.valueOf(-789));
+        this.convertAndCheck2(
+                "#",
+                MINUS + "0789",
+                BigDecimal.valueOf(-789)
+        );
     }
 
     @Test
     public void testHashBigDecimalLeadingZeroInteger2() {
-        this.convertAndCheck2("#",
-                "N00789",
-                BigDecimal.valueOf(-789));
+        this.convertAndCheck2(
+                "#",
+                MINUS + "00789",
+                BigDecimal.valueOf(-789)
+        );
     }
 
     @Test
     public void testQuestionMarkBigDecimalLeadingZeroInteger2() {
-        this.convertAndCheck2("?",
-                "N00789",
-                BigDecimal.valueOf(-789));
+        this.convertAndCheck2(
+                "?",
+                MINUS + "00789",
+                BigDecimal.valueOf(-789)
+        );
     }
 
     @Test
     public void testZeroBigDecimalLeadingZeroInteger2() {
-        this.convertAndCheck2("0",
-                "N00789",
-                BigDecimal.valueOf(-789));
+        this.convertAndCheck2(
+                "0",
+                MINUS + "00789",
+                BigDecimal.valueOf(-789)
+        );
     }
 
     @Test
@@ -141,161 +164,205 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
 
     @Test
     public void testHashHashBigDecimalExtraPattern() {
-        this.convertAndCheck2("##",
+        this.convertAndCheck2(
+                "##",
                 "9",
-                BigDecimal.valueOf(9));
+                BigDecimal.valueOf(9)
+        );
     }
 
     @Test
     public void testQuestionQuestionQuestionBigDecimalExtraPattern() {
-        this.convertAndCheck2("???",
+        this.convertAndCheck2(
+                "???",
                 "78",
-                BigDecimal.valueOf(78));
+                BigDecimal.valueOf(78)
+        );
     }
 
     @Test
     public void testZeroZeroZeroZeroBigDecimalExtraPattern() {
-        this.convertAndCheck2("0000",
+        this.convertAndCheck2(
+                "0000",
                 "6",
-                BigDecimal.valueOf(6));
+                BigDecimal.valueOf(6)
+        );
     }
 
     // fraction values .................................................................................................
 
     @Test
     public void testHashBigDecimalFractionFails() {
-        this.convertAndFail2("#",
-                "0.5");
+        this.convertAndFail2(
+                "#",
+                "0.5"
+        );
     }
 
     @Test
     public void testHashDecimalHashBigDecimalFraction() {
-        this.convertAndCheck2("#.#",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+        this.convertAndCheck2(
+                "#.#",
+                "0" + DECIMAL + "5",
+                BigDecimal.valueOf(0.5)
+        );
     }
 
     @Test
     public void testQuestionDecimalQuestionBigDecimalFraction() {
-        this.convertAndCheck2("?.?",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+        this.convertAndCheck2(
+                "?.?",
+                "0" + DECIMAL + "5",
+                BigDecimal.valueOf(0.5)
+        );
     }
 
     @Test
     public void testZeroDecimalZeroBigDecimalFraction() {
-        this.convertAndCheck2("0.0",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+        this.convertAndCheck2(
+                "0.0",
+                "0" + DECIMAL + "5",
+                BigDecimal.valueOf(0.5)
+        );
     }
 
     @Test
     public void testZeroDecimalZeroBigDecimalFractionExtraPattern() {
-        this.convertAndCheck2("0.00",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+        this.convertAndCheck2(
+                "0.00",
+                "0" + DECIMAL + "5",
+                BigDecimal.valueOf(0.5)
+        );
     }
 
     @Test
     public void testZeroDecimalZeroBigDecimalFractionExtraPattern2() {
-        this.convertAndCheck2("0.000",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+        this.convertAndCheck2(
+                "0.000",
+                "0" + DECIMAL + "5",
+                BigDecimal.valueOf(0.5)
+        );
     }
 
     @Test
     public void testZeroDecimalZeroZeroBigDecimalFraction() {
-        this.convertAndCheck2("0.00",
-                "0D56",
-                BigDecimal.valueOf(0.56));
+        this.convertAndCheck2(
+                "0.00",
+                "0" + DECIMAL + "56",
+                BigDecimal.valueOf(0.56)
+        );
     }
 
     @Test
     public void testZeroDecimalZeroZeroZeroBigDecimalFraction() {
-        this.convertAndCheck2("0.000",
-                "0D56",
-                BigDecimal.valueOf(0.56));
+        this.convertAndCheck2(
+                "0.000",
+                "0" + DECIMAL + "56",
+                BigDecimal.valueOf(0.56)
+        );
     }
 
     // mixed patterns...................................................................................................
 
     @Test
     public void testHashQuestionZeroBigDecimalDigit() {
-        this.convertAndCheck2("#?0",
+        this.convertAndCheck2(
+                "#?0",
                 "1",
-                BigDecimal.valueOf(1));
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashQuestionZeroBigDecimalSpaceDigit() {
-        this.convertAndCheck2("#?0",
+        this.convertAndCheck2(
+                "#?0",
                 " 1",
-                BigDecimal.valueOf(1));
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashQuestionZeroBigDecimalDigitSpaceDigit() {
-        this.convertAndCheck2("#?0",
+        this.convertAndCheck2(
+                "#?0",
                 "0 1",
-                BigDecimal.valueOf(1));
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashQuestionZeroBigDecimalDigitSpaceDigit2() {
-        this.convertAndCheck2("#?0",
+        this.convertAndCheck2(
+                "#?0",
                 "3 4",
-                BigDecimal.valueOf(34));
+                BigDecimal.valueOf(34)
+        );
     }
 
     // exponent.........................................................................................................
 
     @Test
     public void testHashExponentPlusHashBigDecimalDigitExponentDigit() {
-        this.convertAndCheck2("#E+#",
-                "2XQ3",
-                BigDecimal.valueOf(2000));
+        this.convertAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + PLUS + "3",
+                BigDecimal.valueOf(2000)
+        );
     }
 
     @Test
     public void testHashExponentMinusHashBigDecimalDigitExponentDigit() {
-        this.convertAndCheck2("#E+#",
-                "2XQ3",
-                BigDecimal.valueOf(2000));
+        this.convertAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + PLUS + "3",
+                BigDecimal.valueOf(2000)
+        );
     }
 
     @Test
     public void testHashExponentPlusHashBigDecimalDigitExponentDigit2() {
-        this.convertAndCheck2("#E+#",
-                "2xQ3",
-                BigDecimal.valueOf(2000));
+        this.convertAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + PLUS + "3",
+                BigDecimal.valueOf(2000)
+        );
     }
 
     @Test
     public void testHashExponentPlusHashBigDecimalDigitExponentPlusDigit() {
-        this.convertAndCheck2("#E+#",
-                "4XQ5",
-                new BigDecimal("4E+5"));
+        this.convertAndCheck2(
+                "#E+#",
+                "4" + EXPONENT + PLUS + "5",
+                new BigDecimal("4E+5")
+        );
     }
 
     @Test
     public void testHashExponentPlusHashBigDecimalDigitExponentMinusDigit() {
-        this.convertAndCheck2("#E+#",
-                "6XN7",
-                new BigDecimal("6E-7"));
+        this.convertAndCheck2(
+                "#E+#",
+                "6" + EXPONENT + MINUS + "7",
+                new BigDecimal("6E-7")
+        );
     }
 
     @Test
     public void testHashExponentPlusHashHashBigDecimalDigitExponentDigit() {
-        this.convertAndCheck2("#E+##",
-                "8X90",
-                new BigDecimal("8E+90"));
+        this.convertAndCheck2(
+                "#E+##",
+                "8" + EXPONENT + PLUS + "90",
+                new BigDecimal("8E+90")
+        );
     }
 
     @Test
     public void testHashExponentPlusQuestionBigDecimalDigitExponentSpaceDigit() {
-        this.convertAndCheck2("#E+?",
-                "1X 2",
-                new BigDecimal("1E+2"));
+        this.convertAndCheck2(
+                "#E+?",
+                "1" + EXPONENT + " 2",
+                new BigDecimal("1E+2")
+        );
     }
 
     // currency.........................................................................................................
@@ -303,135 +370,51 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
     @Test
     public void testCurrencyHashBigDecimal() {
         this.convertAndCheck2("$#",
-                "aud1",
-                BigDecimal.valueOf(1));
+                CURRENCY + "1",
+                BigDecimal.ONE);
     }
 
     @Test
     public void testHashCurrencyBigDecimal() {
-        this.convertAndCheck2("#$",
-                "1aud",
-                BigDecimal.valueOf(1));
+        this.convertAndCheck2(
+                "#$",
+                "1" + CURRENCY,
+                BigDecimal.ONE
+        );
     }
 
     // percent..........................................................................................................
 
     @Test
     public void testPercentHashBigDecimalPercentDigit() {
-        this.convertAndCheck2("%#",
-                "P1",
-                BigDecimal.valueOf(0.01));
+        this.convertAndCheck2(
+                "%#",
+                PERCENT + "1",
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashPercentBigDecimalDigitPercent() {
-        this.convertAndCheck2("#%",
-                "1P",
-                BigDecimal.valueOf(0.01));
+        this.convertAndCheck2(
+                "#%",
+                "1" + PERCENT,
+                BigDecimal.ONE
+        );
     }
 
     @Test
     public void testHashPercentBigDecimalDigitDigitDigitPercent() {
         this.convertAndCheck2("#%",
-                "123P",
-                BigDecimal.valueOf(1.23));
+                "123" + PERCENT,
+                BigDecimal.valueOf(123));
     }
 
     @Test
     public void testHashDecimalPercentBigDecimalDigitDigitDigitPercent() {
         this.convertAndCheck2("#.#%",
-                "45D6P",
-                BigDecimal.valueOf(0.456));
-    }
-
-    // escape.............................................................................................................
-
-    @Test
-    public void testEscapeHashBigDecimalTextDigit() {
-        this.convertAndCheck2("\\a#",
-                "a1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testEscapeHashEscapeHashBigDecimalTextDigitTextDigit() {
-        this.convertAndCheck2("\\a#\\b#",
-                "a2b3",
-                BigDecimal.valueOf(23));
-    }
-
-    // text.............................................................................................................
-
-    @Test
-    public void testTextHashBigDecimalTextDigit() {
-        this.convertAndCheck2("\"abc\"#",
-                "abc1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testTextHashBigDecimalTextDigitDigit() {
-        this.convertAndCheck2("\"abc\"#",
-                "abc23",
-                BigDecimal.valueOf(23));
-    }
-
-    @Test
-    public void testHashTextBigDecimalTextDigit() {
-        this.convertAndCheck2("#\"abc\"",
-                "4abc",
-                BigDecimal.valueOf(4));
-    }
-
-    @Test
-    public void testTextDigitTextBigDecimalTextDigitTextDigitTextDigit() {
-        this.convertAndCheck2("\"a\"#\"b\"#\"c\"#",
-                "a5b6c7",
-                BigDecimal.valueOf(567));
-    }
-
-    @Test
-    public void testTextDigitTextBigDecimalTextMinusDigitTextDigitTextDigit() {
-        this.convertAndCheck2("\"a\"#\"b\"#\"c\"#",
-                "aN8b9c0",
-                BigDecimal.valueOf(-890));
-    }
-
-    // whitespace.......................................................................................................
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceDigit() {
-        this.convertAndCheck2(" #",
-                " 1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceDigitDigitDigit() {
-        this.convertAndCheck2(" #",
-                " 234",
-                BigDecimal.valueOf(234));
-    }
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceMinusDigit() {
-        this.convertAndCheck2(" #",
-                " N5",
-                BigDecimal.valueOf(-5));
-    }
-
-    @Test
-    public void testWhitespaceHashWhitespaceHashBigDecimal() {
-        this.convertAndCheck2(" # #",
-                " 6 7",
-                BigDecimal.valueOf(67));
-    }
-
-    @Test
-    public void testWhitespaceHashWhitespaceDecimalHashBigDecimal() {
-        this.convertAndCheck2(" # .#",
-                " 8 D9",
-                BigDecimal.valueOf(8.9));
+                "45" + DECIMAL + "6" + PERCENT,
+                BigDecimal.valueOf(45.6));
     }
 
     // several patterns.................................................................................................
@@ -440,7 +423,7 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
     public void testFirstPatternMatches() {
         this.convertAndCheck2("0;\"text-literal\"",
                 "1",
-                BigDecimal.valueOf(1));
+                BigDecimal.ONE);
     }
 
     @Test
@@ -490,7 +473,7 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
 
     @Test
     public void testLong() {
-        this.convertAndCheck2(Long.MAX_VALUE);
+        this.convertAndCheck2(999L);
     }
 
     @Test
@@ -513,18 +496,51 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
         this.convertAndCheck2(1234567890);
     }
 
-    @Test
-    public void testNumber() {
-        this.convertAndCheck2("#",
-                "1234567890",
-                Number.class,
-                BigDecimal.valueOf(1234567890));
+    private void convertAndCheck2(final Number number) {
+        this.convertAndCheck2(
+                "#.#;#",
+                number.toString().replace('.', DECIMAL).replace('+', PLUS).replace('-', MINUS).replace("E", EXPONENT),
+                number
+        );
     }
 
-    private void convertAndCheck2(final Number number) {
-        this.convertAndCheck2("#;#.#",
-                number.toString().replace('.', 'D'),
-                number);
+    @Test
+    public void testNumber() {
+        this.convertAndCheck3(
+                "##.##",
+                "1" + DECIMAL + "25",
+                1.25
+        );
+    }
+
+    private void convertAndCheck3(final String pattern,
+                                  final String text,
+                                  final Number number) {
+        this.convertAndCheck4(
+                pattern,
+                text,
+                ExpressionNumberKind.BIG_DECIMAL,
+                number
+        );
+        this.convertAndCheck4(
+                pattern,
+                text,
+                ExpressionNumberKind.DOUBLE,
+                number
+        );
+    }
+
+    private void convertAndCheck4(final String pattern,
+                                  final String text,
+                                  final ExpressionNumberKind kind,
+                                  final Number number) {
+        this.convertAndCheck(
+                SpreadsheetNumberParsePatterns.parseNumberParsePatterns(pattern).createConverter(),
+                text,
+                ExpressionNumber.class,
+                this.createContext0(kind),
+                kind.create(number)
+        );
     }
 
     // helpers..........................................................................................................
@@ -574,12 +590,16 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
 
     @Override
     public ExpressionNumberConverterContext createContext() {
+        return this.createContext0(EXPRESSION_NUMBER_KIND);
+    }
+
+    private ExpressionNumberConverterContext createContext0(final ExpressionNumberKind kind) {
         return ExpressionNumberConverterContexts.basic(
                 Converters.fake(),
                 ConverterContexts.basic(Converters.fake(),
                         DateTimeContexts.fake(), // DateTimeContext unused
                         this.decimalNumberContext()),
-                EXPRESSION_NUMBER_KIND);
+                kind);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParserTest.java
@@ -18,15 +18,26 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.datetime.DateTimeContexts;
+import walkingkooka.spreadsheet.parser.SpreadsheetCurrencySymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDecimalSeparatorSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDigitsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetExponentSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetGroupingSeparatorSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetMinusSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPercentSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPlusSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetWhitespaceParserToken;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserTesting2;
-import walkingkooka.text.cursor.parser.ParserTokens;
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
-import java.math.BigDecimal;
+import java.util.List;
 
 public final class SpreadsheetNumberParsePatternsParserTest extends SpreadsheetNumberParsePatternsTestCase2<SpreadsheetNumberParsePatternsParser>
         implements ParserTesting2<SpreadsheetNumberParsePatternsParser, SpreadsheetParserContext> {
@@ -41,462 +52,497 @@ public final class SpreadsheetNumberParsePatternsParserTest extends SpreadsheetN
     // integer values single digit pattern..............................................................................
 
     @Test
-    public void testHashBigDecimalZero() {
-        this.parseAndCheck2("#",
+    public void testHashZero() {
+        this.parseAndCheck2(
+                "#",
                 "0",
-                BigDecimal.valueOf(0));
+                digits(0)
+        );
     }
 
     @Test
-    public void testHashBigDecimalPlusInteger() {
-        this.parseAndCheck2("#",
-                "Q1",
-                BigDecimal.valueOf(1));
+    public void testHashPlusInteger() {
+        this.parseAndCheck2(
+                "#",
+                PLUS + "1",
+                plus(),
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashBigDecimalPlusInteger2() {
-        this.parseAndCheck2("#",
-                "Q23",
-                BigDecimal.valueOf(23));
+    public void testHashPlusInteger2() {
+        this.parseAndCheck2(
+                "#",
+                PLUS + "23",
+                plus(),
+                digits(23)
+        );
     }
 
     @Test
-    public void testHashBigDecimalPlusInteger3() {
-        this.parseAndCheck2("#",
-                "Q456",
-                BigDecimal.valueOf(456));
+    public void testHashPlusInteger3() {
+        this.parseAndCheck2(
+                "#",
+                PLUS + "456",
+                plus(),
+                digits(456)
+        );
     }
 
     @Test
-    public void testHashBigDecimalMinusInteger() {
-        this.parseAndCheck2("#",
-                "N1",
-                BigDecimal.valueOf(-1));
+    public void testHashMinusInteger() {
+        this.parseAndCheck2(
+                "#",
+                MINUS + "1",
+                minus(),
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashBigDecimalMinusInteger2() {
-        this.parseAndCheck2("#",
-                "N23",
-                BigDecimal.valueOf(-23));
+    public void testHashMinusInteger2() {
+        this.parseAndCheck2(
+                "#",
+                MINUS + "23",
+                minus(),
+                digits(23)
+        );
     }
 
     @Test
-    public void testHashBigDecimalMinusInteger3() {
-        this.parseAndCheck2("#",
-                "N456",
-                BigDecimal.valueOf(-456));
+    public void testHashMinusInteger3() {
+        this.parseAndCheck2(
+                "#",
+                MINUS + "456",
+                minus(),
+                digits(456)
+        );
     }
 
     @Test
-    public void testHashBigDecimalLeadingZeroInteger() {
-        this.parseAndCheck2("#",
-                "N0789",
-                BigDecimal.valueOf(-789));
+    public void testHashDecimalLeadingZeroInteger() {
+        this.parseAndCheck2(
+                "#",
+                "0789",
+                digits("0789")
+        );
     }
 
     @Test
-    public void testHashBigDecimalLeadingZeroInteger2() {
-        this.parseAndCheck2("#",
-                "N00789",
-                BigDecimal.valueOf(-789));
+    public void testHashDecimalLeadingZeroInteger2() {
+        this.parseAndCheck2(
+                "#",
+                "00789",
+                digits("00789")
+        );
     }
 
     @Test
-    public void testQuestionMarkBigDecimalLeadingZeroInteger2() {
-        this.parseAndCheck2("?",
-                "N00789",
-                BigDecimal.valueOf(-789));
+    public void testQuestionMarkDecimalLeadingZeroInteger2() {
+        this.parseAndCheck2(
+                "?",
+                "00789",
+                digits("00789")
+        );
     }
 
     @Test
-    public void testZeroBigDecimalLeadingZeroInteger2() {
-        this.parseAndCheck2("0",
-                "N00789",
-                BigDecimal.valueOf(-789));
+    public void testZeroDecimalLeadingZeroInteger2() {
+        this.parseAndCheck2(
+                "0",
+                "00789",
+                digits("00789")
+        );
     }
 
     @Test
-    public void testHashHashBigDecimal() {
-        this.parseAndCheck2("##",
+    public void testHashHashDecimal() {
+        this.parseAndCheck2(
+                "##",
                 "12",
-                BigDecimal.valueOf(12));
+                digits(12)
+        );
     }
 
     @Test
-    public void testQuestionQuestionQuestionBigDecimal() {
-        this.parseAndCheck2("???",
+    public void testQuestionQuestionQuestionDecimal() {
+        this.parseAndCheck2(
+                "???",
                 "123",
-                BigDecimal.valueOf(123));
+                digits(123)
+        );
     }
 
     @Test
-    public void testZeroZeroZeroZeroBigDecimal() {
-        this.parseAndCheck2("0000",
+    public void testZeroZeroZeroZeroDecimal() {
+        this.parseAndCheck2(
+                "0000",
                 "1234",
-                BigDecimal.valueOf(1234));
+                digits(1234)
+        );
     }
 
     @Test
-    public void testHashHashBigDecimalExtraPattern() {
-        this.parseAndCheck2("##",
+    public void testHashHashDecimalExtraPattern() {
+        this.parseAndCheck2(
+                "##",
                 "9",
-                BigDecimal.valueOf(9));
+                digits(9)
+        );
     }
 
     @Test
-    public void testQuestionQuestionQuestionBigDecimalExtraPattern() {
-        this.parseAndCheck2("???",
+    public void testQuestionQuestionQuestionDecimalExtraPattern() {
+        this.parseAndCheck2(
+                "???",
                 "78",
-                BigDecimal.valueOf(78));
+                digits(78)
+        );
     }
 
     @Test
-    public void testZeroZeroZeroZeroBigDecimalExtraPattern() {
-        this.parseAndCheck2("0000",
+    public void testZeroZeroZeroZeroDecimalExtraPattern() {
+        this.parseAndCheck2(
+                "0000",
                 "6",
-                BigDecimal.valueOf(6));
+                digits(6)
+        );
     }
 
     // fraction values .................................................................................................
 
     @Test
-    public void testHashBigDecimalFraction() {
+    public void testHashDecimalFraction() {
         final String text = "1";
-        final String after = "D5";
+        final String after = DECIMAL + "5";
 
-        this.parseAndCheck(this.createParser("#"),
+        this.parseAndCheck(
+                this.createParser("#"),
                 text + after,
-                ParserTokens.bigDecimal(BigDecimal.ONE, text),
+                SpreadsheetParserToken.number(
+                        Lists.of(
+                            SpreadsheetParserToken.digits("1", "1")
+                        ),
+                        text
+                ),
                 text,
-                after);
+                after
+        );
     }
 
     @Test
-    public void testHashDecimalHashBigDecimalFraction() {
-        this.parseAndCheck2("#.#",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+    public void testHashDecimalHashDecimalFraction() {
+        this.parseAndCheck2(
+                "#.#",
+                "0" + DECIMAL + "5",
+                digits(0),
+                decimal(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testQuestionDecimalQuestionBigDecimalFraction() {
-        this.parseAndCheck2("?.?",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+    public void testQuestionDecimalQuestionDecimalFraction() {
+        this.parseAndCheck2(
+                "?.?",
+                "0" + DECIMAL + "5",
+                digits(0),
+                decimal(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testZeroDecimalZeroBigDecimalFraction() {
-        this.parseAndCheck2("0.0",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+    public void testZeroDecimalZeroDecimalFraction() {
+        this.parseAndCheck2(
+                "0.0",
+                "0" + DECIMAL + "5",
+                digits(0),
+                decimal(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testZeroDecimalZeroBigDecimalFractionExtraPattern() {
-        this.parseAndCheck2("0.00",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+    public void testZeroDecimalZeroDecimalFractionExtraPattern() {
+        this.parseAndCheck2(
+                "0.00",
+                "0" + DECIMAL + "5",
+                digits(0),
+                decimal(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testZeroDecimalZeroBigDecimalFractionExtraPattern2() {
-        this.parseAndCheck2("0.000",
-                "0D5",
-                BigDecimal.valueOf(0.5));
+    public void testZeroDecimalZeroDecimalFractionExtraPattern2() {
+        this.parseAndCheck2(
+                "0.000",
+                "0" + DECIMAL + "5",
+                digits(0),
+                decimal(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testZeroDecimalZeroZeroBigDecimalFraction() {
-        this.parseAndCheck2("0.00",
-                "0D56",
-                BigDecimal.valueOf(0.56));
+    public void testZeroDecimalZeroZeroDecimalFraction() {
+        this.parseAndCheck2(
+                "0.00",
+                "0" + DECIMAL + "56",
+                digits(0),
+                decimal(),
+                digits(56)
+        );
     }
 
     @Test
-    public void testZeroDecimalZeroZeroZeroBigDecimalFraction() {
-        this.parseAndCheck2("0.000",
-                "0D56",
-                BigDecimal.valueOf(0.56));
+    public void testZeroDecimalZeroZeroZeroDecimalFraction() {
+        this.parseAndCheck2(
+                "0.000",
+                "0" + DECIMAL + "56",
+                digits(0),
+                decimal(),
+                digits(56)
+        );
     }
 
     // mixed patterns...................................................................................................
 
     @Test
-    public void testHashQuestionZeroBigDecimalDigit() {
-        this.parseAndCheck2("#?0",
+    public void testHashQuestionZeroDecimalDigit() {
+        this.parseAndCheck2(
+                "#?0",
                 "1",
-                BigDecimal.valueOf(1));
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashQuestionZeroBigDecimalSpaceDigit() {
-        this.parseAndCheck2("#?0",
-                " 1",
-                BigDecimal.valueOf(1));
+    public void testHashQuestionZeroDecimalSpaceDigit() {
+        this.parseAndCheck2(
+                "#?0",
+                "1 ",
+                digits(1),
+                whitespace()
+        );
     }
 
     @Test
-    public void testHashQuestionZeroBigDecimalDigitSpaceDigit() {
-        this.parseAndCheck2("#?0",
+    public void testHashQuestionZeroDecimalDigitSpaceDigit() {
+        this.parseAndCheck2(
+                "#?0",
                 "0 1",
-                BigDecimal.valueOf(1));
+                digits(0),
+                whitespace(),
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashQuestionZeroBigDecimalDigitSpaceDigit2() {
-        this.parseAndCheck2("#?0",
+    public void testHashQuestionZeroDecimalDigitSpaceDigit2() {
+        this.parseAndCheck2(
+                "#?0",
                 "3 4",
-                BigDecimal.valueOf(34));
+                digits(3),
+                whitespace(),
+                digits(4)
+        );
     }
 
     // exponent.........................................................................................................
 
     @Test
-    public void testHashExponentPlusHashBigDecimalDigitExponentDigit() {
-        this.parseAndCheck2("#E+#",
-                "2XQ3",
-                BigDecimal.valueOf(2000));
+    public void testHashExponentPlusHashDecimalDigitExponentDigit() {
+        this.parseAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + PLUS + "3",
+                digits(2),
+                exponent(),
+                plus(),
+                digits(3)
+        );
     }
 
     @Test
-    public void testHashExponentMinusHashBigDecimalDigitExponentDigit() {
-        this.parseAndCheck2("#E+#",
-                "2XQ3",
-                BigDecimal.valueOf(2000));
+    public void testHashExponentMinusHashDecimalDigitExponentDigit() {
+        this.parseAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + MINUS + "3",
+                digits(2),
+                exponent(),
+                minus(),
+                digits(3)
+        );
     }
 
     @Test
-    public void testHashExponentPlusHashBigDecimalDigitExponentDigit2() {
-        this.parseAndCheck2("#E+#",
-                "2xQ3",
-                BigDecimal.valueOf(2000));
+    public void testHashExponentPlusHashDecimalDigitExponentDigit2() {
+        this.parseAndCheck2(
+                "#E+#",
+                "2" + EXPONENT + PLUS + "3",
+                digits(2),
+                exponent(),
+                plus(),
+                digits(3)
+        );
     }
 
     @Test
-    public void testHashExponentPlusHashBigDecimalDigitExponentPlusDigit() {
-        this.parseAndCheck2("#E+#",
-                "4XQ5",
-                new BigDecimal("4E+5"));
+    public void testHashExponentPlusHashDecimalDigitExponentPlusDigit() {
+        this.parseAndCheck2(
+                "#E+#",
+                4 + EXPONENT + PLUS + 5,
+                digits(4),
+                exponent(),
+                plus(),
+                digits(5)
+        );
     }
 
     @Test
-    public void testHashExponentPlusHashBigDecimalDigitExponentMinusDigit() {
-        this.parseAndCheck2("#E+#",
-                "6XN7",
-                new BigDecimal("6E-7"));
+    public void testHashExponentPlusHashDecimalDigitExponentMinusDigit() {
+        this.parseAndCheck2(
+                "#E+#",
+                6 + EXPONENT + MINUS + 7,
+                digits(6),
+                exponent(),
+                minus(),
+                digits(7)
+        );
     }
 
     @Test
-    public void testHashExponentPlusHashHashBigDecimalDigitExponentDigit() {
-        this.parseAndCheck2("#E+##",
-                "8X90",
-                new BigDecimal("8E+90"));
+    public void testHashExponentPlusHashHashDecimalDigitExponentDigit() {
+        this.parseAndCheck2(
+                "#E+##",
+                7 + EXPONENT  + 890,
+                digits(7),
+                exponent(),
+                digits("890")
+        );
     }
 
     @Test
-    public void testHashExponentPlusQuestionBigDecimalDigitExponentSpaceDigit() {
-        this.parseAndCheck2("#E+?",
-                "1X 2",
-                new BigDecimal("1E+2"));
+    public void testHashExponentPlusQuestionDecimalDigitExponentSpaceDigit() {
+        this.parseAndCheck2(
+                "#E+?",
+                1 + EXPONENT + PLUS + " 2",
+                digits(1),
+                exponent(),
+                plus(),
+                whitespace(),
+                digits(2)
+                );
     }
 
     // currency.........................................................................................................
 
     @Test
-    public void testCurrencyHashBigDecimal() {
-        this.parseAndCheck2("$#",
-                "aud1",
-                BigDecimal.valueOf(1));
+    public void testCurrencyHashDecimal() {
+        this.parseAndCheck2(
+                "$#",
+                CURRENCY + "1",
+                currency(),
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashCurrencyBigDecimal() {
-        this.parseAndCheck2("#$",
-                "1aud",
-                BigDecimal.valueOf(1));
+    public void testHashCurrencyDecimal() {
+        this.parseAndCheck2(
+                "#$",
+                "1" + CURRENCY,
+                digits(1),
+                currency()
+        );
     }
 
     // percent..........................................................................................................
 
     @Test
-    public void testPercentHashBigDecimalPercentDigit() {
-        this.parseAndCheck2("%#",
-                "P1",
-                BigDecimal.valueOf(0.01));
+    public void testPercentHashDecimalPercentDigit() {
+        this.parseAndCheck2(
+                "%#",
+                PERCENT + "1",
+                percent(),
+                digits(1)
+        );
     }
 
     @Test
-    public void testHashPercentBigDecimalDigitPercent() {
-        this.parseAndCheck2("#%",
-                "1P",
-                BigDecimal.valueOf(0.01));
+    public void testHashPercentDecimalDigitPercent() {
+        this.parseAndCheck2(
+                "#%",
+                "1" + PERCENT,
+                digits(1),
+                percent()
+        );
     }
 
     @Test
-    public void testHashPercentBigDecimalDigitDigitDigitPercent() {
-        this.parseAndCheck2("#%",
-                "123P",
-                BigDecimal.valueOf(1.23));
+    public void testHashPercentDecimalDigitDigitDigitPercent() {
+        this.parseAndCheck2(
+                "#%",
+                "123" + PERCENT,
+                digits(123),
+                percent()
+        );
     }
 
     @Test
-    public void testHashDecimalPercentBigDecimalDigitDigitDigitPercent() {
-        this.parseAndCheck2("#.#%",
-                "45D6P",
-                BigDecimal.valueOf(0.456));
-    }
-
-    // escape.............................................................................................................
-
-    @Test
-    public void testEscapeHashBigDecimalTextDigit() {
-        this.parseAndCheck2("\\a#",
-                "a1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testEscapeHashEscapeHashBigDecimalTextDigitTextDigit() {
-        this.parseAndCheck2("\\a#\\b#",
-                "a2b3",
-                BigDecimal.valueOf(23));
-    }
-
-    // text.............................................................................................................
-
-    @Test
-    public void testTextHashBigDecimalTextDigit() {
-        this.parseAndCheck2("\"abc\"#",
-                "abc1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testTextHashBigDecimalTextDigitDigit() {
-        this.parseAndCheck2("\"abc\"#",
-                "abc23",
-                BigDecimal.valueOf(23));
-    }
-
-    @Test
-    public void testHashTextBigDecimalTextDigit() {
-        this.parseAndCheck2("#\"abc\"",
-                "4abc",
-                BigDecimal.valueOf(4));
-    }
-
-    @Test
-    public void testTextDigitTextBigDecimalTextDigitTextDigitTextDigit() {
-        this.parseAndCheck2("\"a\"#\"b\"#\"c\"#",
-                "a5b6c7",
-                BigDecimal.valueOf(567));
-    }
-
-    @Test
-    public void testTextDigitTextBigDecimalTextMinusDigitTextDigitTextDigit() {
-        this.parseAndCheck2("\"a\"#\"b\"#\"c\"#",
-                "aN8b9c0",
-                BigDecimal.valueOf(-890));
-    }
-
-    // whitespace.......................................................................................................
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceDigit() {
-        this.parseAndCheck2(" #",
-                " 1",
-                BigDecimal.valueOf(1));
-    }
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceDigitDigitDigit() {
-        this.parseAndCheck2(" #",
-                " 234",
-                BigDecimal.valueOf(234));
-    }
-
-    @Test
-    public void testWhitespaceHashBigDecimalSpaceMinusDigit() {
-        this.parseAndCheck2(" #",
-                " N5",
-                BigDecimal.valueOf(-5));
-    }
-
-    @Test
-    public void testWhitespaceHashWhitespaceHashBigDecimal() {
-        this.parseAndCheck2(" # #",
-                " 6 7",
-                BigDecimal.valueOf(67));
-    }
-
-    @Test
-    public void testWhitespaceHashWhitespaceDecimalHashBigDecimal() {
-        this.parseAndCheck2(" # .#",
-                " 8 D9",
-                BigDecimal.valueOf(8.9));
+    public void testHashDecimalPercentDecimalDigitDigitDigitPercent() {
+        this.parseAndCheck2(
+                "#.#%",
+                "45" + DECIMAL + "6" + PERCENT,
+                digits(45),
+                decimal(),
+                digits(6),
+                percent()
+        );
     }
 
     // several patterns.................................................................................................
 
     @Test
     public void testFirstPatternMatches() {
-        this.parseAndCheck2("0;\"text-literal\"",
+        this.parseAndCheck2(
+                "0;$0",
                 "1",
-                BigDecimal.valueOf(1));
+                digits(1)
+        );
     }
 
     @Test
     public void testLastPatternMatches() {
-        this.parseAndCheck2("\"text-literal\";0",
+        this.parseAndCheck2(
+                "$0;0",
                 "2",
-                BigDecimal.valueOf(2));
-    }
-
-    // partial..........................................................................................................
-
-    @Test
-    public void testPartial() {
-        final String text = "123D45";
-        final String after = "abc";
-
-        this.parseAndCheck(this.createParser("#.#"),
-                text + after,
-                ParserTokens.bigDecimal(new BigDecimal("123.45"), text),
-                text,
-                after);
-    }
-
-    @Test
-    public void testTelephonePartial() {
-        final String text = "02-123-4567";
-        final String after = "abc";
-
-        this.parseAndCheck(this.createParser("00\\-000\\-0000"),
-                text + after,
-                ParserTokens.bigDecimal(new BigDecimal("21234567"), text),
-                text,
-                after);
+                digits(2));
     }
 
     // helpers..........................................................................................................
 
     private void parseAndFail2(final String pattern,
                                final String text) {
-        this.parseFailAndCheck(this.createParser(pattern),
-                text);
+        this.parseFailAndCheck(
+                this.createParser(pattern),
+                text
+        );
     }
 
     private void parseAndCheck2(final String pattern,
                                 final String text,
-                                final BigDecimal expected) {
-        this.parseAndCheck(this.createParser(pattern),
+                                final SpreadsheetParserToken ...tokens) {
+        final List<ParserToken> tokensList = Lists.of(tokens);
+        this.parseAndCheck(
+                this.createParser(pattern),
                 text,
-                ParserTokens.bigDecimal(expected, text),
+                SpreadsheetParserToken.number(tokensList, ParserToken.text(tokensList)),
                 text,
-                "");
+                ""
+        );
     }
 
     // ParserTesting....................................................................................................
@@ -518,6 +564,46 @@ public final class SpreadsheetNumberParsePatternsParserTest extends SpreadsheetN
                 ExpressionNumberKind.BIG_DECIMAL,
                 VALUE_SEPARATOR
         );
+    }
+
+    private SpreadsheetCurrencySymbolParserToken currency() {
+        return SpreadsheetParserToken.currencySymbol(CURRENCY, CURRENCY);
+    }
+
+    private SpreadsheetDecimalSeparatorSymbolParserToken decimal() {
+        return SpreadsheetParserToken.decimalSeparatorSymbol("" + DECIMAL, "" + DECIMAL);
+    }
+
+    private SpreadsheetDigitsParserToken digits(final int value) {
+        return digits("" + value);
+    }
+
+    private SpreadsheetDigitsParserToken digits(final String text) {
+        return SpreadsheetParserToken.digits(text, text);
+    }
+
+    private SpreadsheetExponentSymbolParserToken exponent() {
+        return SpreadsheetParserToken.exponentSymbol(EXPONENT, EXPONENT);
+    }
+
+    private SpreadsheetGroupingSeparatorSymbolParserToken group() {
+        return SpreadsheetParserToken.groupingSeparatorSymbol("" + GROUP, "" + GROUP);
+    }
+
+    private SpreadsheetMinusSymbolParserToken minus() {
+        return SpreadsheetParserToken.minusSymbol("" + MINUS, "" + MINUS);
+    }
+
+    private SpreadsheetPercentSymbolParserToken percent() {
+        return SpreadsheetParserToken.percentSymbol("" + PERCENT, "" + PERCENT);
+    }
+
+    private SpreadsheetPlusSymbolParserToken plus() {
+        return SpreadsheetParserToken.plusSymbol("" + PLUS, "" + PLUS);
+    }
+
+    private SpreadsheetWhitespaceParserToken whitespace() {
+        return SpreadsheetParserToken.whitespace(" ", " ");
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsRequestTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsRequestTest.java
@@ -18,119 +18,28 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.ToStringBuilder;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.iterator.Iterators;
-import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.reflect.ClassTesting;
-
-import java.math.BigDecimal;
-import java.math.MathContext;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class SpreadsheetNumberParsePatternsRequestTest extends SpreadsheetNumberParsePatternsTestCase2<SpreadsheetNumberParsePatternsRequest>
         implements ClassTesting<SpreadsheetNumberParsePatternsRequest>,
         ToStringTesting<SpreadsheetNumberParsePatternsRequest> {
 
     @Test
-    public void testComputeValueNeitherNegativeOrPositiveZero() {
-        this.computeValueAndCheck(null, BigDecimal.ZERO, true, 0, BigDecimal.ZERO.negate());
-    }
-
-    @Test
-    public void testComputeValueNegativeZero() {
-        this.computeValueAndCheck(true, BigDecimal.ZERO, true, 0, BigDecimal.ZERO.negate());
-    }
-
-    @Test
-    public void testComputeValuePositiveZero() {
-        this.computeValueAndCheck(false, BigDecimal.ZERO, true, 0, BigDecimal.ZERO);
-    }
-
-    @Test
-    public void testComputeValueWithoutExponent() {
-        this.computeValueAndCheck(false, "12.34", false, 0, "12.34");
-    }
-
-    @Test
-    public void testComputeValueNegativeWithoutExponent() {
-        this.computeValueAndCheck(true, "12.34", false, 0, "-12.34");
-    }
-
-    @Test
-    public void testComputeValueWithExponent1() {
-        this.computeValueAndCheck(false, "123.4", false, 1, "1234");
-    }
-
-    @Test
-    public void testComputeValueWithExponent2() {
-        this.computeValueAndCheck(false, "75", false, 2, "7500");
-    }
-
-    @Test
-    public void testComputeValueNegativeExponent1() {
-        this.computeValueAndCheck(false, "75", true, 1, "7.5");
-    }
-
-    private void computeValueAndCheck(final boolean negativeMantissa,
-                                      final String mantissa,
-                                      final boolean negativeExponent,
-                                      final int exponent,
-                                      final String expected) {
-        this.computeValueAndCheck(negativeMantissa,
-                new BigDecimal(mantissa),
-                negativeExponent,
-                exponent,
-                new BigDecimal(expected));
-    }
-
-    private void computeValueAndCheck(final Boolean negativeMantissa,
-                                      final BigDecimal mantissa,
-                                      final boolean negativeExponent,
-                                      final int exponent,
-                                      final BigDecimal expected) {
-        final SpreadsheetNumberParsePatternsRequest request = this.createRequest();
-        request.negativeMantissa = negativeMantissa;
-        request.mantissa = mantissa;
-        request.negativeExponent = negativeExponent;
-        request.exponent = exponent;
-
-        assertEquals(expected.stripTrailingZeros(),
-                request.computeValue().stripTrailingZeros(),
-                () -> ToStringBuilder.empty()
-                        .label("negativeMantissa").value(negativeMantissa)
-                        .label("mantissa").value(mantissa)
-                        .label("negativeExponent").value(negativeExponent)
-                        .label("exponent").value(exponent)
-                        .build());
-    }
-
-    @Test
     public void testToString() {
-        this.toStringAndCheck(this.createRequest(), "INTEGER 0");
-    }
-
-    @Test
-    public void testToString2() {
-        final SpreadsheetNumberParsePatternsRequest request = this.createRequest();
-        request.negativeMantissa = true;
-        request.mantissa = BigDecimal.valueOf(123.5);
-
-        this.toStringAndCheck(request, "INTEGER -123.5");
-    }
-
-    @Test
-    public void testToStringPercent() {
-        final SpreadsheetNumberParsePatternsRequest request = this.createRequest();
-        request.mantissa = BigDecimal.valueOf(123.5);
-        request.percentage = true;
-
-        this.toStringAndCheck(request, "INTEGER 1.235");
+        this.toStringAndCheck(
+                this.createRequest(),
+                "context=" + decimalNumberContext() + " digitMode=" + SpreadsheetNumberParsePatternsComponentDigitMode.INTEGER_OR_SIGN
+        );
     }
 
     private SpreadsheetNumberParsePatternsRequest createRequest() {
-        return SpreadsheetNumberParsePatternsRequest.with(Iterators.fake(), DecimalNumberContexts.american(MathContext.UNLIMITED));
+        return SpreadsheetNumberParsePatternsRequest.with(
+                Iterators.fake(),
+                SpreadsheetNumberParsePatternsMode.VALUE,
+                this.decimalNumberContext()
+        );
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTest.java
@@ -23,20 +23,20 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContexts;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.spreadsheet.parser.SpreadsheetNumberParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.text.cursor.parser.ParserTokens;
+import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 public final class SpreadsheetNumberParsePatternsTest extends SpreadsheetParsePatternsTestCase<SpreadsheetNumberParsePatterns,
         SpreadsheetFormatNumberParserToken,
         SpreadsheetNumberParserToken,
-        BigDecimal> {
+        ExpressionNumber> {
 
     @Test
     public void testWithAmpmFails() {
@@ -99,28 +99,46 @@ public final class SpreadsheetNumberParsePatternsTest extends SpreadsheetParsePa
 
     @Test
     public void testConvertFails() {
-        this.convertFails2("#.00",
-                "abc123");
+        this.convertFails2(
+                "#.00",
+                "abc123"
+        );
     }
 
     @Test
     public void testConvertFails2() {
-        this.convertFails2("$ #.00",
-                "1.23");
+        this.convertFails2(
+                "$ #.00",
+                "1" + DECIMAL + "23"
+        );
     }
 
     @Test
     public void testConvertNumber() {
-        this.convertAndCheck2("#.00",
-                "1.23",
-                BigDecimal.valueOf(1.23));
+        this.convertAndCheck3(
+                "#.00",
+                "1" + DECIMAL + "23",
+                1.23
+        );
     }
 
     @Test
     public void testConvertNumberWithCurrency() {
-        this.convertAndCheck2("$ #.00",
-                "$ 1.23",
-                BigDecimal.valueOf(1.23));
+        this.convertAndCheck3(
+                "$#.00",
+                CURRENCY + "1" + DECIMAL + "23",
+                1.23
+        );
+    }
+
+    private void convertAndCheck3(final String pattern,
+                                 final String text,
+                                 final Number value) {
+        this.convertAndCheck2(
+                pattern,
+                text,
+                EXPRESSION_NUMBER_KIND.create(value)
+        );
     }
 
     // parser........................................................................................................
@@ -134,49 +152,225 @@ public final class SpreadsheetNumberParsePatternsTest extends SpreadsheetParsePa
     @Test
     public void testParseFails2() {
         this.parseFails2("$ #.00",
-                "1.23");
+                "1" + DECIMAL + "23");
     }
 
     @Test
-    public void testParseNumber() {
-        this.parseAndCheck3("#.00",
-                "1.23",
-                BigDecimal.valueOf(1.23));
+    public void testParseNumber0() {
+        this.parseAndCheck2(
+                "#",
+                "0",
+                digit0()
+        );
     }
 
     @Test
-    public void testParseNumberWithCurrency() {
-        this.parseAndCheck3("$ #.00",
-                "$ 1.23",
-                BigDecimal.valueOf(1.23));
+    public void testParseNumber1() {
+        this.parseAndCheck2(
+                "#",
+                "1",
+                digit1()
+        );
     }
 
     @Test
-    public void testParseNumberTrailingSeparator() {
-        this.parseAndCheck3("#.00;",
-                "1.23",
-                BigDecimal.valueOf(1.23));
+    public void testParseNumber12() {
+        this.parseAndCheck2(
+                "#",
+                "12",
+                digit12()
+        );
     }
 
     @Test
-    public void testParseNumberFirstPattern() {
-        this.parseAndCheck3("0;0.0%",
-                "9",
-                BigDecimal.valueOf(9));
+    public void testParseNumber0Decimal() {
+        this.parseAndCheck2(
+                "#.",
+                "0" + DECIMAL,
+                digit0(),
+                decimalSeparator()
+        );
     }
 
     @Test
-    public void testParseNumberSecondPattern() {
-        this.parseAndCheck3("0.0;0$",
-                "9",
-                BigDecimal.valueOf(9));
+    public void testParseNumber1Decimal() {
+        this.parseAndCheck2(
+                "#.",
+                "1" + DECIMAL,
+                digit1(),
+                decimalSeparator()
+        );
     }
 
     @Test
-    public void testParseNumberSecondPatternTrailingSeparator() {
-        this.parseAndCheck3("$0.00;0.00;",
-                "1.23",
-                BigDecimal.valueOf(1.23));
+    public void testParseNumber0DecimalFive() {
+        this.parseAndCheck2(
+                "#.#",
+                "0" + DECIMAL + "5",
+                digit0(),
+                decimalSeparator(),
+                digit5()
+        );
+    }
+
+    @Test
+    public void testParseNumber0DecimalZeroFive() {
+        this.parseAndCheck2(
+                "#.##",
+                "0" + DECIMAL + "05",
+                digit0(),
+                decimalSeparator(),
+                digit05()
+        );
+    }
+
+    @Test
+    public void testParseNumber0DecimalZeroSevenFive() {
+        this.parseAndCheck2(
+                "#.##",
+                "0" + DECIMAL + "075",
+                digit0(),
+                decimalSeparator(),
+                digit075()
+        );
+    }
+
+    @Test
+    public void testParsePlusNumber0() {
+        this.parseAndCheck2(
+                "#",
+                PLUS + "0",
+                plus(),
+                digit0()
+        );
+    }
+
+    @Test
+    public void testParsePlusNumber12() {
+        this.parseAndCheck2(
+                "#",
+                PLUS + "12",
+                plus(),
+                digit12()
+        );
+    }
+
+    @Test
+    public void testParseMinusNumber0() {
+        this.parseAndCheck2(
+                "#",
+                MINUS + "0",
+                minus(),
+                digit0()
+        );
+    }
+
+    @Test
+    public void testParseMinusNumber12() {
+        this.parseAndCheck2(
+                "#",
+                MINUS + "12",
+                minus(),
+                digit12()
+        );
+    }
+
+    @Test
+    public void testParseCurrencyNumber0() {
+        this.parseAndCheck2(
+                "$#",
+                CURRENCY + "0",
+                currencyDollarSign(),
+                digit0()
+        );
+    }
+
+    @Test
+    public void testParseCurrencyNumber12() {
+        this.parseAndCheck2(
+                "$#",
+                CURRENCY + "12",
+                currencyDollarSign(),
+                digit12()
+        );
+    }
+
+    @Test
+    public void testParseCurrencyNumber12Decimal() {
+        this.parseAndCheck2(
+                "$#.",
+                CURRENCY + "12" + DECIMAL,
+                currencyDollarSign(),
+                digit12(),
+                decimalSeparator()
+        );
+    }
+
+    @Test
+    public void testParseCurrencyNumber0Decimal075() {
+        this.parseAndCheck2(
+                "$#.#",
+                CURRENCY + "0" + DECIMAL + "075",
+                currencyDollarSign(),
+                digit0(),
+                decimalSeparator(),
+                digit075()
+        );
+    }
+
+    @Test
+    public void testParseNumberExponentNumber() {
+        this.parseAndCheck2(
+                "#E+#",
+                "0" + EXPONENT + "1",
+                digit0(),
+                e(),
+                digit1()
+        );
+    }
+
+    @Test
+    public void testParseNumberExponentPlusNumber() {
+        this.parseAndCheck2(
+                "#E+#",
+                "0" + EXPONENT + PLUS + "1",
+                digit0(),
+                e(),
+                plus(),
+                digit1()
+        );
+    }
+
+    @Test
+    public void testParseNumberExponentMinusNumber() {
+        this.parseAndCheck2(
+                "#E+#",
+                "0" + EXPONENT + MINUS + "1",
+                digit0(),
+                e(),
+                minus(),
+                digit1()
+        );
+    }
+
+    @Test
+    public void testParseNumberSeparator() {
+        this.parseAndCheck2(
+                "#;",
+                "1",
+                digit1()
+        );
+    }
+
+    @Test
+    public void testParseSecondPatternNumberDecimalNumber() {
+        this.parseAndCheck2(
+                "$#;#.#",
+                "1" + DECIMAL + "5",
+                digit1(),
+                decimalSeparator(),
+                digit5()
+        );
     }
 
     // helpers.........................................................................................................
@@ -206,36 +400,15 @@ public final class SpreadsheetNumberParsePatternsTest extends SpreadsheetParsePa
         return SpreadsheetFormatParserToken.number(tokens, text);
     }
 
-    private void parseAndCheck3(final String pattern,
-                                final String text,
-                                final BigDecimal value) {
-        this.parseAndCheck3(pattern,
-                text,
-                value,
-                "");
-    }
-
-    private void parseAndCheck3(final String pattern,
-                                final String text,
-                                final BigDecimal value,
-                                final String textAfter) {
-        this.parseAndCheck(this.parseString(pattern).parser(),
-                this.parserContext(),
-                text,
-                ParserTokens.bigDecimal(value, text),
-                text,
-                textAfter);
-    }
-
     @Override
     SpreadsheetNumberParserToken parent(final List<ParserToken> tokens,
                                         final String text) {
-        throw new UnsupportedOperationException();
+        return SpreadsheetParserToken.number(tokens, text);
     }
 
     @Override
-    Class<BigDecimal> targetType() {
-        return BigDecimal.class;
+    Class<ExpressionNumber> targetType() {
+        return ExpressionNumber.class;
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsTestCase.java
@@ -23,17 +23,30 @@ import walkingkooka.math.FakeDecimalNumberContext;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.TypeNameTesting;
+import walkingkooka.text.cursor.parser.ParserTesting;
 
 import java.math.MathContext;
 
 public abstract class SpreadsheetNumberParsePatternsTestCase<T> implements ClassTesting2<T>,
+        ParserTesting,
         TypeNameTesting<T> {
 
     SpreadsheetNumberParsePatternsTestCase() {
         super();
     }
 
-    final static String CURRENCY = "aud";
+    final static boolean NEXT_CALLED = false;
+    final static boolean NEXT_SKIPPED = true;
+
+    final static String CURRENCY = "NZ$";
+
+    final static char GROUP = 'g';
+    final static char PERCENT = 'q';
+    final static String EXPONENT = "XYZ";
+
+    final static char PLUS = 'p';
+    final static char MINUS = 'm';
+    final static char DECIMAL = 'd';
 
     public final DecimalNumberContext decimalNumberContext() {
         return new FakeDecimalNumberContext() {
@@ -44,32 +57,32 @@ public abstract class SpreadsheetNumberParsePatternsTestCase<T> implements Class
 
             @Override
             public char decimalSeparator() {
-                return 'D';
+                return DECIMAL;
             }
 
             @Override
             public String exponentSymbol() {
-                return "X";
+                return EXPONENT;
             }
 
             @Override
             public char groupingSeparator() {
-                return 'G';
+                return GROUP;
             }
 
             @Override
             public char negativeSign() {
-                return 'N';
+                return MINUS;
             }
 
             @Override
             public char percentageSymbol() {
-                return 'P';
+                return PERCENT;
             }
 
             @Override
             public char positiveSign() {
-                return 'Q';
+                return PLUS;
             }
 
             @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
@@ -23,20 +23,28 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.ConverterTesting;
 import walkingkooka.convert.Converters;
+import walkingkooka.math.DecimalNumberContext;
+import walkingkooka.math.FakeDecimalNumberContext;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParentParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetAmPmParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetCurrencySymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetDayNumberParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetDecimalSeparatorSymbolParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetDigitsParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetExponentSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetHourParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetMillisecondParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetMinusSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetMinuteParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetMonthNameAbbreviationParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetMonthNameParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetMonthNumberParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParentParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetPlusSymbolParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetSecondsParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetTextLiteralParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetYearParserToken;
@@ -53,15 +61,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetParsePatterns<T>,
         T extends SpreadsheetFormatParentParserToken,
-        SPT extends SpreadsheetParserToken, // SpreadsheetParentParserToken
+        SPT extends SpreadsheetParentParserToken,
         V> extends SpreadsheetPatternTestCase<P, List<T>>
         implements ConverterTesting {
 
     final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
     final static char VALUE_SEPARATOR = ',';
 
+    final static String CURRENCY = "NZ$";
+    final static char DECIMAL = 'd';
+    final static String EXPONENT = "XP";
+    final static char GROUPING = 'g';
+    final static char MINUS = 'm';
+    final static char PERCENT = 'q';
+    final static char PLUS = 'p';
+
     SpreadsheetParsePatternsTestCase() {
         super();
+        assertEquals(this.decimalNumberContext().currencySymbol(), currencyDollarSign().text(), "currencySymbol");
+        assertEquals(this.decimalNumberContext().exponentSymbol(), e().text(), "exponentSymbol");
     }
 
     @Test
@@ -242,6 +260,46 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
                 this.createPattern(Lists.of(parseFormatParserToken(patternText), parseFormatParserToken(patternText2))));
     }
 
+    @Override
+    public DecimalNumberContext decimalNumberContext() {
+        return new FakeDecimalNumberContext() {
+            @Override
+            public String currencySymbol() {
+                return CURRENCY;
+            }
+
+            @Override
+            public char decimalSeparator() {
+                return DECIMAL;
+            }
+
+            @Override
+            public String exponentSymbol() {
+                return EXPONENT;
+            }
+
+            @Override
+            public char groupingSeparator() {
+                return GROUPING;
+            }
+
+            @Override
+            public char negativeSign() {
+                return MINUS;
+            }
+
+            @Override
+            public char percentageSymbol() {
+                return PERCENT;
+            }
+
+            @Override
+            public char positiveSign() {
+                return PLUS;
+            }
+        };
+    }
+
     static SpreadsheetAmPmParserToken am() {
         return SpreadsheetParserToken.amPm(0, "AM");
     }
@@ -253,12 +311,48 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
         return textLiteral(",");
     }
 
+    static SpreadsheetCurrencySymbolParserToken currencyDollarSign() {
+        return SpreadsheetParserToken.currencySymbol(CURRENCY, CURRENCY);
+    }
+
     static SpreadsheetDayNumberParserToken day31() {
         return SpreadsheetParserToken.dayNumber(31, "31");
     }
 
     static SpreadsheetDecimalSeparatorSymbolParserToken decimalSeparator() {
-        return SpreadsheetParserToken.decimalSeparatorSymbol(".", ".");
+        return SpreadsheetParserToken.decimalSeparatorSymbol("" + DECIMAL, "" + DECIMAL);
+    }
+
+    static SpreadsheetDigitsParserToken digit0() {
+        return digits("0");
+    }
+
+    static SpreadsheetDigitsParserToken digit05() {
+        return digits("05");
+    }
+
+    static SpreadsheetDigitsParserToken digit075() {
+        return digits("075");
+    }
+
+    static SpreadsheetDigitsParserToken digit1() {
+        return digits("1");
+    }
+
+    static SpreadsheetDigitsParserToken digit12() {
+        return digits("12");
+    }
+
+    static SpreadsheetDigitsParserToken digit5() {
+        return digits("5");
+    }
+
+    private static SpreadsheetDigitsParserToken digits(final String text) {
+        return SpreadsheetParserToken.digits(text, text);
+    }
+
+    static SpreadsheetExponentSymbolParserToken e() {
+        return SpreadsheetParserToken.exponentSymbol("" + EXPONENT, "" + EXPONENT);
     }
 
     static SpreadsheetHourParserToken hour9() {
@@ -275,6 +369,10 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
 
     static SpreadsheetMillisecondParserToken milli(final int value, final String text) {
         return SpreadsheetParserToken.millisecond(value, text);
+    }
+
+    static SpreadsheetMinusSymbolParserToken minus() {
+        return SpreadsheetParserToken.minusSymbol("" + MINUS, "" + MINUS);
     }
 
     static SpreadsheetMinuteParserToken minute8() {
@@ -295,6 +393,10 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
 
     static SpreadsheetMonthNameParserToken monthDecember() {
         return SpreadsheetParserToken.monthName(12, "December");
+    }
+
+    static SpreadsheetPlusSymbolParserToken plus() {
+        return SpreadsheetParserToken.plusSymbol("" + PLUS, "" + PLUS);
     }
 
     static SpreadsheetAmPmParserToken pm() {

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
@@ -172,7 +172,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal() {
         this.parseAndCheck2(
                 "hh:mm:ss.",
-                "9:58:59.",
+                "9:58:59" + DECIMAL,
                 hour9(),
                 colon(),
                 minute58(),
@@ -186,7 +186,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal2() {
         this.parseAndCheck2(
                 "hh:mm:ss.",
-                "13:58:59.",
+                "13:58:59" + DECIMAL,
                 hour13(),
                 colon(),
                 minute58(),
@@ -200,7 +200,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal1Millis() {
         this.parseAndCheck2(
                 "hh:mm:ss.0",
-                "11:58:59.1",
+                "11:58:59" + DECIMAL + "1",
                 hour11(),
                 colon(),
                 minute58(),
@@ -215,7 +215,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal1Millis2() {
         this.parseAndCheck2(
                 "hh:mm:ss.0",
-                "11:58:59.",
+                "11:58:59" + DECIMAL,
                 hour11(),
                 colon(),
                 minute58(),
@@ -229,7 +229,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal2Millis() {
         this.parseAndCheck2(
                 "hh:mm:ss.00",
-                "11:58:59.12",
+                "11:58:59" + DECIMAL + "12",
                 hour11(),
                 colon(),
                 minute58(),
@@ -244,7 +244,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal3Millis() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.123",
+                "11:58:59" + DECIMAL + "123",
                 hour11(),
                 colon(),
                 minute58(),
@@ -259,7 +259,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal3Millis2() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.12",
+                "11:58:59" + DECIMAL + "12",
                 hour11(),
                 colon(),
                 minute58(),
@@ -274,7 +274,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal3Millis3() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.1",
+                "11:58:59" + DECIMAL + "1",
                 hour11(),
                 colon(),
                 minute58(),
@@ -289,7 +289,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsDecimal3Millis4() {
         this.parseAndCheck2(
                 "hh:mm:ss.000",
-                "11:58:59.",
+                "11:58:59" + DECIMAL,
                 hour11(),
                 colon(),
                 minute58(),
@@ -357,7 +357,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseHourMinutesSecondsMillisAmpm() {
         this.parseAndCheck2(
                 "hh:mm:ss.0 AM/PM",
-                "11:58:59.1 PM",
+                "11:58:59" + DECIMAL + "1 PM",
                 hour11(),
                 colon(),
                 minute58(),
@@ -461,7 +461,7 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     public void testParseSecondsDecimalSeparator() {
         this.parseAndCheck2(
                 "s.",
-                "9.",
+                "9" + DECIMAL,
                 second9(),
                 decimalSeparator()
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -541,47 +541,47 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     @Test
     public void testConverterStringToExpressionNumber() {
-        this.convertAndCheck2("Number 123.500", EXPRESSION_NUMBER_KIND.create(123.5));
+        this.convertAndCheck2("123.500", EXPRESSION_NUMBER_KIND.create(123.5));
     }
 
     @Test
     public void testConverterStringToBigDecimal() {
-        this.convertAndCheck2("Number 123.500", BigDecimal.valueOf(123.5));
+        this.convertAndCheck2("123.500", BigDecimal.valueOf(123.5));
     }
 
     @Test
     public void testConverterStringToBigInteger() {
-        this.convertAndCheck2("Number 123.000", BigInteger.valueOf(123));
+        this.convertAndCheck2("123.000", BigInteger.valueOf(123));
     }
 
     @Test
     public void testConverterStringToByte() {
-        this.convertAndCheck2("Number 123.000", (byte) 123);
+        this.convertAndCheck2("123.000", (byte) 123);
     }
 
     @Test
     public void testConverterStringToShort() {
-        this.convertAndCheck2("Number 123.000", (short) 123);
+        this.convertAndCheck2("123.000", (short) 123);
     }
 
     @Test
     public void testConverterStringToInteger() {
-        this.convertAndCheck2("Number 123.000", 123);
+        this.convertAndCheck2("123.000", 123);
     }
 
     @Test
     public void testConverterStringToLong() {
-        this.convertAndCheck2("Number 123.000", 123L);
+        this.convertAndCheck2("123.000", 123L);
     }
 
     @Test
     public void testConverterStringToFloat() {
-        this.convertAndCheck2("Number 123.500", 123.5f);
+        this.convertAndCheck2("123.500", 123.5f);
     }
 
     @Test
     public void testConverterStringToDouble() {
-        this.convertAndCheck2("Number 123.500", 123.5);
+        this.convertAndCheck2("123.500", 123.5);
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
@@ -188,6 +188,16 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
     }
 
     @Override
+    protected Visiting startVisit(final SpreadsheetNumberParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetNumberParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -309,11 +319,6 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
 
     @Override
     protected void visit(final SpreadsheetExponentSymbolParserToken token) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void visit(final SpreadsheetNumberParserToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetAdditionParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetAdditionParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetAdditionParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetPlusSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetPlusSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,11 @@ public final class SpreadsheetAdditionParserTokenTest extends SpreadsheetBinaryP
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetBinaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetBinaryParserTokenTestCase.java
@@ -20,9 +20,6 @@ package walkingkooka.spreadsheet.parser;
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
-import walkingkooka.tree.expression.Expression;
-import walkingkooka.tree.expression.ExpressionNumber;
-import walkingkooka.tree.expression.ExpressionNumberExpression;
 
 import java.util.List;
 
@@ -106,21 +103,5 @@ public abstract class SpreadsheetBinaryParserTokenTestCase<T extends Spreadsheet
         final SpreadsheetParserToken right = this.rightToken();
 
         return this.createToken(right.text() + operatorSymbol.text() + left.text(), right, operatorSymbol, left);
-    }
-
-    final ExpressionNumber expressionNumber1() {
-        return this.expressionNumber(NUMBER1);
-    }
-
-    final ExpressionNumber expressionNumber2() {
-        return this.expressionNumber(NUMBER2);
-    }
-
-    final ExpressionNumberExpression expressionNumberExpression1() {
-        return Expression.expressionNumber(this.expressionNumber1());
-    }
-
-    final ExpressionNumberExpression expressionNumberExpression2() {
-        return Expression.expressionNumber(this.expressionNumber2());
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetBinaryParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetBinaryParserTokenTestCase2.java
@@ -24,7 +24,12 @@ public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends Spreadshee
 
     @Test
     public final void testToExpression() {
-        this.toExpressionAndCheck(this.expressionNode(this.expressionNumberExpression1(), this.expressionNumberExpression2()));
+        this.toExpressionAndCheck(
+                this.expressionNode(
+                        this.expression1(),
+                        this.expression2()
+                )
+        );
     }
 
     abstract Expression expressionNode(final Expression left, final Expression right);

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDivisionParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDivisionParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetDivisionParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetDivideSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetDivideSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,11 @@ public final class SpreadsheetDivisionParserTokenTest extends SpreadsheetBinaryP
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetEqualsParserTokenTest.java
@@ -71,21 +71,29 @@ public final class SpreadsheetEqualsParserTokenTest extends SpreadsheetBinaryPar
                 visited.add(t);
             }
 
+
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetEqualsSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetEqualsSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +104,11 @@ public final class SpreadsheetEqualsParserTokenTest extends SpreadsheetBinaryPar
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetExpressionParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetExpressionParserTokenTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
-import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
@@ -36,7 +35,7 @@ public final class SpreadsheetExpressionParserTokenTest extends SpreadsheetParen
 
     @Test
     public void testWithTwoTokensFails() {
-        this.createToken(NUMBER1 + NUMBER2, this.number1(), this.number2());
+        this.createToken("" + NUMBER1 + NUMBER2, this.number1(), this.number2());
     }
 
     @Test
@@ -81,18 +80,15 @@ public final class SpreadsheetExpressionParserTokenTest extends SpreadsheetParen
 
     @Test
     public void testToExpressionAddition() {
-        final ExpressionNumber number1 = this.expressionNumber(1);
-        final ExpressionNumber number2 = this.expressionNumber(2);
-
         this.toExpressionAndCheck(
                 SpreadsheetExpressionParserToken.with(
                         Lists.of(
                                 equalsSymbol(),
                                 SpreadsheetParserToken.addition(
                                         Lists.of(
-                                                SpreadsheetParserToken.number(number1, "1"),
+                                                number1(),
                                                 SpreadsheetParserToken.plusSymbol("+", "+"),
-                                                SpreadsheetParserToken.number(number2, "2")
+                                                number2()
                                         ),
                                         "1+2"
                                 )
@@ -100,17 +96,14 @@ public final class SpreadsheetExpressionParserTokenTest extends SpreadsheetParen
                         "=1+2"
                 ),
                 Expression.add(
-                        Expression.expressionNumber(number1),
-                        Expression.expressionNumber(number2)
+                        Expression.expressionNumber(this.expressionNumber(NUMBER1)),
+                        Expression.expressionNumber(this.expressionNumber(NUMBER2))
                 )
         );
     }
 
     @Test
     public void testToExpressionWhitespaceAddition() {
-        final ExpressionNumber number1 = this.expressionNumber(1);
-        final ExpressionNumber number2 = this.expressionNumber(2);
-
         this.toExpressionAndCheck(
                 SpreadsheetExpressionParserToken.with(
                         Lists.of(
@@ -118,9 +111,9 @@ public final class SpreadsheetExpressionParserTokenTest extends SpreadsheetParen
                                 whitespace(),
                                 SpreadsheetParserToken.addition(
                                         Lists.of(
-                                                SpreadsheetParserToken.number(number1, "1"),
+                                                number1(),
                                                 SpreadsheetParserToken.plusSymbol("+", "+"),
-                                                SpreadsheetParserToken.number(number2, "2")
+                                                number2()
                                         ),
                                         "1+2"
                                 )
@@ -128,8 +121,8 @@ public final class SpreadsheetExpressionParserTokenTest extends SpreadsheetParen
                         "= 1+2"
                 ),
                 Expression.add(
-                        Expression.expressionNumber(number1),
-                        Expression.expressionNumber(number2)
+                        Expression.expressionNumber(this.expressionNumber(NUMBER1)),
+                        Expression.expressionNumber(this.expressionNumber(NUMBER2))
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetFunctionParserTokenTest.java
@@ -83,9 +83,14 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
 
     @Test
     public void testToExpression() {
-        this.toExpressionAndCheck(Expression.function(
-                FunctionExpressionName.with(FUNCTION),
-                Lists.of(Expression.expressionNumber(this.expressionNumber(NUMBER1)))));
+        this.toExpressionAndCheck(
+                Expression.function(
+                        FunctionExpressionName.with(FUNCTION),
+                        Lists.of(
+                                Expression.expressionNumber(this.expressionNumber(NUMBER1))
+                        )
+                )
+        );
     }
 
     private void checkFunction(final SpreadsheetFunctionParserToken function, final SpreadsheetFunctionName name) {

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGreaterThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGreaterThanEqualsParserTokenTest.java
@@ -71,21 +71,29 @@ public final class SpreadsheetGreaterThanEqualsParserTokenTest extends Spreadshe
                 visited.add(t);
             }
 
+
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -95,12 +103,14 @@ public final class SpreadsheetGreaterThanEqualsParserTokenTest extends Spreadshe
                 b.append("8");
                 visited.add(t);
             }
+
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGreaterThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGreaterThanParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetGreaterThanParserTokenTest extends SpreadsheetBina
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetGreaterThanSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetGreaterThanSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,12 @@ public final class SpreadsheetGreaterThanParserTokenTest extends SpreadsheetBina
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetGroupParserTokenTest.java
@@ -35,7 +35,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
 
     @Test
     public void testWithTwoTokensFails() {
-        this.createToken(NUMBER1 + NUMBER2, this.number1(), this.number2());
+        this.createToken("" + NUMBER1 + NUMBER2, this.number1(), this.number2());
     }
 
     @Test
@@ -95,7 +95,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
 
     @Override
     public SpreadsheetGroupParserToken createDifferentToken() {
-        return this.createToken(NUMBER2, this.number2());
+        return this.createToken("" + NUMBER2, this.number2());
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetLessThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetLessThanEqualsParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetLessThanEqualsParserTokenTest extends SpreadsheetB
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetLessThanEqualsSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetLessThanEqualsSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -95,12 +102,14 @@ public final class SpreadsheetLessThanEqualsParserTokenTest extends SpreadsheetB
                 b.append("8");
                 visited.add(t);
             }
+
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetLessThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetLessThanParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetLessThanParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetLessThanSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetLessThanSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -95,12 +102,14 @@ public final class SpreadsheetLessThanParserTokenTest extends SpreadsheetBinaryP
                 b.append("8");
                 visited.add(t);
             }
+
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetMultiplicationParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetMultiplicationParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetMultiplicationParserTokenTest extends SpreadsheetB
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetMultiplySymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetMultiplySymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,12 @@ public final class SpreadsheetMultiplicationParserTokenTest extends SpreadsheetB
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNegativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNegativeParserTokenTest.java
@@ -70,21 +70,29 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
                 visited.add(t);
             }
 
+
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetMinusSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetMinusSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -95,10 +103,10 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
                 visited.add(t);
             }
         }.accept(unary);
-        assertEquals("7137162871528428", b.toString());
+        assertEquals("81381728815628428", b.toString());
         assertEquals(Lists.of(unary, unary, unary,
                 symbol, symbol, symbol, symbol, symbol,
-                parameter, parameter, parameter, parameter, parameter,
+                parameter, parameter, parameter, parameter, parameter, parameter,
                 unary, unary, unary),
                 visited,
                 "visited");
@@ -106,7 +114,11 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
 
     @Test
     public final void testToExpression() {
-        this.toExpressionAndCheck(Expression.negative(this.expressionNumberExpression()));
+        this.toExpressionAndCheck(
+                Expression.negative(
+                        expression1()
+                )
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNotEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNotEqualsParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetNotEqualsParserTokenTest extends SpreadsheetBinary
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetNotEqualsSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetNotEqualsSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,12 @@ public final class SpreadsheetNotEqualsParserTokenTest extends SpreadsheetBinary
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
@@ -27,7 +27,7 @@ import walkingkooka.tree.expression.ExpressionNumberExpression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,8 +40,8 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
     final static String APOSTROPHE = "\'";
     final static String DOUBLE_QUOTE = "\"";
 
-    final static String NUMBER1 = "1";
-    final static String NUMBER2 = "22";
+    final static BigInteger NUMBER1 = BigInteger.valueOf(1);
+    final static BigInteger NUMBER2 = BigInteger.valueOf(22);
 
     final static String TEXT = "abc123";
 
@@ -163,15 +163,24 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
     }
 
     final SpreadsheetNumberParserToken number1() {
-        return this.number(NUMBER1);
+        return this.number("" + NUMBER1);
     }
 
     final SpreadsheetNumberParserToken number2() {
-        return this.number(NUMBER2);
+        return this.number("" + NUMBER2);
     }
 
-    final SpreadsheetNumberParserToken number(final String value) {
-        return SpreadsheetParserToken.number(expressionNumber(value), value);
+    private SpreadsheetNumberParserToken number(final String value) {
+        return this.number(value, value);
+    }
+
+    final SpreadsheetNumberParserToken number(final String value, final String text) {
+        return SpreadsheetParserToken.number(
+                Lists.of(
+                        SpreadsheetParserToken.digits(value, text)
+                ),
+                "" + value
+        );
     }
 
     final SpreadsheetPercentSymbolParserToken percentSymbol() {
@@ -210,16 +219,20 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
         return SpreadsheetParserToken.parenthesisCloseSymbol(")", ")");
     }
 
-    final ExpressionNumber expressionNumber(final String value) {
-        return this.expressionNumber(new BigDecimal(value));
+    final ExpressionNumberExpression expression1() {
+        return this.expression(NUMBER1);
+    }
+
+    final ExpressionNumberExpression expression2() {
+        return this.expression(NUMBER2);
+    }
+
+    final ExpressionNumberExpression expression(final Number number) {
+        return Expression.expressionNumber(EXPRESSION_NUMBER_KIND.create(number));
     }
 
     final ExpressionNumber expressionNumber(final Number value) {
         return EXPRESSION_NUMBER_KIND.create(value);
-    }
-
-    final ExpressionNumberExpression expressionNumberExpression(final Number value) {
-        return Expression.expressionNumber(this.expressionNumber(value));
     }
 
     final ExpressionEvaluationContext expressionEvaluationContext(final int twoDigitYear) {

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorExpressionNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorExpressionNumberTest.java
@@ -15,14 +15,17 @@
  *
  */
 
-package walkingkooka.spreadsheet.format.pattern;
+package walkingkooka.spreadsheet.parser;
 
-import walkingkooka.ToStringTesting;
+public final class SpreadsheetParserTokenVisitorExpressionNumberTest extends SpreadsheetParserTokenVisitorTestCase<SpreadsheetParserTokenVisitorExpressionNumber> {
 
-public abstract class SpreadsheetNumberParsePatternsComponentTestCase2<C extends SpreadsheetNumberParsePatternsComponent2> extends SpreadsheetNumberParsePatternsComponentTestCase<C>
-        implements ToStringTesting<C> {
+    @Override
+    public SpreadsheetParserTokenVisitorExpressionNumber createVisitor() {
+        return new SpreadsheetParserTokenVisitorExpressionNumber();
+    }
 
-    SpreadsheetNumberParsePatternsComponentTestCase2() {
-        super();
+    @Override
+    public Class<SpreadsheetParserTokenVisitorExpressionNumber> type() {
+        return SpreadsheetParserTokenVisitorExpressionNumber.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpressionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpressionTest.java
@@ -18,7 +18,7 @@
 package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.collect.list.Lists;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -26,7 +26,13 @@ public final class SpreadsheetParserTokenVisitorToExpressionTest extends Spreads
 
     @Test
     public void testNullExpressionNumberKindFails() {
-        assertThrows(NullPointerException.class, () -> SpreadsheetParserTokenVisitorToExpression.accept(SpreadsheetParserToken.number(ExpressionNumberKind.DEFAULT.create(1), "1"), null));
+        assertThrows(NullPointerException.class, () -> SpreadsheetParserTokenVisitorToExpression.accept(
+                SpreadsheetParserToken.number(
+                        Lists.of(
+                                SpreadsheetParserToken.digits("1", "1")
+                        ),
+                        "1"),
+                null));
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContextTest.java
@@ -15,14 +15,20 @@
  *
  */
 
-package walkingkooka.spreadsheet.format.pattern;
+package walkingkooka.spreadsheet.parser;
 
-import walkingkooka.ToStringTesting;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
 
-public abstract class SpreadsheetNumberParsePatternsComponentTestCase2<C extends SpreadsheetNumberParsePatternsComponent2> extends SpreadsheetNumberParsePatternsComponentTestCase<C>
-        implements ToStringTesting<C> {
+public final class SpreadsheetParsersExpressionEvaluationContextTest implements ClassTesting<SpreadsheetParsersExpressionEvaluationContext> {
 
-    SpreadsheetNumberParsePatternsComponentTestCase2() {
-        super();
+    @Override
+    public Class<SpreadsheetParsersExpressionEvaluationContext> type() {
+        return SpreadsheetParsersExpressionEvaluationContext.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetPercentageParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetPercentageParserTokenTest.java
@@ -25,7 +25,6 @@ import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import walkingkooka.visit.Visiting;
 
-import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,9 +56,22 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
             }
 
             @Override
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.SKIP;
+            }
+
+            @Override
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+            
+            @Override
             protected Visiting startVisit(final SpreadsheetPercentageParserToken t) {
                 assertSame(unary, t);
-                b.append("3");
+                b.append("5");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -67,25 +79,19 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
             @Override
             protected void endVisit(final SpreadsheetPercentageParserToken t) {
                 assertSame(unary, t);
-                b.append("4");
-                visited.add(t);
-            }
-
-            @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
-                b.append("5");
-                visited.add(t);
-            }
-
-            @Override
-            protected void visit(final SpreadsheetPercentSymbolParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetPercentSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,9 +102,9 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
                 visited.add(t);
             }
         }.accept(unary);
-        assertEquals("7137152871628428", b.toString());
+        assertEquals("81581342881728628", b.toString());
         assertEquals(Lists.of(unary, unary, unary,
-                parameter, parameter, parameter, parameter, parameter,
+                parameter, parameter, parameter, parameter, parameter, parameter,
                 symbol, symbol, symbol, symbol, symbol,
                 unary, unary, unary),
                 visited,
@@ -107,7 +113,16 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
 
     @Test
     public final void testToExpression() {
-        this.toExpressionAndCheck(Expression.divide(this.expressionNumberExpression(), Expression.expressionNumber(EXPRESSION_NUMBER_KIND.create(100))));
+        this.toExpressionAndCheck(
+                Expression.divide(
+                        Expression.expressionNumber(
+                                this.expressionNumber(200)
+                        ),
+                        Expression.expressionNumber(
+                                this.expressionNumber(100)
+                        )
+                )
+        );
     }
 
     @Override
@@ -117,17 +132,20 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
 
     @Override
     public String text() {
-        return NUMBER1 + "00" + "%";
+        return "200%";
     }
 
     @Override
     List<ParserToken> tokens() {
-        return Lists.of(SpreadsheetParserToken.number(this.expressionNumber(BigInteger.ONE), "100"), this.percentSymbol());
+        return Lists.of(
+                this.number("200", "200"),
+                this.percentSymbol()
+        );
     }
 
     @Override
     public SpreadsheetPercentageParserToken createDifferentToken() {
-        return this.createToken(NUMBER2, this.number2(), this.percentSymbol());
+        return this.createToken(NUMBER2.toString(), this.number2(), this.percentSymbol());
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetPowerParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetPowerParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetPowerParserTokenTest extends SpreadsheetBinaryPars
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetPowerSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetPowerSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,12 @@ public final class SpreadsheetPowerParserTokenTest extends SpreadsheetBinaryPars
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetSubtractionParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetSubtractionParserTokenTest.java
@@ -72,20 +72,27 @@ public final class SpreadsheetSubtractionParserTokenTest extends SpreadsheetBina
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected Visiting startVisit(final SpreadsheetNumberParserToken t) {
                 b.append("5");
                 visited.add(t);
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void visit(final SpreadsheetMinusSymbolParserToken t) {
+            protected void endVisit(final SpreadsheetNumberParserToken t) {
                 b.append("6");
                 visited.add(t);
             }
 
             @Override
-            protected Visiting startVisit(final ParserToken t) {
+            protected void visit(final SpreadsheetMinusSymbolParserToken t) {
                 b.append("7");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("8");
                 visited.add(t);
                 return Visiting.CONTINUE;
             }
@@ -96,11 +103,12 @@ public final class SpreadsheetSubtractionParserTokenTest extends SpreadsheetBina
                 visited.add(t);
             }
         }.accept(binary);
-        assertEquals("713715287162871528428", b.toString());
+
+        assertEquals("81381562881728815628428", b.toString());
         assertEquals(Lists.of(binary, binary, binary,
-                left, left, left, left, left,
+                left, left, left, left, left, left,
                 symbol, symbol, symbol, symbol, symbol,
-                right, right, right, right, right,
+                right, right, right, right, right, right,
                 binary, binary, binary),
                 visited,
                 "visited");

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetUnaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetUnaryParserTokenTestCase.java
@@ -18,13 +18,14 @@
 package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.tree.expression.Expression;
-import walkingkooka.tree.expression.ExpressionNumber;
-import walkingkooka.tree.expression.ExpressionNumberExpression;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SpreadsheetUnaryParserTokenTestCase<T extends SpreadsheetUnaryParserToken> extends SpreadsheetParentParserTokenTestCase<T> {
+
+    SpreadsheetUnaryParserTokenTestCase() {
+        super();
+    }
 
     @Test
     public final void testWithMissingNonNoisyToken() {
@@ -34,13 +35,5 @@ public abstract class SpreadsheetUnaryParserTokenTestCase<T extends SpreadsheetU
     @Test
     public final void testWithMissingNonNoisyToken2() {
         assertThrows(IllegalArgumentException.class, () -> this.createToken("", this.whitespace(), this.whitespace()));
-    }
-
-    final ExpressionNumber expressionNumber() {
-        return this.expressionNumber(1);
-    }
-
-    final ExpressionNumberExpression expressionNumberExpression() {
-        return Expression.expressionNumber(this.expressionNumber());
     }
 }


### PR DESCRIPTION
- SpreadsheetParsers, expression, function and valueOrExpression support number parser parameter
- SpreadsheetNumberParsePatterns.expressionParser, ignores grouping-separators.
- SpreadsheetNumberParsePatternsParser skips pattern text literals & whitespace.
- SpreadsheetNumberParsePatternsConverter does not scale values with percentage patterns, the original value is returned.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1193
- SpreadsheetParsers should accept SpreadsheetFormatParsers for numbers and not Parsers.bigDecimal