### PR TITLE
SpreadsheetMetadata set & unmarshall duplicate clash improvements

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
@@ -71,16 +71,11 @@ final class SpreadsheetMetadataEmpty extends SpreadsheetMetadata {
         return Maps.empty();
     }
 
-    // get/set/remove...................................................................................................
+    // get/remove.......................................................................................................
 
     @Override
     <V> Optional<V> getIgnoringDefaults(final SpreadsheetMetadataPropertyName<V> propertyName) {
         return Optional.empty();
-    }
-
-    @Override
-    <V> SpreadsheetMetadata set0(final SpreadsheetMetadataPropertyName<V> propertyName, final V value) {
-        return SpreadsheetMetadataNonEmpty.with(Maps.of(propertyName, value), this.defaults);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1600,9 +1600,30 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     @Test
     public void testFromJsonInvalidCharacterValueFails() {
         this.unmarshallFails(
-                JsonNode.parse("{" +
+                "{" +
                         "  \"decimal-separator\": \"d\"\n" +
-                        "}")
+                        "}",
+                SpreadsheetMetadata.class
+        );
+    }
+
+    @Test
+    public void testFromJsonWithDefaultSwap() {
+        this.unmarshallAndCheck(
+                "{\n" +
+                        "    \"decimal-separator\": \",\",\n" +
+                        "    \"_defaults\": {\n" +
+                        "        \"decimal-separator\": \".\",\n" +
+                        "        \"grouping-separator\": \",\"\n" +
+                        "    }\n" +
+                        "}",
+                SpreadsheetMetadata.EMPTY
+                        .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, ',')
+                        .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, '.')
+                        .setDefaults(SpreadsheetMetadata.EMPTY
+                                .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, '.')
+                                .set(SpreadsheetMetadataPropertyName.GROUPING_SEPARATOR, ',')
+                        )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -242,7 +242,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     private SpreadsheetMetadata metadata() {
         return SpreadsheetMetadataNonEmpty.with(
                 Maps.of(this.property1(), this.value1()),
-                SpreadsheetMetadata.EMPTY
+                null
         );
     }
 


### PR DESCRIPTION
- set even on EMPTY checks defaults for duplicates.
- unmarshall rebuilds a SpreadsheetMetadata using json one property at a time.