### PR TITLE
walkingkooka-spreadsheet/issues/1367 SpreadsheetNumberParserPatterns.…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponent.java
@@ -50,7 +50,7 @@ abstract class SpreadsheetNumberParsePatternsComponent {
      */
     static SpreadsheetNumberParsePatternsComponent digit(final SpreadsheetNumberParsePatternsComponentDigitMode mode,
                                                          final int max) {
-        return SpreadsheetNumberParsePatternsComponentDigitDigit.with(mode,max);
+        return SpreadsheetNumberParsePatternsComponentDigitDigit.with(mode, max);
     }
 
     /**
@@ -93,6 +93,13 @@ abstract class SpreadsheetNumberParsePatternsComponent {
     }
 
     /**
+     * {@see SpreadsheetNumberParsePatternsComponentThousandsSeparator}
+     */
+    static SpreadsheetNumberParsePatternsComponent thousands() {
+        return SpreadsheetNumberParsePatternsComponentThousandsSeparator.INSTANCE;
+    }
+
+    /**
      * {@see SpreadsheetNumberParsePatternsComponentWhitespace}
      */
     @SuppressWarnings("SameReturnValue")
@@ -113,12 +120,22 @@ abstract class SpreadsheetNumberParsePatternsComponent {
      */
     abstract SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode);
 
+    // used within Streams as a method reference
+    final boolean isNotExpressionCompatible() {
+        return !this.isExpressionCompatible();
+    }
+
+    /**
+     * Some components (grouping separator) are not valid within an expression but are valid as a number literal.
+     */
+    abstract boolean isExpressionCompatible();
+
     /**
      * Each component in turn is asked to consume and possibly update the number value in the context.
      * A return value of false indicates matching was completed.
      */
     abstract boolean parse(final TextCursor cursor,
-                        final SpreadsheetNumberParsePatternsRequest request);
+                           final SpreadsheetNumberParsePatternsRequest request);
 
     /**
      * Advances the cursor attempting to match the given token in full.

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrency.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentCurrency.java
@@ -36,8 +36,13 @@ final class SpreadsheetNumberParsePatternsComponentCurrency extends SpreadsheetN
     }
 
     @Override
+    boolean isExpressionCompatible() {
+        return true;
+    }
+
+    @Override
     boolean parse(final TextCursor cursor,
-               final SpreadsheetNumberParsePatternsRequest request) {
+                  final SpreadsheetNumberParsePatternsRequest request) {
         return this.parseToken(
                 cursor,
                 request.context.currencySymbol(),

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDecimalSeparator.java
@@ -35,8 +35,13 @@ final class SpreadsheetNumberParsePatternsComponentDecimalSeparator extends Spre
     }
 
     @Override
+    boolean isExpressionCompatible() {
+        return true;
+    }
+
+    @Override
     boolean parse(final TextCursor cursor,
-               final SpreadsheetNumberParsePatternsRequest request) {
+                  final SpreadsheetNumberParsePatternsRequest request) {
         boolean completed = false;
 
         if (false == cursor.isEmpty()) {

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigit.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentDigit.java
@@ -37,11 +37,16 @@ abstract class SpreadsheetNumberParsePatternsComponentDigit extends SpreadsheetN
     }
 
     @Override
+    final boolean isExpressionCompatible() {
+        return true;
+    }
+
+    @Override
     final boolean parse(final TextCursor cursor,
-                     final SpreadsheetNumberParsePatternsRequest request) {
+                        final SpreadsheetNumberParsePatternsRequest request) {
         boolean completed;
 
-        if(cursor.isEmpty()) {
+        if (cursor.isEmpty()) {
             completed = request.nextComponent(cursor);
         } else {
             request.digitMode.tryParseSign(cursor, request);

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercent.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentPercent.java
@@ -36,8 +36,13 @@ final class SpreadsheetNumberParsePatternsComponentPercent extends SpreadsheetNu
     }
 
     @Override
+    boolean isExpressionCompatible() {
+        return false;
+    }
+
+    @Override
     boolean parse(final TextCursor cursor,
-               final SpreadsheetNumberParsePatternsRequest request) {
+                  final SpreadsheetNumberParsePatternsRequest request) {
         final char percentSymbol = request.context.percentageSymbol();
         return this.parseToken(
                 cursor,

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteral.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTextLiteral.java
@@ -34,8 +34,13 @@ final class SpreadsheetNumberParsePatternsComponentTextLiteral extends Spreadshe
     }
 
     @Override
+    boolean isExpressionCompatible() {
+        return this.text.equals(";"); // Pattern separator is ok!
+    }
+
+    @Override
     boolean parse(final TextCursor cursor,
-               final SpreadsheetNumberParsePatternsRequest request) {
+                  final SpreadsheetNumberParsePatternsRequest request) {
         // not consumed
         return request.nextComponent(cursor);
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentThousandsSeparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentThousandsSeparator.java
@@ -17,47 +17,35 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
-import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
-import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
- * A {@link SpreadsheetNumberParsePatternsComponent} that matches an exponent and switches parsing to exponent parsing mode.
+ * A {@link SpreadsheetNumberParsePatternsComponent} that does not actually expect or consume the grouping character.
  */
-final class SpreadsheetNumberParsePatternsComponentExponent extends SpreadsheetNumberParsePatternsComponent2 {
+final class SpreadsheetNumberParsePatternsComponentThousandsSeparator extends SpreadsheetNumberParsePatternsComponent2 {
 
     /**
      * Singleton
      */
-    final static SpreadsheetNumberParsePatternsComponentExponent INSTANCE = new SpreadsheetNumberParsePatternsComponentExponent();
+    final static SpreadsheetNumberParsePatternsComponentThousandsSeparator INSTANCE = new SpreadsheetNumberParsePatternsComponentThousandsSeparator();
 
-    /**
-     * Private ctor use singleton.
-     */
-    private SpreadsheetNumberParsePatternsComponentExponent() {
+    private SpreadsheetNumberParsePatternsComponentThousandsSeparator() {
         super();
     }
 
     @Override
     boolean isExpressionCompatible() {
-        return true;
+        return false;
     }
 
     @Override
     boolean parse(final TextCursor cursor,
                   final SpreadsheetNumberParsePatternsRequest request) {
-        return this.parseToken(
-                cursor,
-                request.context.exponentSymbol(),
-                CaseSensitivity.INSENSITIVE,
-                SpreadsheetParserToken::exponentSymbol,
-                SpreadsheetNumberParsePatternsComponentDigitMode.EXPONENT_OR_SIGN,
-                request
-        );
+        return request.nextComponent(cursor);
     }
 
     @Override
     public String toString() {
-        return "E";
+        return ",";
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespace.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentWhitespace.java
@@ -34,8 +34,13 @@ final class SpreadsheetNumberParsePatternsComponentWhitespace extends Spreadshee
     }
 
     @Override
+    boolean isExpressionCompatible() {
+        return false;
+    }
+
+    @Override
     boolean parse(final TextCursor cursor,
-               final SpreadsheetNumberParsePatternsRequest request) {
+                  final SpreadsheetNumberParsePatternsRequest request) {
         // not consumed
         return request.nextComponent(cursor);
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParser.java
@@ -45,6 +45,8 @@ final class SpreadsheetNumberParsePatternsParser implements Parser<SpreadsheetPa
         super();
         this.pattern = pattern;
         this.mode = mode;
+
+        this.mode.checkCompatible(pattern);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsSpreadsheetFormatParserTokenVisitor.java
@@ -35,6 +35,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserTokenVisito
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatPercentParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatSecondParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatThousandsParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTimeParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatYearParserToken;
 import walkingkooka.visit.Visiting;
@@ -190,6 +191,11 @@ final class SpreadsheetNumberParsePatternsSpreadsheetFormatParserTokenVisitor ex
     @Override
     protected void visit(final SpreadsheetFormatSecondParserToken token) {
         this.failInvalid(token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatThousandsParserToken token) {
+        this.addComponent(SpreadsheetNumberParsePatternsComponent.thousands());
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentTestCase.java
@@ -60,6 +60,12 @@ public abstract class SpreadsheetNumberParsePatternsComponentTestCase<C extends 
     private Iterator<SpreadsheetNumberParsePatternsComponent> next() {
         return Iterators.one(
                 new SpreadsheetNumberParsePatternsComponent() {
+
+                    @Override
+                    boolean isExpressionCompatible() {
+                        return true;
+                    }
+
                     @Override
                     SpreadsheetNumberParsePatternsComponent lastDigit(final SpreadsheetNumberParsePatternsComponentDigitMode mode) {
                         throw new UnsupportedOperationException();
@@ -67,7 +73,7 @@ public abstract class SpreadsheetNumberParsePatternsComponentTestCase<C extends 
 
                     @Override
                     boolean parse(final TextCursor cursor,
-                               final SpreadsheetNumberParsePatternsRequest request) {
+                                  final SpreadsheetNumberParsePatternsRequest request) {
                         return true;
                     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentThousandsSeparatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsComponentThousandsSeparatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.pattern;
+
+import org.junit.jupiter.api.Test;
+
+public final class SpreadsheetNumberParsePatternsComponentThousandsSeparatorTest extends SpreadsheetNumberParsePatternsComponentTestCase2<SpreadsheetNumberParsePatternsComponentThousandsSeparator> {
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createComponent(), ",");
+    }
+
+    @Override
+    SpreadsheetNumberParsePatternsComponentThousandsSeparator createComponent() {
+        return SpreadsheetNumberParsePatternsComponentThousandsSeparator.INSTANCE;
+    }
+
+    // ClassTesting.....................................................................................................
+
+    @Override
+    public Class<SpreadsheetNumberParsePatternsComponentThousandsSeparator> type() {
+        return SpreadsheetNumberParsePatternsComponentThousandsSeparator.class;
+    }
+
+    // TypeNameTesting..................................................................................................
+
+    @Override
+    public String typeNameSuffix() {
+        return "ThousandsSeparator";
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsParserTest.java
@@ -39,6 +39,8 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class SpreadsheetNumberParsePatternsParserTest extends SpreadsheetNumberParsePatternsTestCase2<SpreadsheetNumberParsePatternsParser>
         implements ParserTesting2<SpreadsheetNumberParsePatternsParser, SpreadsheetParserContext> {
 
@@ -47,6 +49,27 @@ public final class SpreadsheetNumberParsePatternsParserTest extends SpreadsheetN
     @Test
     public void testHashInvalidFails() {
         this.parseAndFail2("#", "A");
+    }
+
+    // expression parser fail...........................................................................................
+
+    @Test
+    public void testExpressionGroupingSeparatorFails() {
+        this.parseExpressionFails("#,###.##");
+    }
+
+    @Test
+    public void testExpressionTextLiteralFails() {
+        this.parseExpressionFails("#\"text\"#");
+    }
+
+    @Test
+    public void testExpressionPercentFails() {
+        this.parseExpressionFails("#.#%");
+    }
+
+    private void parseExpressionFails(final String pattern) {
+        assertThrows(IllegalStateException.class, () -> SpreadsheetNumberParsePatterns.parseNumberParsePatterns(pattern).expressionParser());
     }
 
     // integer values single digit pattern..............................................................................


### PR DESCRIPTION
…expressionParser() should fail if text literal, grouping separator, percent are present

- Added SpreadsheetNumberParsePatternsComponentThousandsSeparator component, doesnt consume any characters during parsing.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1367
- SpreadsheetNumberParserPatterns.expressionParser() should fail if text literal, grouping separator, percent are present