### PR TITLE
public SpreadsheetMetadata.with Map removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -108,16 +108,6 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
     public final static SpreadsheetMetadata EMPTY = SpreadsheetMetadataEmpty.instance();
 
     /**
-     * Factory that creates a {@link SpreadsheetMetadata} from a {@link Map}.
-     */
-    public static SpreadsheetMetadata with(final Map<SpreadsheetMetadataPropertyName<?>, Object> properties) {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> copy = Maps.immutable(properties);
-        return copy.isEmpty() ?
-                EMPTY :
-                SpreadsheetMetadataNonEmpty.withImmutableMap(copy);
-    }
-
-    /**
      * Private ctor to limit sub classes.
      */
     SpreadsheetMetadata(final SpreadsheetMetadata defaults) {
@@ -715,7 +705,11 @@ public abstract class SpreadsheetMetadata implements HasConverter<ExpressionNumb
             properties.put(name, name.unmarshall(child, context));
         }
 
-        return with(properties).setDefaults(defaults);
+        return (
+                properties.isEmpty() ?
+                        EMPTY :
+                        SpreadsheetMetadataNonEmpty.with(properties)
+        ).setDefaults(defaults);
     }
 
     static {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
@@ -80,7 +80,7 @@ final class SpreadsheetMetadataEmpty extends SpreadsheetMetadata {
 
     @Override
     <V> SpreadsheetMetadata set0(final SpreadsheetMetadataPropertyName<V> propertyName, final V value) {
-        return with(Maps.of(propertyName, value));
+        return SpreadsheetMetadataNonEmpty.with(Maps.of(propertyName, value));
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
@@ -55,7 +55,7 @@ final class SpreadsheetMetadataNonEmpty extends SpreadsheetMetadata {
     /**
      * Factory that creates a {@link SpreadsheetMetadataNonEmpty} from a {@link Map<SpreadsheetMetadataPropertyName<?>, Object>}.
      */
-    static SpreadsheetMetadataNonEmpty withImmutableMap(final Map<SpreadsheetMetadataPropertyName<?>, Object> properties) {
+    static SpreadsheetMetadataNonEmpty with(final Map<SpreadsheetMetadataPropertyName<?>, Object> properties) {
         properties.forEach((p, v) -> p.checkValue(v));
         return new SpreadsheetMetadataNonEmpty(properties, null);
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStoreTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStoreTesting.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.meta.store;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.TypeNameTesting;
 import walkingkooka.spreadsheet.SpreadsheetId;
@@ -59,12 +58,13 @@ public interface SpreadsheetMetadataStoreTesting<S extends SpreadsheetMetadataSt
         final EmailAddress modifiedEmail = EmailAddress.parse("modified@example.com");
         final LocalDateTime modifiedDateTime = LocalDateTime.of(2000, 1, 2, 12, 58, 59);
 
-        return SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, this.id(),
-                SpreadsheetMetadataPropertyName.CREATOR, creatorEmail,
-                SpreadsheetMetadataPropertyName.CREATE_DATE_TIME, createDateTime,
-                SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH,
-                SpreadsheetMetadataPropertyName.MODIFIED_BY, modifiedEmail,
-                SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, modifiedDateTime));
+        return SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, this.id())
+                .set(SpreadsheetMetadataPropertyName.CREATOR, creatorEmail)
+                .set(SpreadsheetMetadataPropertyName.CREATE_DATE_TIME, createDateTime)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.MODIFIED_BY, modifiedEmail)
+                .set(SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, modifiedDateTime);
     }
 
     // TypeNameTesting..................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponentsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataComponentsTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.meta;
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.ClassTesting2;
@@ -51,7 +50,7 @@ public final class SpreadsheetMetadataComponentsTest implements ClassTesting2,
         final SpreadsheetMetadataPropertyName<EmailAddress> property = SpreadsheetMetadataPropertyName.CREATOR;
         final EmailAddress value = EmailAddress.parse("user@example.com");
 
-        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.with(Maps.of(property, value)));
+        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.EMPTY.set(property, value));
         assertEquals(value, components.getOrNull(property));
         this.checkMissing(components);
     }
@@ -105,7 +104,7 @@ public final class SpreadsheetMetadataComponentsTest implements ClassTesting2,
         final SpreadsheetMetadataPropertyName<EmailAddress> property = SpreadsheetMetadataPropertyName.CREATOR;
         final EmailAddress value = EmailAddress.parse("user@example.com");
 
-        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.with(Maps.of(property, value)));
+        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(SpreadsheetMetadata.EMPTY.set(property, value));
         components.getOrNull(property);
         components.reportIfMissing();
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
@@ -40,11 +40,6 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
     }
 
     @Test
-    public void testEmpty() {
-        assertSame(SpreadsheetMetadata.EMPTY, SpreadsheetMetadata.with(Maps.empty()));
-    }
-
-    @Test
     public void testValue() {
         assertSame(SpreadsheetMetadata.EMPTY.value(), SpreadsheetMetadata.EMPTY.value());
     }
@@ -56,10 +51,12 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
         final SpreadsheetMetadataPropertyName<EmailAddress> propertyName = SpreadsheetMetadataPropertyName.CREATOR;
         final EmailAddress familyName = EmailAddress.parse("user@example.com");
 
-        this.setAndCheck(SpreadsheetMetadata.EMPTY,
+        this.setAndCheck(
+                SpreadsheetMetadata.EMPTY,
                 propertyName,
                 familyName,
-                SpreadsheetMetadata.with(Maps.of(propertyName, familyName)));
+                SpreadsheetMetadataNonEmpty.with(Maps.of(propertyName, familyName))
+        );
     }
 
     // HateosResourceTesting............................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.color.Color;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.JavaVisibility;
@@ -39,9 +38,12 @@ public final class SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest 
     public void testToString() {
         final SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor();
 
-        visitor.accept(SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"),
-                SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("apple")), Color.fromRgb(0x112233),
-                SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("banana")), Color.fromRgb(0xffeedd))));
+        visitor.accept(
+                SpreadsheetMetadata.EMPTY
+                        .set(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"))
+                        .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("apple")), Color.fromRgb(0x112233))
+                        .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("banana")), Color.fromRgb(0xffeedd))
+        );
         this.toStringAndCheck(visitor, "{apple=#112233, banana=#ffeedd}");
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -105,21 +105,6 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     private final static int DEFAULT_YEAR = 1900;
 
     @Test
-    public void testWithMapCopied() {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
-        map.put(this.property1(), this.value1());
-        map.put(this.property2(), this.value2());
-
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> copy = Maps.sorted();
-        copy.putAll(map);
-
-        final SpreadsheetMetadataNonEmpty metadata = this.createSpreadsheetMetadata(map);
-
-        map.clear();
-        assertEquals(copy, metadata.value(), "value");
-    }
-
-    @Test
     public void testId() {
         final SpreadsheetId id = SpreadsheetId.with(123);
         final SpreadsheetMetadata metadata = this.createSpreadsheetMetadata(Maps.of(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, id));
@@ -147,7 +132,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         final SpreadsheetMetadataPropertyName<EmailAddress> propertyName = SpreadsheetMetadataPropertyName.CREATOR;
         final EmailAddress value = EmailAddress.parse("creator111@example.com");
 
-        final SpreadsheetMetadata notEmpty = SpreadsheetMetadata.with(Maps.of(propertyName, value));
+        final SpreadsheetMetadata notEmpty = SpreadsheetMetadataNonEmpty.with(Maps.of(propertyName, value));
         this.getAndCheck(notEmpty,
                 propertyName,
                 value);
@@ -869,13 +854,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         Arrays.stream(Locale.getAvailableLocales())
                 .forEach(l -> {
                     final int twoDigitYear = 49;
-                    final SpreadsheetMetadata metadata = SpreadsheetMetadata.with(
-                            Maps.of(
-                                    SpreadsheetMetadataPropertyName.DEFAULT_YEAR, DEFAULT_YEAR,
-                                    SpreadsheetMetadataPropertyName.LOCALE, l,
-                                    SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, twoDigitYear
-                            )
-                    );
+                    final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                            .set(SpreadsheetMetadataPropertyName.DEFAULT_YEAR, DEFAULT_YEAR)
+                            .set(SpreadsheetMetadataPropertyName.LOCALE, l)
+                            .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, twoDigitYear);
 
                     final DateFormatSymbols symbols = DateFormatSymbols.getInstance(l);
                     final DateTimeContext context = metadata.dateTimeContext();
@@ -892,13 +874,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     @Test
     public void testDateTimeContextCached() {
-        final SpreadsheetMetadata metadata = SpreadsheetMetadata.with(
-                Maps.of(
-                        SpreadsheetMetadataPropertyName.DEFAULT_YEAR, DEFAULT_YEAR,
-                        SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH,
-                        SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20
-                )
-        );
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DEFAULT_YEAR, DEFAULT_YEAR)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20);
         assertSame(metadata.dateTimeContext(), metadata.dateTimeContext());
     }
     
@@ -1629,7 +1608,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 missing,
                 () -> "Several properties are missing values in " + properties);
 
-        this.marshallRoundTripTwiceAndCheck(SpreadsheetMetadata.with(properties));
+        this.marshallRoundTripTwiceAndCheck(SpreadsheetMetadataNonEmpty.with(properties));
     }
 
     // helpers...........................................................................................................
@@ -1672,7 +1651,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     }
 
     private SpreadsheetMetadataNonEmpty createSpreadsheetMetadata(final Map<SpreadsheetMetadataPropertyName<?>, Object> map) {
-        return Cast.to(SpreadsheetMetadata.with(map));
+        return SpreadsheetMetadataNonEmpty.with(map);
     }
 
     @SuppressWarnings("SameReturnValue")

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitorTest.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.color.Color;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.JavaVisibility;
@@ -38,9 +37,12 @@ public final class SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitorTes
     public void testToString() {
         final SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor();
 
-        visitor.accept(SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"),
-                SpreadsheetMetadataPropertyName.numberedColor(12), Color.fromRgb(0x112233),
-                SpreadsheetMetadataPropertyName.numberedColor(13), Color.fromRgb(0xffeedd))));
+        visitor.accept(
+                SpreadsheetMetadata.EMPTY
+                        .set(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"))
+                        .set(SpreadsheetMetadataPropertyName.numberedColor(12), Color.fromRgb(0x112233))
+                        .set(SpreadsheetMetadataPropertyName.numberedColor(13), Color.fromRgb(0xffeedd))
+        );
         this.toStringAndCheck(visitor, "{12=#112233, 13=#ffeedd}");
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -26,7 +26,6 @@ import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.SpreadsheetCoordinates;
-import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -50,7 +49,6 @@ import walkingkooka.tree.text.WordWrap;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,38 +60,6 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         HashCodeEqualsDefinedTesting2<SpreadsheetMetadata>,
         JsonNodeMarshallingTesting<SpreadsheetMetadata>,
         ToStringTesting<SpreadsheetMetadata> {
-
-    @Test
-    public void testWithNullFails() {
-        assertThrows(NullPointerException.class, () -> SpreadsheetMetadata.with(null));
-    }
-
-    @Test
-    public void testWithInvalidPropertyFails() {
-        assertThrows(SpreadsheetMetadataPropertyValueException.class, () -> SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.CREATOR, null)));
-    }
-
-    @Test
-    public void testWithMapNullValueFails() {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.of(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, SpreadsheetId.with(123), SpreadsheetMetadataPropertyName.SPREADSHEET_NAME, null);
-        final SpreadsheetMetadataPropertyValueException thrown = assertThrows(SpreadsheetMetadataPropertyValueException.class, () -> SpreadsheetMetadata.with(map));
-        assertEquals("Missing value, but got null for \"spreadsheet-name\"", thrown.getMessage(), "message");
-    }
-
-    @Test
-    public void testWithMapCopied() {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.sorted();
-        map.put(this.property1(), this.value1());
-        map.put(this.property2(), this.value2());
-
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> copy = Maps.sorted();
-        copy.putAll(map);
-
-        final SpreadsheetMetadata metadata = SpreadsheetMetadata.with(map);
-
-        map.clear();
-        assertEquals(copy, metadata.value(), "value");
-    }
 
     @Test
     public void testMaxNumberColorConstant() {
@@ -251,12 +217,12 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
 
     @Test
     public void testToString() {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.of(this.property1(),
-                this.value1(),
-                this.property2(),
-                this.value2());
-
-        this.toStringAndCheck(SpreadsheetMetadata.with(map), map.toString());
+        this.toStringAndCheck(
+                SpreadsheetMetadata.EMPTY
+                        .set(this.property1(), this.value1())
+                        .set(this.property2(), this.value2()),
+                "{create-date-time=2000-01-02T12:58:59, creator=user@example.com}"
+        );
     }
 
     @Test
@@ -271,13 +237,13 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     }
 
     private SpreadsheetMetadata metadata() {
-        final Map<SpreadsheetMetadataPropertyName<?>, Object> map = Maps.ordered();
-        map.put(this.property1(), this.value1());
-        return SpreadsheetMetadata.with(map);
+        return SpreadsheetMetadataNonEmpty.with(
+                Maps.of(this.property1(), this.value1())
+        );
     }
 
     @SuppressWarnings("SameReturnValue")
-    private SpreadsheetMetadataPropertyName<?> property1() {
+    private SpreadsheetMetadataPropertyName<LocalDateTime> property1() {
         return SpreadsheetMetadataPropertyName.CREATE_DATE_TIME;
     }
 
@@ -286,7 +252,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     }
 
     @SuppressWarnings("SameReturnValue")
-    private SpreadsheetMetadataPropertyName<?> property2() {
+    private SpreadsheetMetadataPropertyName<EmailAddress> property2() {
         return SpreadsheetMetadataPropertyName.CREATOR;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converters;
 import walkingkooka.net.email.EmailAddress;
@@ -482,7 +481,7 @@ public final class SpreadsheetMetadataVisitorTest implements SpreadsheetMetadata
     }
 
     private static <T> SpreadsheetMetadata metadata(final SpreadsheetMetadataPropertyName<T> propertyName, final T value) {
-        return SpreadsheetMetadata.with(Maps.of(propertyName, value));
+        return SpreadsheetMetadata.EMPTY.set(propertyName, value);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStoreTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStoreTestCase.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.meta.store;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -167,11 +166,12 @@ public abstract class SpreadsheetMetadataStoreTestCase<S extends SpreadsheetMeta
         final EmailAddress modifiedEmail = EmailAddress.parse("modified@example.com");
         final LocalDateTime modifiedDateTime = LocalDateTime.of(2000, 1, 2, 12, 58, 59);
 
-        return SpreadsheetMetadata.with(Maps.of(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, id,
-                SpreadsheetMetadataPropertyName.CREATOR, creatorEmail,
-                SpreadsheetMetadataPropertyName.CREATE_DATE_TIME, createDateTime,
-                SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"),
-                SpreadsheetMetadataPropertyName.MODIFIED_BY, modifiedEmail,
-                SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, modifiedDateTime));
+        return SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, id)
+                .set(SpreadsheetMetadataPropertyName.CREATOR, creatorEmail)
+                .set(SpreadsheetMetadataPropertyName.CREATE_DATE_TIME, createDateTime)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"))
+                .set(SpreadsheetMetadataPropertyName.MODIFIED_BY, modifiedEmail)
+                .set(SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, modifiedDateTime);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/meta/store/TreeMapSpreadsheetMetadataStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/store/TreeMapSpreadsheetMetadataStoreTest.java
@@ -29,7 +29,7 @@ public final class TreeMapSpreadsheetMetadataStoreTest extends SpreadsheetMetada
         store.save(this.metadata(1, "user1@example.com"));
         store.save(this.metadata(2, "user2@example.com"));
 
-        this.toStringAndCheck(store, "[{spreadsheet-id=1, creator=user1@example.com, create-date-time=1999-12-31T12:58:59, locale=en_AU, modified-by=modified@example.com, modified-date-time=2000-01-02T12:58:59}, {spreadsheet-id=2, creator=user2@example.com, create-date-time=1999-12-31T12:58:59, locale=en_AU, modified-by=modified@example.com, modified-date-time=2000-01-02T12:58:59}]");
+        this.toStringAndCheck(store, "[{create-date-time=1999-12-31T12:58:59, creator=user1@example.com, locale=en_AU, modified-by=modified@example.com, modified-date-time=2000-01-02T12:58:59, spreadsheet-id=1}, {create-date-time=1999-12-31T12:58:59, creator=user2@example.com, locale=en_AU, modified-by=modified@example.com, modified-date-time=2000-01-02T12:58:59, spreadsheet-id=2}]");
     }
 
     @Override


### PR DESCRIPTION
- Necessary to remove ability to create invalid instances with duplicate character properties