### PR TITLE
SpreadsheetFormula.MAX_FORMULA_TEXT_LENGTH

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -128,7 +128,15 @@ public final class SpreadsheetFormula implements HasText,
 
     private static void checkText(final String text) {
         Objects.requireNonNull(text, "text");
+
+        final int length = text.length();
+        if (length >= MAX_FORMULA_TEXT_LENGTH) {
+            throw new IllegalArgumentException("Invalid text length " + length + ">= " + MAX_FORMULA_TEXT_LENGTH);
+        }
     }
+
+
+    public final static int MAX_FORMULA_TEXT_LENGTH = 8192;
 
     // token .............................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonNodeException;
@@ -56,6 +57,11 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     @Test
+    public void testWithNullMaxTextLengthFails() {
+        assertThrows(IllegalArgumentException.class, () -> SpreadsheetFormula.with(CharSequences.repeating(' ', 8192).toString()));
+    }
+
+    @Test
     public void testWith() {
         final SpreadsheetFormula formula = this.createObject();
         this.checkText(formula, TEXT);
@@ -76,6 +82,11 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     @Test
     public void testSetTextNullFails() {
         assertThrows(NullPointerException.class, () -> this.createObject().setText(null));
+    }
+
+    @Test
+    public void testSetTextMaxTextLengthFails() {
+        assertThrows(IllegalArgumentException.class, () -> this.createObject().setText(CharSequences.repeating(' ', 8192).toString()));
     }
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1263
- Limit formula text to 8192 characters