### PR TITLE
DateTimeSpreadsheetFormatter.format cant convert LocalDateTime fails

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatter.java
@@ -58,7 +58,7 @@ final class DateTimeSpreadsheetFormatter extends SpreadsheetFormatter3<Spreadshe
     @Override
     public boolean canFormat(final Object value,
                              final SpreadsheetFormatterContext context) throws SpreadsheetFormatException {
-        return this.typeTester.test(value) && context.canConvert(value, LocalDateTime.class);
+        return this.typeTester.test(value) && context.canConvertOrFail(value, LocalDateTime.class);
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterTest.java
@@ -51,6 +51,26 @@ public final class DateTimeSpreadsheetFormatterTest extends SpreadsheetFormatter
     // tests.............................................................................................................
 
     @Test
+    public void testFormatConvertLocalDateTimeFails() {
+        final LocalDateTime value = LocalDateTime.now();
+
+        assertThrows(SpreadsheetFormatException.class, () -> {
+            this.createFormatter().format(
+                    value,
+                    new FakeSpreadsheetFormatterContext() {
+
+                        @Override
+                        public <T> Either<T, String> convert(final Object v,
+                                                             final Class<T> type) {
+                            assertSame(value, v, "value");
+                            assertEquals(LocalDateTime.class, type, "type");
+                            return Either.<T, String>right("Failed!");
+                        }
+                    });
+        });
+    }
+
+    @Test
     public void testConvertLocalDateTimeFails() {
         final LocalTime time = LocalTime.now();
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1394
- Should DateTimeSpreadsheetFormatter.canFormat throw if it cant convert value to LocalDateTime