### PR TITLE
SpreadsheetMetadata.toString() quote character and string values

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMap.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMap.java
@@ -78,6 +78,11 @@ final class SpreadsheetMetadataNonEmptyMap extends AbstractMap<SpreadsheetMetada
 
     final SpreadsheetMetadataNonEmptyMapEntrySet entries;
 
+    @Override
+    public String toString() {
+        return this.entries.toString0("{", "}");
+    }
+
     // SpreadsheetMetadataVisitor.......................................................................................
 
     void accept(final SpreadsheetMetadataVisitor visitor) {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapEntrySet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapEntrySet.java
@@ -21,6 +21,7 @@ import walkingkooka.collect.iterator.Iterators;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A read only {@link Set} sorted view of textStyle that have had their values checked.
@@ -102,6 +104,26 @@ final class SpreadsheetMetadataNonEmptyMapEntrySet extends AbstractSet<Entry<Spr
     }
 
     final List<Entry<SpreadsheetMetadataPropertyName<?>, Object>> entries;
+
+    // toString.........................................................................................................
+
+    @Override
+    public String toString() {
+        return toString0("[", "]");
+    }
+
+    /**
+     * This method supports the different surrounding characters of a {@link Map}.
+     */
+    String toString0(final String prefix, final String suffix) {
+        return this.entries.stream()
+                .map(SpreadsheetMetadataNonEmptyMapEntrySet::toStringEntry)
+                .collect(Collectors.joining(", ", prefix, suffix));
+    }
+
+    private static String toStringEntry(final Entry<SpreadsheetMetadataPropertyName<?>, Object> entry) {
+        return entry.getKey() + "=" + CharSequences.quoteIfChars(entry.getValue());
+    }
 
     // SpreadsheetMetadataVisitor.......................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapEntrySetTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapEntrySetTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.iterator.IteratorTesting;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.SetTesting2;
+import walkingkooka.collect.set.Sets;
 import walkingkooka.net.email.EmailAddress;
 
 import java.time.LocalDateTime;
@@ -68,7 +69,27 @@ public final class SpreadsheetMetadataNonEmptyMapEntrySetTest implements SetTest
         map.put(this.property1(), this.value1());
         map.put(this.property2(), this.value2());
 
+        System.out.println("@@@" + Sets.of(property1(), value1()));
+
         this.toStringAndCheck(this.createSet(), map.entrySet().toString());
+    }
+
+    @Test
+    public void testToStringCharacterValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, '.');
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmptyMapEntrySet.with(map), "[decimal-separator='.', modified-by=modified@example.com]");
+    }
+
+    @Test
+    public void testToStringStringValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "AUD");
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmptyMapEntrySet.with(map), "[currency-symbol=\"AUD\", modified-by=modified@example.com]");
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyMapTest.java
@@ -96,6 +96,24 @@ public final class SpreadsheetMetadataNonEmptyMapTest implements MapTesting2<Spr
         this.toStringAndCheck(this.createMap(), map.toString());
     }
 
+    @Test
+    public void testToStringCharacterValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, '.');
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmptyMap.with(map), "{decimal-separator='.', modified-by=modified@example.com}");
+    }
+
+    @Test
+    public void testToStringStringValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "AUD");
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmptyMap.with(map), "{currency-symbol=\"AUD\", modified-by=modified@example.com}");
+    }
+
     @Override
     public SpreadsheetMetadataNonEmptyMap createMap() {
         final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.ordered();

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1321,6 +1321,24 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         this.toStringAndCheck(SpreadsheetMetadataNonEmpty.with(map), map.toString());
     }
 
+    @Test
+    public void testToStringCharacterValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, '.');
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmpty.with(map), "{decimal-separator='.', modified-by=modified@example.com}");
+    }
+
+    @Test
+    public void testToStringStringValue() {
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
+        map.put(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "AUD");
+        map.put(SpreadsheetMetadataPropertyName.MODIFIED_BY, EmailAddress.parse("modified@example.com"));
+
+        this.toStringAndCheck(SpreadsheetMetadataNonEmpty.with(map), "{currency-symbol=\"AUD\", modified-by=modified@example.com}");
+    }
+
     // JsonNodeMarshallingTesting...........................................................................................
 
     @Test


### PR DESCRIPTION
- Note values which hold a String like creator are not quoted but use EmailAddress.toString() which is not quoted.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1454
- SpreadsheetMetadataNonEmpty.toString() should quote character and String property values