### PR TITLE
SpreadsheetParsePatterns datetime & time seconds/ampm permutations

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
@@ -58,9 +58,10 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern extends 
 
     @Override
     Optional<SpreadsheetDateFormatPattern> extractLocaleValue(final Locale locale) {
-        return this.extractLocaleSimpleDateFormat(locale,
-                (l) -> DateFormat.getDateInstance(DateFormat.FULL, l),
-                SpreadsheetDateFormatPattern::parseDateFormatPattern);
+        return this.extractLocaleSimpleDateFormat(
+                DateFormat.getDateInstance(DateFormat.FULL, locale),
+                SpreadsheetDateFormatPattern::parseDateFormatPattern
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns.java
@@ -17,8 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePatterns;
-import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePatterns;
 
 import java.text.DateFormat;
 import java.util.Locale;
@@ -59,14 +60,15 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns extends 
 
     @Override
     Optional<SpreadsheetDateParsePatterns> extractLocaleValue(final Locale locale) {
-        return dateFormatThenParsePattern(locale,
-                SpreadsheetMetadataPropertyNameSpreadsheetDateParsePatterns::simpleDateFormatParse,
-                SpreadsheetParsePatterns::parseDateParsePatterns);
-    }
-
-    private static String simpleDateFormatParse(final int style,
-                                                final Locale locale) {
-        return toPattern(DateFormat.getDateInstance(style, locale));
+        return this.extractLocaleSimpleDateFormat(
+                Lists.of(
+                        DateFormat.getDateInstance(DateFormat.FULL, locale),
+                        DateFormat.getDateInstance(DateFormat.LONG, locale),
+                        DateFormat.getDateInstance(DateFormat.MEDIUM, locale),
+                        DateFormat.getDateInstance(DateFormat.SHORT, locale)
+                ),
+                SpreadsheetDateFormatPattern::parseDateParsePatterns
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 
@@ -58,21 +57,14 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern exte
         visitor.visitDateTimeFormatPattern(value);
     }
 
-    @Override
     Optional<SpreadsheetDateTimeFormatPattern> extractLocaleValue(final Locale locale) {
-        return this.extractLocaleSimpleDateFormat(locale,
-                (l) -> DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, l),
-                SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern::parseDateTimeFormatPattern);
-    }
-
-    private static SpreadsheetDateTimeFormatPattern parseDateTimeFormatPattern(final String text) {
-        final SpreadsheetDateTimeFormatPattern pattern = SpreadsheetPattern.parseDateTimeFormatPattern(text);
-
-        return SpreadsheetPattern.dateTimeFormatPattern(
-                SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsSpreadsheetFormatParserTokenVisitor.fix(
-                        pattern.value(),
-                        SpreadsheetFormatParserToken::dateTime
-                )
+        return this.extractLocaleSimpleDateFormat(
+                DateFormat.getDateTimeInstance(
+                        DateFormat.FULL,
+                        DateFormat.FULL,
+                        locale
+                ),
+                SpreadsheetPattern::parseDateTimeFormatPattern
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns.java
@@ -17,15 +17,14 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatDateTimeParserToken;
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeParsePatterns;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 
 import java.text.DateFormat;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns extends SpreadsheetMetadataPropertyName<SpreadsheetDateTimeParsePatterns> {
 
@@ -62,39 +61,23 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns exte
 
     @Override
     Optional<SpreadsheetDateTimeParsePatterns> extractLocaleValue(final Locale locale) {
-        final StringBuilder pattern = new StringBuilder();
+        final List<DateFormat> patterns = Lists.array();
 
-        String separator = "";
-
-        for (final int dateStyle : styles) {
-            for (final int timeStyle : styles) {
-                pattern.append(separator);
-                pattern.append(toPattern(DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale)));
-                separator = ";";
+        for (final int dateStyle : DATE_FORMAT_STYLES) {
+            for (final int timeStyle : DATE_FORMAT_STYLES) {
+                patterns.add(
+                        DateFormat.getDateTimeInstance(
+                                dateStyle,
+                                timeStyle,
+                                locale
+                        )
+                );
             }
         }
 
-        return Optional.of(SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns.parseDateTimeParsePatterns(pattern.toString()));
-    }
-
-    private final static int[] styles = new int[]{DateFormat.FULL, DateFormat.LONG, DateFormat.MEDIUM, DateFormat.SHORT};
-
-    private static SpreadsheetDateTimeParsePatterns parseDateTimeParsePatterns(final String text) {
-        final SpreadsheetDateTimeParsePatterns pattern = SpreadsheetPattern.parseDateTimeParsePatterns(text);
-
-        return SpreadsheetPattern.dateTimeParsePatterns(
-                pattern
-                        .value()
-                        .stream()
-                        .map(SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatterns::parseDateTimeParsePatterns0)
-                        .collect(Collectors.toList())
-        );
-    }
-
-    private static SpreadsheetFormatDateTimeParserToken parseDateTimeParsePatterns0(final SpreadsheetFormatDateTimeParserToken token) {
-        return SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsSpreadsheetFormatParserTokenVisitor.fix(
-                token,
-                SpreadsheetFormatParserToken::dateTime
+        return this.extractLocaleSimpleDateFormat(
+                patterns,
+                SpreadsheetPattern::parseDateTimeParsePatterns
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeFormatPattern;
 
@@ -61,19 +60,11 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern extends 
     @Override
     Optional<SpreadsheetTimeFormatPattern> extractLocaleValue(final Locale locale) {
         return this.extractLocaleSimpleDateFormat(
-                locale,
-                (l) -> DateFormat.getTimeInstance(DateFormat.FULL, l),
-                SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern::parseTimeFormatPattern
-        );
-    }
-
-    private static SpreadsheetTimeFormatPattern parseTimeFormatPattern(final String text) {
-        final SpreadsheetTimeFormatPattern pattern = SpreadsheetPattern.parseTimeFormatPattern(text);
-        return SpreadsheetPattern.timeFormatPattern(
-                SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsSpreadsheetFormatParserTokenVisitor.fix(
-                        pattern.value(),
-                        SpreadsheetFormatParserToken::time
-                )
+                DateFormat.getTimeInstance(
+                        DateFormat.FULL,
+                        locale
+                ),
+                SpreadsheetPattern::parseTimeFormatPattern
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns.java
@@ -17,15 +17,14 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
-import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTimeParserToken;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeParsePatterns;
 
 import java.text.DateFormat;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 final class SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns extends SpreadsheetMetadataPropertyName<SpreadsheetTimeParsePatterns> {
 
@@ -60,33 +59,21 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns extends 
         visitor.visitTimeParsePatterns(value);
     }
 
-    @Override
     Optional<SpreadsheetTimeParsePatterns> extractLocaleValue(final Locale locale) {
-        return dateFormatThenParsePattern(locale,
-                SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns::simpleDateFormatParse,
-                SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns::parseTimeParsePatterns);
-    }
+        final List<DateFormat> patterns = Lists.array();
 
-    private static String simpleDateFormatParse(final int style,
-                                                final Locale locale) {
-        return toPattern(DateFormat.getTimeInstance(style, locale));
-    }
+        for (final int timeStyle : DATE_FORMAT_STYLES) {
+            patterns.add(
+                    DateFormat.getTimeInstance(
+                            timeStyle,
+                            locale
+                    )
+            );
+        }
 
-    private static SpreadsheetTimeParsePatterns parseTimeParsePatterns(final String text) {
-        final SpreadsheetTimeParsePatterns pattern = SpreadsheetPattern.parseTimeParsePatterns(text);
-        return SpreadsheetPattern.timeParsePatterns(
-                pattern
-                        .value()
-                        .stream()
-                        .map(SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatterns::parseTimeParsePatterns0)
-                        .collect(Collectors.toList())
-        );
-    }
-
-    private static SpreadsheetFormatTimeParserToken parseTimeParsePatterns0(final SpreadsheetFormatTimeParserToken token) {
-        return SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsSpreadsheetFormatParserTokenVisitor.fix(
-                token,
-                SpreadsheetFormatParserToken::time
+        return this.extractLocaleSimpleDateFormat(
+                patterns,
+                SpreadsheetPattern::parseTimeParsePatterns
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitorTest.java
@@ -111,7 +111,11 @@ public final class SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor
                 final SimpleDateFormat dateFormat = (SimpleDateFormat)localeToFormatPattern.apply(locale);
                 pattern = dateFormat.toPattern();
                 assertNotEquals("",
-                        SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor.pattern(pattern),
+                        SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor.pattern(
+                                pattern,
+                                false, // ignoreSeconds
+                                false // ignoreAmpm
+                        ),
                         () -> "" + locale);
             } catch (final UnsupportedOperationException cause) {
                 throw new UnsupportedOperationException(pattern + " " + locale.toLanguageTag() + " " + cause.getMessage(), cause);
@@ -121,7 +125,7 @@ public final class SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor
 
     @Override
     public SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor createVisitor() {
-        return new SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor();
+        return new SpreadsheetMetadataPropertyNameSimpleDateFormatPatternVisitor(false, false);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatternsTest.java
@@ -29,7 +29,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePatter
     public void testExtractLocaleValue() {
         this.extractLocaleValueAndCheck(
                 Locale.ENGLISH,
-                SpreadsheetDateParsePatterns.parseDateTimeParsePatterns("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm AM/PM;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy, h:mm:ss AM/PM;mmmm d, yyyy, h:mm AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm AM/PM")
+                SpreadsheetDateParsePatterns.parseDateTimeParsePatterns("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss;dddd, mmmm d, yyyy \\a\\t h:mm AM/PM;dddd, mmmm d, yyyy, h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm:ss;dddd, mmmm d, yyyy, h:mm AM/PM;dddd, mmmm d, yyyy, h:mm;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy \\a\\t h:mm:ss;mmmm d, yyyy \\a\\t h:mm AM/PM;mmmm d, yyyy, h:mm:ss AM/PM;mmmm d, yyyy, h:mm:ss;mmmm d, yyyy, h:mm AM/PM;mmmm d, yyyy, h:mm;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss;mmm d, yyyy, h:mm AM/PM;mmm d, yyyy, h:mm;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss;m/d/yy, h:mm AM/PM;m/d/yy, h:mm")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsTest.java
@@ -26,8 +26,10 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePatternsTe
 
     @Test
     public void testExtractLocaleValue() {
-        this.extractLocaleValueAndCheck(Locale.ENGLISH,
-                SpreadsheetTimeParsePatterns.parseTimeParsePatterns("h:mm:ss AM/PM;h:mm:ss AM/PM;h:mm:ss AM/PM;h:mm AM/PM"));
+        this.extractLocaleValueAndCheck(
+                Locale.ENGLISH,
+                SpreadsheetTimeParsePatterns.parseTimeParsePatterns("h:mm:ss AM/PM;h:mm:ss;h:mm AM/PM;h:mm")
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -224,7 +224,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
                         .set(SpreadsheetMetadataPropertyName.DATE_FORMAT_PATTERN, SpreadsheetPattern.parseDateFormatPattern("dddd, mmmm d, yyyy"))
                         .set(SpreadsheetMetadataPropertyName.DATE_PARSE_PATTERNS, SpreadsheetPattern.parseDateParsePatterns("dddd, mmmm d, yyyy;mmmm d, yyyy;mmm d, yyyy;m/d/yy"))
                         .set(SpreadsheetMetadataPropertyName.DATETIME_FORMAT_PATTERN, SpreadsheetPattern.parseDateTimeFormatPattern("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM"))
-                        .set(SpreadsheetMetadataPropertyName.DATETIME_PARSE_PATTERNS, SpreadsheetPattern.parseDateTimeParsePatterns("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm AM/PM;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy, h:mm:ss AM/PM;mmmm d, yyyy, h:mm AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm AM/PM"))
+                        .set(SpreadsheetMetadataPropertyName.DATETIME_PARSE_PATTERNS, SpreadsheetPattern.parseDateTimeParsePatterns("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss;dddd, mmmm d, yyyy \\a\\t h:mm AM/PM;dddd, mmmm d, yyyy, h:mm:ss AM/PM;dddd, mmmm d, yyyy, h:mm:ss;dddd, mmmm d, yyyy, h:mm AM/PM;dddd, mmmm d, yyyy, h:mm;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yyyy \\a\\t h:mm:ss;mmmm d, yyyy \\a\\t h:mm AM/PM;mmmm d, yyyy, h:mm:ss AM/PM;mmmm d, yyyy, h:mm:ss;mmmm d, yyyy, h:mm AM/PM;mmmm d, yyyy, h:mm;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yyyy, h:mm:ss;mmm d, yyyy, h:mm AM/PM;mmm d, yyyy, h:mm;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss;m/d/yy, h:mm AM/PM;m/d/yy, h:mm"))
                         .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, '.')
                         .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
                         .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, ',')
@@ -235,7 +235,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
                         .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, '%')
                         .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, '+')
                         .set(SpreadsheetMetadataPropertyName.TIME_FORMAT_PATTERN, SpreadsheetPattern.parseTimeFormatPattern("h:mm:ss AM/PM"))
-                        .set(SpreadsheetMetadataPropertyName.TIME_PARSE_PATTERNS, SpreadsheetPattern.parseTimeParsePatterns("h:mm:ss AM/PM;h:mm:ss AM/PM;h:mm:ss AM/PM;h:mm AM/PM"))
+                        .set(SpreadsheetMetadataPropertyName.TIME_PARSE_PATTERNS, SpreadsheetPattern.parseTimeParsePatterns("h:mm:ss AM/PM;h:mm:ss;h:mm AM/PM;h:mm"))
                         .set(SpreadsheetMetadataPropertyName.VALUE_SEPARATOR, ','),
                 SpreadsheetMetadata.EMPTY.set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH).loadFromLocale());
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1404
- When generating datetime & time patterns from Locale and DateTimeFormatter need to generate version without am/pm, without seconds, without seconds ampm

- remove duplicate patterns, could happen that FULL, LONG, MEDIUM, SHORT may not be unique.