### PR TITLE
SpreadsheetNumberParserToken.toNumber divide by 100 percent values.

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterTest.java
@@ -390,7 +390,7 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
         this.convertAndCheck2(
                 "%#",
                 PERCENT + "1",
-                BigDecimal.ONE
+                BigDecimal.valueOf(0.01)
         );
     }
 
@@ -398,8 +398,8 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
     public void testHashPercentBigDecimalDigitPercent() {
         this.convertAndCheck2(
                 "#%",
-                "1" + PERCENT,
-                BigDecimal.ONE
+                "12" + PERCENT,
+                BigDecimal.valueOf(0.12)
         );
     }
 
@@ -407,14 +407,14 @@ public final class SpreadsheetNumberParsePatternsConverterTest extends Spreadshe
     public void testHashPercentBigDecimalDigitDigitDigitPercent() {
         this.convertAndCheck2("#%",
                 "123" + PERCENT,
-                BigDecimal.valueOf(123));
+                BigDecimal.valueOf(1.23));
     }
 
     @Test
     public void testHashDecimalPercentBigDecimalDigitDigitDigitPercent() {
         this.convertAndCheck2("#.#%",
                 "45" + DECIMAL + "6" + PERCENT,
-                BigDecimal.valueOf(45.6));
+                BigDecimal.valueOf(0.456));
     }
 
     // several patterns.................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNumberParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetNumberParserTokenTest.java
@@ -28,6 +28,7 @@ import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.math.MathContext;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -283,6 +284,52 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetParentPar
         );
     }
 
+    @Test
+    public void testToExpressionNumber0Percent() {
+        this.toExpressionAndCheck2(
+                0.0,
+                digit("0"),
+                percent()
+        );
+    }
+
+    @Test
+    public void testToExpressionNumber50Percent() {
+        this.toExpressionAndCheck2(
+                0.5,
+                digit("50"),
+                percent()
+        );
+    }
+
+    @Test
+    public void testToExpressionNumber200Percent() {
+        this.toExpressionAndCheck2(
+                2.0,
+                digit("200"),
+                percent()
+        );
+    }
+
+    @Test
+    public void testToExpressionNumberPercent300() {
+        this.toExpressionAndCheck2(
+                3.0,
+                digit("300"),
+                percent()
+        );
+    }
+
+    @Test
+    public void testToExpressionNumberMinusPercent400() {
+        this.toExpressionAndCheck2(
+                -4.0,
+                minus(),
+                digit("400"),
+                percent()
+        );
+    }
+
     private static SpreadsheetDigitsParserToken digit(final String text) {
         return SpreadsheetDigitsParserToken.digits(text, text);
     }
@@ -293,6 +340,10 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetParentPar
 
     private static SpreadsheetMinusSymbolParserToken minus() {
         return SpreadsheetDigitsParserToken.minusSymbol("-", "-");
+    }
+
+    private static SpreadsheetPercentSymbolParserToken percent() {
+        return SpreadsheetDigitsParserToken.percentSymbol("%", "%");
     }
 
     private static SpreadsheetPlusSymbolParserToken plus() {
@@ -341,6 +392,12 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetParentPar
 
     private ExpressionEvaluationContext expressionEvaluationContext(final ExpressionNumberKind kind) {
         return new FakeExpressionEvaluationContext() {
+
+            @Override
+            public MathContext mathContext() {
+                return MathContext.DECIMAL32;
+            }
+
             @Override
             public ExpressionNumberKind expressionNumberKind() {
                 return kind;


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1370
- SpreadsheetNumberParserToken.toNumber should divide percentages by 100 when converting to a number

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1365
- SpreadsheetNumberParserPatterns.convert should divide percentages by 100 when converting to a number