### PR TITLE
SpreadsheetParsePatterns.parser().toString() returns pattern

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2.java
@@ -113,6 +113,7 @@ abstract class SpreadsheetParsePatterns2<F extends SpreadsheetFormatParserToken,
                         .mapToObj(this::createParser0)
                         .collect(Collectors.toList())
         ).transform(this::parserTransform)
+                .setToString(this.toString())
                 .cast();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternsTestCase.java
@@ -301,9 +301,16 @@ public abstract class SpreadsheetParsePatternsTestCase<P extends SpreadsheetPars
         };
     }
 
+    @Test
+    public final void testParserToString() {
+        final P pattern = this.createPattern();
+        this.toStringAndCheck(pattern.parser(), pattern.toString());
+    }
+
     static SpreadsheetAmPmParserToken am() {
         return SpreadsheetParserToken.amPm(0, "AM");
     }
+
     static SpreadsheetTextLiteralParserToken colon() {
         return textLiteral(":");
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternsTest.java
@@ -108,6 +108,12 @@ public final class SpreadsheetTimeParsePatternsTest extends SpreadsheetParsePatt
     // parser...........................................................................................................
 
     @Test
+    public void testParserToString2() {
+        final String pattern = "hh:mm:ss";
+        this.toStringAndCheck(SpreadsheetTimeParsePatterns.parseTimeParsePatterns(pattern).parser(), pattern);
+    }
+
+    @Test
     public void testParseHour9() {
         this.parseAndCheck2(
                 "h",


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1431
- SpreadsheetParsePatterns.parser() for date/datetime/time .toString() should return pattern

- Also supports SpreadsheetParsePatterns number.