### PR TITLE
SpreadsheetParsePatterns date, datetime, time require empty TextCurso…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns.java
@@ -84,7 +84,10 @@ public abstract class SpreadsheetParsePatterns<T extends SpreadsheetFormatParser
     // HasParser........................................................................................................
 
     /**
-     * Returns a {@link Parser} which will try all the patterns.
+     * Returns a {@link Parser} which will try all the patterns.<br>
+     * {@link java.time.LocalDate}, {@link java.time.LocalDateTime}, {@link java.time.LocalTime} will all fail to parse
+     * the if the value has extra trailing text. If this parse is for {@link walkingkooka.tree.expression.ExpressionNumber}
+     * and will be used to parse number literals the {@link Parser#andEmptyTextCursor()} must be called afterwards.
      */
     public final Parser<SpreadsheetParserContext> parser() {
         if (null == this.parser) {

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor.java
@@ -80,6 +80,7 @@ final class SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor extends
 
         final Parser<SpreadsheetParserContext> parser = visitor.sequenceParserBuilder.build();
         return parser.transform(SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor::flat)
+                .andEmptyTextCursor()
                 .setToString(parser.toString());
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -538,10 +538,10 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
         return SpreadsheetParsers.valueOrExpression(
                 Parsers.alternatives(
                         Lists.of(
-                                date.parser().andEmptyTextCursor(),
-                                dateTime.parser().andEmptyTextCursor(),
+                                date.parser(),
+                                dateTime.parser(),
                                 number.parser().andEmptyTextCursor(),
-                                time.parser().andEmptyTextCursor()
+                                time.parser()
                         )
                 )
         );

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
@@ -31,6 +31,7 @@ import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.PublicStaticHelperTesting;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePatterns;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.function.SpreadsheetFunctionName;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnOrRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -145,6 +146,14 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     // date values.......................................................................................................
 
     @Test
+    public void testParseDateWithExtraTextFails() {
+        this.parseFailAndCheck(
+                SpreadsheetParsers.valueOrExpression(SpreadsheetPattern.parseDateParsePatterns("yyyy/mm/dd").parser()),
+                "2000/12/31 Extra"
+        );
+    }
+
+    @Test
     public void testDateDayMonthYear2000() {
         this.parseDateAndCheck(
                 "31/12/2000",
@@ -197,6 +206,14 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     // date/time values.................................................................................................
 
     @Test
+    public void testParseDateTimeWithExtraTextFails() {
+        this.parseFailAndCheck(
+                SpreadsheetParsers.valueOrExpression(SpreadsheetPattern.parseDateTimeParsePatterns("yyyy/mm/dd hh:m").parser()),
+                "2000/12/31 12:58 Extra"
+        );
+    }
+
+    @Test
     public void testDateTimeDayMonthYearHourMinutes() {
         this.parseDateTimeAndCheck(
                 "31/12/2000 11:58:59.123 pm",
@@ -231,6 +248,14 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
     }
 
     // time values.......................................................................................................
+
+    @Test
+    public void testParseTimeWithExtraTextFails() {
+        this.parseFailAndCheck(
+                SpreadsheetParsers.valueOrExpression(SpreadsheetPattern.parseTimeParsePatterns("hh:mm").parser()),
+                "12:58 Extra"
+        );
+    }
 
     @Test
     public void testTimeHourMinutes() {
@@ -385,6 +410,16 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
                         ),
                         text),
                 text);
+    }
+
+    // NUMBER...........................................................................................................
+
+    @Test
+    public void testParseNumberWithExtraTextFails() {
+        this.parseFailAndCheck(
+                SpreadsheetParsers.valueOrExpression(SpreadsheetPattern.parseNumberParsePatterns("#").parser().andEmptyTextCursor()),
+                "12 Extra"
+        );
     }
 
     @Test


### PR DESCRIPTION
…r to parse successfully

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1378
- SpreadsheetParsers.valueOrExpression() value parsers should fail if they dont consume entire text