### PR TITLE
SpreadsheetMetadata.DATE_TIME_OFFSET removed from defaults blacklist

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -369,8 +369,7 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name, Compar
      * Defaults must not include a spreadsheet-id, email address or timestamp.
      */
     final boolean isInvalidGenericProperty() {
-        return this instanceof SpreadsheetMetadataPropertyNameDateTimeOffset ||
-                this instanceof SpreadsheetMetadataPropertyNameEmailAddress ||
+        return this instanceof SpreadsheetMetadataPropertyNameEmailAddress ||
                 this instanceof SpreadsheetMetadataPropertyNameLocalDateTime ||
                 this instanceof SpreadsheetMetadataPropertyNameSpreadsheetId;
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
@@ -322,11 +322,6 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
     }
 
     @Test
-    public final void testSetDefaultsIncludesDateTimeOffsetFails() {
-        this.setDefaultsWithInvalidFails(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, 123L);
-    }
-
-    @Test
     public final void testSetDefaultsIncludesModifiedByFails() {
         this.setDefaultsWithInvalidFails(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
     }


### PR DESCRIPTION
- previously the blacklist prevented a "default" date-time-offset.

- related https://github.com/mP1/walkingkooka-spreadsheet-react/issues/591
- Settings: date-time-offset missing default button