### PR TITLE
SpreadsheetViewport.reference SpreadsheetCellReferenceOrLabelName was…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -33,6 +33,7 @@ import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -586,10 +587,12 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
     private final SpreadsheetMetadata metadata;
 
     @Override
-    public SpreadsheetRange computeRange(final SpreadsheetViewport viewport) {
-        Objects.requireNonNull(viewport, "rectangle");
+    public SpreadsheetRange computeRange(final SpreadsheetViewport viewport,
+                                         final SpreadsheetEngineContext context) {
+        Objects.requireNonNull(viewport, "viewport");
+        Objects.requireNonNull(context, "context");
 
-        final SpreadsheetCellReference reference = viewport.reference();
+        final SpreadsheetCellReference reference = context.resolveCellReference(viewport.reference().toString());
 
         final double width = viewport.width();
         double x = 0;

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
@@ -123,7 +123,8 @@ public class FakeSpreadsheetEngine implements SpreadsheetEngine, Fake {
     }
 
     @Override
-    public SpreadsheetRange computeRange(final SpreadsheetViewport viewport) {
+    public SpreadsheetRange computeRange(final SpreadsheetViewport viewport,
+                                         final SpreadsheetEngineContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -134,7 +134,8 @@ public interface SpreadsheetEngine {
     /**
      * Computes the {@link SpreadsheetRange} from the given {@link SpreadsheetViewport} using the column width and row heights.
      */
-    SpreadsheetRange computeRange(final SpreadsheetViewport viewport);
+    SpreadsheetRange computeRange(final SpreadsheetViewport viewport,
+                                  final SpreadsheetEngineContext context);
 
     /**
      * Locates the {@link SpreadsheetCellBox} at the given coordinates.

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -765,16 +765,29 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
 
     default void computeRangeAndCheck(final SpreadsheetViewport viewport,
                                       final SpreadsheetRange expected) {
+        this.computeRangeAndCheck(
+                viewport,
+                this.createContext(),
+                expected
+        );
+    }
+
+    default void computeRangeAndCheck(final SpreadsheetViewport viewport,
+                                      final SpreadsheetEngineContext context,
+                                      final SpreadsheetRange expected) {
         this.computeRangeAndCheck(this.createSpreadsheetEngine(),
                 viewport,
-                expected);
+                context,
+                expected
+        );
     }
 
     default void computeRangeAndCheck(final SpreadsheetEngine engine,
                                       final SpreadsheetViewport viewport,
+                                      final SpreadsheetEngineContext context,
                                       final SpreadsheetRange expected) {
         assertEquals(expected,
-                engine.computeRange(viewport),
+                engine.computeRange(viewport, context),
                 () -> "computeRange " + viewport + " of " + engine);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.java
@@ -30,4 +30,6 @@ abstract public class SpreadsheetCellReferenceOrLabelName<C extends SpreadsheetC
     SpreadsheetCellReferenceOrLabelName() {
         super();
     }
+
+    abstract public SpreadsheetCellReferenceOrLabelName<C> toRelative();
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewport.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewport.java
@@ -52,7 +52,7 @@ public final class SpreadsheetViewport extends SpreadsheetRectangle implements C
                 throw new IllegalArgumentException("Incorrect number of tokens in " + CharSequences.quoteAndEscape(text));
         }
 
-        final SpreadsheetCellReference reference;
+        final SpreadsheetCellReferenceOrLabelName<?> reference;
         try {
             reference = SpreadsheetCellReference.parseCellReference(tokens[0]);
         } catch (final NumberFormatException cause) {
@@ -78,10 +78,13 @@ public final class SpreadsheetViewport extends SpreadsheetRectangle implements C
     /**
      * Factory that creates a new {@link SpreadsheetViewport}.
      */
-    static SpreadsheetViewport with(final SpreadsheetCellReference reference,
+    static SpreadsheetViewport with(final SpreadsheetCellReferenceOrLabelName<?> reference,
                                     final double width,
                                     final double height) {
         Objects.requireNonNull(reference, "reference");
+        if (reference.isViewport()) {
+            throw new IllegalArgumentException("Invalid reference got " + reference);
+        }
 
         if (width <= 0) {
             throw new IllegalArgumentException("Invalid width " + width + " <= 0");
@@ -92,7 +95,7 @@ public final class SpreadsheetViewport extends SpreadsheetRectangle implements C
         return new SpreadsheetViewport(reference, width, height);
     }
 
-    private SpreadsheetViewport(final SpreadsheetCellReference reference,
+    private SpreadsheetViewport(final SpreadsheetCellReferenceOrLabelName<?> reference,
                                 final double width,
                                 final double height) {
         super();
@@ -113,11 +116,11 @@ public final class SpreadsheetViewport extends SpreadsheetRectangle implements C
 
     // properties.......................................................................................................
 
-    public SpreadsheetCellReference reference() {
+    public SpreadsheetExpressionReference reference() {
         return this.reference;
     }
 
-    private final SpreadsheetCellReference reference;
+    private final SpreadsheetCellReferenceOrLabelName<?> reference;
 
     public double width() {
         return this.width;

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -181,6 +181,9 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     private final static int TWO_DIGIT_YEAR = 20;
     private final static char VALUE_SEPARATOR = ';';
 
+    private final static SpreadsheetLabelName LABEL = SpreadsheetLabelName.labelName("Label123");
+    private final static SpreadsheetCellReference LABEL_CELL = SpreadsheetCellReference.parseCellReference("Z99");
+
     @Test
     public void testWithNullIdFails() {
         assertThrows(NullPointerException.class, () -> BasicSpreadsheetEngine.with(null,
@@ -5221,7 +5224,17 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
     @Override
     public SpreadsheetEngineContext createContext() {
-        return SpreadsheetEngineContexts.fake();
+        return new FakeSpreadsheetEngineContext() {
+            @Override
+            public SpreadsheetCellReference resolveCellReference(final String text) {
+                final SpreadsheetExpressionReference reference = SpreadsheetExpressionReference.parse(text);
+                if (reference.isCellReference()) {
+                    return (SpreadsheetCellReference) reference;
+                }
+                assertEquals(LABEL, reference.toString());
+                return LABEL_CELL;
+            }
+        };
     }
 
     private SpreadsheetEngineContext createContext(final BasicSpreadsheetEngine engine) {


### PR DESCRIPTION
… SpreadsheetCellReference

- SpreadsheetEngineTesting new overload accepting SpreadsheetEngineContext
- SpreadsheetEngine.computeRange added SpreadsheetEngineContext param.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1538
- SpreadsheetViewport reference change from SpreadsheetCellReference to SpreadsheetExpressionReference