### PR TITLE
SpreadsheetParsers.function parser uses SpreadsheetParserContext.valu…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
@@ -121,14 +121,8 @@ public final class SpreadsheetParsers implements PublicStaticHelper {
 
     private static void functions(final Map<EbnfIdentifierName, Parser<SpreadsheetParserContext>> predefined) {
         predefined.put(FUNCTION_NAME_IDENTIFIER, functionName());
-        predefined.put(VALUE_SEPARATOR_SYMBOL_IDENTIFIER, VALUE_SEPARATOR_SYMBOL);
+        predefined.put(VALUE_SEPARATOR_SYMBOL_IDENTIFIER, SpreadsheetParsersValueSeparatorParser.INSTANCE);
     }
-
-    private static final Parser<SpreadsheetParserContext> VALUE_SEPARATOR_SYMBOL = symbol(
-            ',',
-            SpreadsheetParserToken::valueSeparatorSymbol,
-            SpreadsheetValueSeparatorSymbolParserToken.class
-    );
 
     private static final EbnfIdentifierName FUNCTION_NAME_IDENTIFIER = EbnfIdentifierName.with("FUNCTION_NAME");
     private static final EbnfIdentifierName VALUE_SEPARATOR_SYMBOL_IDENTIFIER = EbnfIdentifierName.with("VALUE_SEPARATOR_SYMBOL");

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersValueSeparatorParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersValueSeparatorParser.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.Optional;
+
+/**
+ * This {@link Parser} attempts to match the {@link SpreadsheetParserContext#valueSeparator()} and then creates a {@link SpreadsheetValueSeparatorSymbolParserToken}.
+ */
+final class SpreadsheetParsersValueSeparatorParser implements Parser<SpreadsheetParserContext> {
+
+    /**
+     * Singleton
+     */
+    final static SpreadsheetParsersValueSeparatorParser INSTANCE = new SpreadsheetParsersValueSeparatorParser();
+
+    private SpreadsheetParsersValueSeparatorParser() {
+        super();
+    }
+
+    @Override
+    public Optional<ParserToken> parse(final TextCursor cursor,
+                                       final SpreadsheetParserContext context) {
+
+        SpreadsheetValueSeparatorSymbolParserToken token = null;
+        if (false == cursor.isEmpty()) {
+            final char valueSeparator = context.valueSeparator();
+            final char c = cursor.at();
+            if (c == valueSeparator) {
+                final String text = Character.toString(valueSeparator);
+                token = SpreadsheetParserToken.valueSeparatorSymbol(text, text);
+
+                cursor.next();
+            }
+        }
+
+        return Optional.ofNullable(token);
+    }
+
+    @Override
+    public String toString() {
+        return ",";
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
@@ -83,7 +83,7 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
 
     private final static int TWO_DIGIT_YEAR = 20;
     private ExpressionNumberKind expressionNumberKind;
-    private final static char VALUE_SEPARATOR = ',';
+    private final static char VALUE_SEPARATOR = ';'; // deliberate choice picking something different other than comma
 
     /**
      * The name of the test (test method) is important and is used to select a {@link ExpressionNumberKind}.
@@ -1391,7 +1391,7 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     }
 
     private void testFunctionWithTwoArguments() {
-        final String text = "xyz(123,456)";
+        final String text = "xyz(123;456)";
         final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(123), valueSeparator(), number(456), closeParenthesis()), text);
 
         this.functionParseAndCheck(text, f, text);
@@ -1408,7 +1408,7 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     }
 
     private void testFunctionWithFourArguments() {
-        final String text = "xyz(1,2,3,4)";
+        final String text = "xyz(1;2;3;4)";
         final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(1), valueSeparator(), number(2), valueSeparator(), number(3), valueSeparator(), number(4), closeParenthesis()), text);
 
         this.functionParseAndCheck(text, f, text);
@@ -2396,7 +2396,7 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     }
 
     private SpreadsheetParserToken valueSeparator() {
-        return SpreadsheetParserToken.valueSeparatorSymbol(",", ",");
+        return SpreadsheetParserToken.valueSeparatorSymbol("" + VALUE_SEPARATOR, "" + VALUE_SEPARATOR);
     }
 
     // PublicStaticHelperTesting........................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersValueSeparatorParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersValueSeparatorParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public final class SpreadsheetParsersValueSeparatorParserTest extends SpreadsheetParserTestCase<SpreadsheetParsersValueSeparatorParser,
+        SpreadsheetValueSeparatorSymbolParserToken>
+        implements ToStringTesting<SpreadsheetParsersValueSeparatorParser> {
+
+    @Test
+    public void testIncorrectCharacterFails() {
+        assertNotEquals("@", VALUE_SEPARATOR, "valueSeparator");
+
+        this.parseFailAndCheck("@");
+    }
+
+    @Test
+    public void testMatch() {
+        final String text = VALUE_SEPARATOR + "";
+
+        this.parseAndCheck(
+                text,
+                SpreadsheetParserToken.valueSeparatorSymbol(text, text),
+                text
+        );
+    }
+
+    @Test
+    public void testMatch2() {
+        final String text = VALUE_SEPARATOR + "";
+        final String after = "@";
+
+        this.parseAndCheck(
+                text + after,
+                SpreadsheetParserToken.valueSeparatorSymbol(text, text),
+                text,
+                after
+        );
+    }
+
+    // ensure only consumes a single character
+    @Test
+    public void testMatch3() {
+        final String text = VALUE_SEPARATOR + "";
+
+        this.parseAndCheck(
+                text + text,
+                SpreadsheetParserToken.valueSeparatorSymbol(text, text),
+                text,
+                text
+        );
+    }
+
+    @Test
+    public void testDifferentValueSeparator() {
+        final char c = ';';
+        assertNotEquals(c, VALUE_SEPARATOR, "valueSeparator");
+        final String text = c + "";
+
+        this.parseAndCheck(
+                SpreadsheetParsersValueSeparatorParser.INSTANCE,
+                new FakeSpreadsheetParserContext() {
+                    @Override
+                    public char valueSeparator() {
+                        return c;
+                    }
+                },
+                text,
+                SpreadsheetParserToken.valueSeparatorSymbol(text, text),
+                text
+        );
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createParser().toString(), ",");
+    }
+
+    @Override
+    public SpreadsheetParsersValueSeparatorParser createParser() {
+        return SpreadsheetParsersValueSeparatorParser.INSTANCE;
+    }
+
+    @Override
+    public Class<SpreadsheetParsersValueSeparatorParser> type() {
+        return SpreadsheetParsersValueSeparatorParser.class;
+    }
+}


### PR DESCRIPTION
…eSeparator()

- Previously was hardcoded to use "," (comma) now uses SpreadsheetParserContext.valueSeparator().

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1358
- SpreadsheetParserContext.valueSeparator() should be used by SpreadsheetParsers.function parser