### PR TITLE
SpreadsheetTextFormatPattern star missing character fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
@@ -581,10 +581,13 @@ public final class SpreadsheetFormatParsers implements PublicStaticHelper {
                 .cast();
     }
 
+    /**
+     * This parser requires two characters, the second becomes the {@link Character} value of the {@link SpreadsheetFormatParserToken}
+     */
     private static Parser<SpreadsheetFormatParserContext> escapeStarOrUnderline(final char initial,
                                                                                 final BiFunction<Character, String, ParserToken> factory,
                                                                                 final Class<? extends SpreadsheetFormatLeafParserToken> tokenClass) {
-        return Parsers.stringInitialAndPartCharPredicate(CharPredicates.is(initial), CharPredicates.always(), 1, 2)
+        return Parsers.stringInitialAndPartCharPredicate(CharPredicates.is(initial), CharPredicates.always(), 2, 2)
                 .transform((stringParserToken, context) -> factory.apply(stringParserToken.cast(StringParserToken.class).value().charAt(1), stringParserToken.text()))
                 .setToString(snakeCaseParserClassSimpleName(tokenClass))
                 .cast();

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
@@ -177,6 +177,21 @@ public final class SpreadsheetTextFormatPatternTest extends SpreadsheetFormatPat
     // Parse............................................................................................................
 
     @Test
+    public void testParseStringEscapeMissingRepeatingCharacterFails() {
+        this.parseStringFails("\\", IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testParseStringStarMissingRepeatingCharacterFails() {
+        this.parseStringFails("*", IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testParseStringUnderscoreMissingRepeatingCharacterFails() {
+        this.parseStringFails("_", IllegalArgumentException.class);
+    }
+
+    @Test
     public void testParseStringDatePatternFails() {
         this.parseStringFails("ddmmyyyy", IllegalArgumentException.class);
     }


### PR DESCRIPTION
- Previously a "*" without the required character through a StringIndexOutOfBoundsException.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1276
- pattern "*" without required trailing character should be an invalid pattern.