### PR TITLE
parse date & datetime uses default-year

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserToken.java
@@ -40,7 +40,9 @@ public final class SpreadsheetDateParserToken extends SpreadsheetParentParserTok
      * Creates a {@link LocalDate} from the components in this {@link SpreadsheetDateParserToken}.
      */
     public LocalDate toLocalDate(final ExpressionEvaluationContext context) {
-        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this)
+        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(
+                this,
+                context.defaultYear())
                 .toLocalDate(context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserToken.java
@@ -40,7 +40,10 @@ public final class SpreadsheetDateTimeParserToken extends SpreadsheetParentParse
      * Creates a {@link LocalDateTime} from the components in this {@link SpreadsheetDateTimeParserToken}.
      */
     public LocalDateTime toLocalDateTime(final ExpressionEvaluationContext context) {
-        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this)
+        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(
+                this,
+                context.defaultYear()
+        )
                 .toLocalDateTime(context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTime.java
@@ -35,15 +35,17 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
      * Creates a {@link SpreadsheetParserTokenVisitorLocalDateTime}, visits the {@link SpreadsheetParentParserToken} and returns the visitor
      * which has methods to create one of {@link LocalDate}, {@link LocalDateTime} or {@link LocalTime}.
      */
-    static SpreadsheetParserTokenVisitorLocalDateTime acceptSpreadsheetParentParserToken(final SpreadsheetParentParserToken token) {
-        final SpreadsheetParserTokenVisitorLocalDateTime visitor = new SpreadsheetParserTokenVisitorLocalDateTime();
+    static SpreadsheetParserTokenVisitorLocalDateTime acceptSpreadsheetParentParserToken(final SpreadsheetParentParserToken token,
+                                                                                         final int defaultYear) {
+        final SpreadsheetParserTokenVisitorLocalDateTime visitor = new SpreadsheetParserTokenVisitorLocalDateTime(defaultYear);
         visitor.accept(token);
         return visitor;
     }
 
     // @VisibleForTesting
-    SpreadsheetParserTokenVisitorLocalDateTime() {
+    SpreadsheetParserTokenVisitorLocalDateTime(final int defaultYear) {
         super();
+        this.year = defaultYear;
     }
 
     // visit....................................................................................................
@@ -149,7 +151,7 @@ final class SpreadsheetParserTokenVisitorLocalDateTime extends SpreadsheetParser
 
     private int day = 1;
     private int month = 1;
-    private int year = 0; // https://github.com/mP1/walkingkooka-spreadsheet/issues/1309 Default year when parsing date or date/time
+    private int year;
     private boolean twoDigitYear = false;
 
     private int hour = 0;

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTimeParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTimeParserToken.java
@@ -39,7 +39,7 @@ public final class SpreadsheetTimeParserToken extends SpreadsheetParentParserTok
      * Creates a {@link LocalTime} from the components in this {@link SpreadsheetTimeParserToken}.
      */
     public LocalTime toLocalTime() {
-        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this)
+        return SpreadsheetParserTokenVisitorLocalDateTime.acceptSpreadsheetParentParserToken(this, Integer.MAX_VALUE)
                 .toLocalTime();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -170,6 +170,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
     private final static MathContext MATH_CONTEXT = MathContext.DECIMAL32;
 
+    private final static int DEFAULT_YEAR = 1900;
     private final static int TWO_DIGIT_YEAR = 20;
     private final static char VALUE_SEPARATOR = ';';
 
@@ -5099,6 +5100,11 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         return new FakeSpreadsheetEngineContext() {
 
             @Override
+            public int defaultYear() {
+                return DEFAULT_YEAR;
+            }
+
+            @Override
             public ExpressionNumberKind expressionNumberKind() {
                 return BasicSpreadsheetEngineTest.this.expressionNumberKind();
             }
@@ -5371,6 +5377,12 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 .setExpression(
                         token.toExpression(
                                 new FakeExpressionEvaluationContext() {
+
+                                    @Override
+                                    public int defaultYear() {
+                                        return DEFAULT_YEAR;
+                                    }
+
                                     @Override
                                     public ExpressionNumberKind expressionNumberKind() {
                                         return expressionNumberKind;

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternsTest.java
@@ -319,7 +319,7 @@ public final class SpreadsheetDateParsePatternsTest extends SpreadsheetParsePatt
     public void testConvertDateOnlyPatternDefaultsYear() {
         this.convertAndCheck2("dd/mm",
                 "31/12",
-                LocalDate.of(0, 12, 31));
+                LocalDate.of(DEFAULT_YEAR, 12, 31));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternsTest.java
@@ -389,28 +389,28 @@ public final class SpreadsheetDateTimeParsePatternsTest extends SpreadsheetParse
     public void testConvertHourMinutesOnlyPattern() {
         this.convertAndCheck2("hh:mm",
                 "11:59",
-                LocalDateTime.of(0, 1, 1, 11, 59));
+                LocalDateTime.of(DEFAULT_YEAR, 1, 1, 11, 59));
     }
 
     @Test
     public void testConvertHourMinutesSecondsOnlyPattern() {
         this.convertAndCheck2("hh:mm:ss",
                 "11:58:59",
-                LocalDateTime.of(0, 1, 1, 11, 58, 59));
+                LocalDateTime.of(DEFAULT_YEAR, 1, 1, 11, 58, 59));
     }
 
     @Test
     public void testConvertHourMinutesSecondsAmpmOnlyPattern() {
         this.convertAndCheck2("hh:mm:ss AM/PM",
                 "11:58:59 PM",
-                LocalDateTime.of(0, 1, 1, 23, 58, 59));
+                LocalDateTime.of(DEFAULT_YEAR, 1, 1, 23, 58, 59));
     }
 
     @Test
     public void testConvertHourDefaultsMinutes() {
         this.convertAndCheck2("hh",
                 "11",
-                LocalDateTime.of(0, 1, 1, 11, 0, 0));
+                LocalDateTime.of(DEFAULT_YEAR, 1, 1, 11, 0, 0));
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
@@ -65,6 +65,7 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
         V> extends SpreadsheetPatternTestCase<P, List<T>>
         implements ConverterTesting {
 
+    final static int DEFAULT_YEAR = 1900;
     final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
     final static char VALUE_SEPARATOR = ',';
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1206,6 +1206,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
         final ExpressionEvaluationContext expressionEvaluationContext = new FakeExpressionEvaluationContext() {
             @Override
+            public int defaultYear() {
+                return 1900;
+            }
+
+            @Override
             public ExpressionNumberKind expressionNumberKind() {
                 return EXPRESSION_NUMBER_KIND;
             }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateParserTokenTest.java
@@ -100,7 +100,7 @@ public final class SpreadsheetDateParserTokenTest extends SpreadsheetParentParse
     @Test
     public void testToExpressionDayNumberMonthNumber() {
         this.toExpressionAndCheck2(
-                LocalDate.of(0, MONTH, DAY),
+                LocalDate.of(DEFAULT_YEAR, MONTH, DAY),
                 dayNumber(),
                 slashTextLiteral(),
                 monthNumber()
@@ -160,7 +160,7 @@ public final class SpreadsheetDateParserTokenTest extends SpreadsheetParentParse
     private void toExpressionAndCheck2(final LocalDate expected,
                                        final SpreadsheetParserToken...tokens) {
         this.toExpressionAndCheck2(
-                this.expressionEvaluationContext(20),
+                this.expressionEvaluationContext(DEFAULT_YEAR, 20),
                 expected,
                 tokens
         );

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetDateTimeParserTokenTest.java
@@ -122,7 +122,7 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
     @Test
     public void testToExpressionDayNumberMonthNumber() {
         this.toExpressionAndCheck2(
-                LocalDate.of(0, MONTH, DAY),
+                LocalDate.of(DEFAULT_YEAR, MONTH, DAY),
                 dayNumber(),
                 slashTextLiteral(),
                 monthNumber()
@@ -136,6 +136,16 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
                 dayNumber(),
                 slashTextLiteral(),
                 year()
+        );
+    }
+
+    @Test
+    public void testToExpressionDayNumber() {
+        this.toExpressionAndCheck2(
+                LocalDate.of(DEFAULT_YEAR, MONTH, DAY),
+                dayNumber(),
+                slashTextLiteral(),
+                monthName()
         );
     }
 
@@ -251,7 +261,7 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
     @Test
     public void testToExpressionMonthNumberYearBeforeTwoDigitYearBefore2() {
         this.toExpressionAndCheck2(
-                this.expressionEvaluationContext(50),
+                this.expressionEvaluationContext(DEFAULT_YEAR, 50),
                 LocalDate.of(2040, MONTH, 1),
                 monthNumber(),
                 slashTextLiteral(),
@@ -262,7 +272,7 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
     private void toExpressionAndCheck2(final LocalDate expected,
                                        final SpreadsheetParserToken... tokens) {
         this.toExpressionAndCheck2(
-                this.expressionEvaluationContext(20),
+                this.expressionEvaluationContext(DEFAULT_YEAR, 20),
                 LocalDateTime.of(
                         expected,
                         LocalTime.of(0, 0)
@@ -288,7 +298,7 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
                                        final SpreadsheetParserToken... tokens) {
         this.toExpressionAndCheck2(
                 LocalDateTime.of(
-                        LocalDate.of(0, 1, 1),
+                        LocalDate.of(DEFAULT_YEAR, 1, 1),
                         expected
                 ),
                 tokens
@@ -298,7 +308,7 @@ public final class SpreadsheetDateTimeParserTokenTest extends SpreadsheetParentP
     private void toExpressionAndCheck2(final LocalDateTime expected,
                                        final SpreadsheetParserToken... tokens) {
         this.toExpressionAndCheck2(
-                this.expressionEvaluationContext(20),
+                this.expressionEvaluationContext(DEFAULT_YEAR, 20),
                 expected,
                 tokens
         );

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParentParserTokenTestCase.java
@@ -235,8 +235,15 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
         return EXPRESSION_NUMBER_KIND.create(value);
     }
 
-    final ExpressionEvaluationContext expressionEvaluationContext(final int twoDigitYear) {
+    final ExpressionEvaluationContext expressionEvaluationContext(final int defaultYear,
+                                                                  final int twoDigitYear) {
         return new FakeExpressionEvaluationContext() {
+
+            @Override
+            public int defaultYear() {
+                return defaultYear;
+            }
+
             @Override
             public int twoDigitYear() {
                 return twoDigitYear;

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenTestCase.java
@@ -44,9 +44,16 @@ public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParser
         JsonNodeMarshallingTesting<T>,
         ParserTokenTesting<T> {
 
+    final static int DEFAULT_YEAR = 1900;
     final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
     final static int TWO_DIGIT_YEAR = 20;
     final static ExpressionEvaluationContext EXPRESSION_EVALUATION_CONTEXT = new FakeExpressionEvaluationContext() {
+
+        @Override
+        public int defaultYear() {
+            return DEFAULT_YEAR;
+        }
+
         @Override
         public ExpressionNumberKind expressionNumberKind() {
             return EXPRESSION_NUMBER_KIND;

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorLocalDateTimeTest.java
@@ -21,7 +21,7 @@ public final class SpreadsheetParserTokenVisitorLocalDateTimeTest extends Spread
 
     @Override
     public SpreadsheetParserTokenVisitorLocalDateTime createVisitor() {
-        return new SpreadsheetParserTokenVisitorLocalDateTime();
+        return new SpreadsheetParserTokenVisitorLocalDateTime(0);
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1309
- Default year when parsing date or date/time (new SpreadsheetMetadata property) "default-year"