### PR TITLE
SpreadsheetMetadata set Character value swap when duplicate

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -311,6 +311,47 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name, Compar
         this.jsonPropertyName = JsonPropertyName.with(name);
     }
 
+    /**
+     * Setting a {@link Character} property that is a duplicate value of another {@link Character} should result
+     * in the duplicate value being replaced with the value of the property being set.<br>
+     * <pre>
+     * BEFORE
+     * decimal=dot
+     * group=comma
+     * SET
+     * decimal=comma
+     * AFTER
+     * decimal=comma
+     * group=dot
+     * </pre>
+     * Because group held the new value, it actually gains the old value of decimal, aka values were swapped.
+     * Note that grouping and value separator may have the same value and not be considered duplicates.
+     */
+    final boolean swapIfDuplicateValue() {
+        return this.isCharacter();
+    }
+
+    /**
+     * A test to prevent {@link #GROUPING_SEPARATOR} and {@link #VALUE_SEPARATOR} are both Characters, they cannot be duplicates
+     * of each other.
+     */
+    boolean isDuplicateIfValuesEqual(final SpreadsheetMetadataPropertyName<?> possible) {
+        return this.isCharacter() && possible.isCharacter() &&
+                (
+                        (this.isGroupingSeparatorOrValueSeparator() && possible.isGroupingSeparatorOrValueSeparator()) ?
+                                false :
+                                true
+                );
+    }
+
+    private boolean isCharacter() {
+        return this instanceof SpreadsheetMetadataPropertyNameCharacter;
+    }
+
+    private boolean isGroupingSeparatorOrValueSeparator() {
+        return this instanceof SpreadsheetMetadataPropertyNameGroupingSymbol || this instanceof SpreadsheetMetadataPropertyNameValueSeparator;
+    }
+
     @Override
     public final String value() {
         return this.name;

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -277,6 +277,171 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 this.createSpreadsheetMetadata(property1, value1, property2, value2, property3, value3));
     }
 
+    @Test
+    public void testSetNewPropertyAndWithoutSwapValue() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character comma = ',';
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(decimalSeparator, dot),
+                grouping,
+                comma,
+                this.createSpreadsheetMetadata(decimalSeparator, dot, grouping, comma)
+        );
+    }
+
+    @Test
+    public void testSetNewPropertyAndWithoutSwapValue2() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character comma = ',';
+
+        final SpreadsheetMetadataPropertyName<Character> positive = SpreadsheetMetadataPropertyName.POSITIVE_SIGN;
+        final Character plus = '+';
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(decimalSeparator, dot, grouping, comma),
+                positive,
+                plus,
+                this.createSpreadsheetMetadata(decimalSeparator, dot, grouping, comma, positive, plus)
+        );
+    }
+
+    @Test
+    public void testSetNewPropetyGroupingSeparatorAndValueSeparatorWithSameValue() {
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> value = SpreadsheetMetadataPropertyName.VALUE_SEPARATOR;
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(grouping, dot),
+                value,
+                dot,
+                this.createSpreadsheetMetadata(grouping, dot, value, dot)
+        );
+    }
+
+    @Test
+    public void testSetNewPropertyWithDuplicateFails() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> this.createSpreadsheetMetadata(decimalSeparator, dot).set(grouping, dot)
+        );
+
+        assertEquals("Duplicate value grouping-separator='.' and decimal-separator", thrown.getMessage(), "thrown message");
+    }
+
+    @Test
+    public void testSetPropertyCharacterGroupingSeparatorAndValueSeparator() {
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> value = SpreadsheetMetadataPropertyName.VALUE_SEPARATOR;
+        final Character comma = ',';
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(grouping, dot, value, comma),
+                value,
+                dot,
+                this.createSpreadsheetMetadata(grouping, dot, value, dot)
+        );
+    }
+
+    @Test
+    public void testSetPropertyCausesSwap() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character comma = ',';
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(decimalSeparator, dot, grouping, comma),
+                grouping,
+                dot,
+                this.createSpreadsheetMetadata(decimalSeparator, comma, grouping, dot)
+        );
+    }
+
+    @Test
+    public void testSetPropertyCausesSwap2() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character comma = ',';
+
+        final SpreadsheetMetadataPropertyName<Character> positive = SpreadsheetMetadataPropertyName.POSITIVE_SIGN;
+        final Character plus = '+';
+
+        this.setAndCheck(
+                this.createSpreadsheetMetadata(
+                        decimalSeparator, dot,
+                        grouping, comma,
+                        positive, plus
+                ),
+                grouping,
+                dot,
+                this.createSpreadsheetMetadata(
+                        decimalSeparator, comma,
+                        grouping, dot,
+                        positive, plus
+                )
+        );
+    }
+
+    @Test
+    public void testSetPropertyCausesSwapTwice() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+
+        final SpreadsheetMetadataPropertyName<Character> grouping = SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR;
+        final Character comma = ',';
+
+        final SpreadsheetMetadataPropertyName<Character> positive = SpreadsheetMetadataPropertyName.POSITIVE_SIGN;
+        final Character plus = '+';
+
+        // start
+        //  decimal=dot
+        //  grouping=comma
+        //  positive=plus
+
+        // set decimal=comma
+        //  decimal=comma
+        //  grouping=dot (swap with decimal)
+        //  positive=plus
+
+        // set grouping=plus
+        //  decimal=comma
+        //  grouping=plus
+        //  positive=dot
+
+        assertEquals(
+                this.createSpreadsheetMetadata(
+                        decimalSeparator, comma,
+                        grouping, plus,
+                        positive, dot
+                ),
+                this.createSpreadsheetMetadata(
+                        decimalSeparator, dot,
+                        grouping, comma,
+                        positive,
+                        plus
+                ).set(decimalSeparator, comma).set(grouping, plus)
+        );
+    }
+
     private <T> void setAndCheck(final SpreadsheetMetadata metadata,
                                  final SpreadsheetMetadataPropertyName<T> propertyName,
                                  final T value) {


### PR DESCRIPTION
- set will fail if character property value is a duplicate and not replacing.
- GROUPING_SEPARATOR and VALUE_SEPARATOR may hold the same value without triggering duplicate failures.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1322
- SpreadsheetMetadata character properties swap dont allow duplicates