### PR TITLE
BasicSpreadsheetEngineContext remove cellCharacterWidth dependency

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -32,6 +32,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatExpressionParserT
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContexts;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
@@ -74,7 +75,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                                               final ExpressionNumberConverterContext converterContext,
                                               final Function<Integer, Optional<Color>> numberToColor,
                                               final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
-                                              final int cellCharacterWidth,
                                               final Function<BigDecimal, Fraction> fractioner,
                                               final SpreadsheetFormatter defaultSpreadsheetFormatter,
                                               final SpreadsheetStoreRepository storeRepository) {
@@ -85,9 +85,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
         Objects.requireNonNull(converterContext, "converterContext");
         Objects.requireNonNull(numberToColor, "numberToColor");
         Objects.requireNonNull(nameToColor, "nameToColor");
-        if (cellCharacterWidth <= 0) {
-            throw new IllegalArgumentException("Invalid cellCharacterWidth " + cellCharacterWidth + " <= 0");
-        }
         Objects.requireNonNull(fractioner, "fractioner");
         Objects.requireNonNull(defaultSpreadsheetFormatter, "defaultSpreadsheetFormatter");
         Objects.requireNonNull(storeRepository, "storeRepository");
@@ -101,7 +98,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                 converterContext,
                 numberToColor,
                 nameToColor,
-                cellCharacterWidth,
                 fractioner,
                 defaultSpreadsheetFormatter,
                 storeRepository
@@ -119,7 +115,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                                           final ExpressionNumberConverterContext converterContext,
                                           final Function<Integer, Optional<Color>> numberToColor,
                                           final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
-                                          final int cellCharacterWidth,
                                           final Function<BigDecimal, Fraction> fractioner,
                                           final SpreadsheetFormatter defaultSpreadsheetFormatter,
                                           final SpreadsheetStoreRepository storeRepository) {
@@ -145,7 +140,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
 
         this.spreadsheetFormatContext = SpreadsheetFormatterContexts.basic(numberToColor,
                 nameToColor,
-                cellCharacterWidth,
+                metadata.getOrFail(SpreadsheetMetadataPropertyName.CELL_CHARACTER_WIDTH),
                 defaultSpreadsheetFormatter,
                 converterContext);
         this.fractioner = fractioner;

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContexts.java
@@ -48,7 +48,6 @@ public final class SpreadsheetEngineContexts implements PublicStaticHelper {
                                                  final ExpressionNumberConverterContext converterContext,
                                                  final Function<Integer, Optional<Color>> numberToColor,
                                                  final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
-                                                 final int cellCharacterWidth,
                                                  final Function<BigDecimal, Fraction> fractioner,
                                                  final SpreadsheetFormatter defaultSpreadsheetFormatter,
                                                  final SpreadsheetStoreRepository storeRepository) {
@@ -61,7 +60,6 @@ public final class SpreadsheetEngineContexts implements PublicStaticHelper {
                 converterContext,
                 numberToColor,
                 nameToColor,
-                cellCharacterWidth,
                 fractioner,
                 defaultSpreadsheetFormatter,
                 storeRepository

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -37,6 +37,7 @@ import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePatterns;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
@@ -76,6 +77,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
 
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
     private final static char VALUE_SEPARATOR = ',';
+    private final static int WIDTH = 1;
 
     @Test
     public void testWithNullMetadataFails() {
@@ -88,7 +90,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -107,7 +108,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -126,7 +126,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -145,7 +144,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -164,7 +162,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 null,
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -183,7 +180,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 null,
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -202,7 +198,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 null,
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -211,9 +206,9 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
     }
 
     @Test
-    public void testWithInvalidCellCharacterWidthFails() {
+    public void testWithMissingCellCharacterWidthFails() {
         assertThrows(IllegalArgumentException.class, () -> BasicSpreadsheetEngineContext.with(
-                this.metadata(),
+                SpreadsheetMetadata.EMPTY,
                 this.valueParser(),
                 VALUE_SEPARATOR,
                 this.functions(),
@@ -221,7 +216,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                0,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -240,7 +234,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 null,
                 this.defaultSpreadsheetFormatter(),
                 this.storeRepository()
@@ -259,7 +252,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 null,
                 this.storeRepository()
@@ -278,7 +270,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 this.defaultSpreadsheetFormatter(),
                 null
@@ -620,7 +611,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                 this.converterContext(),
                 this.numberToColor(),
                 this.nameToColor(),
-                WIDTH,
                 FRACTIONER,
                 defaultSpreadsheetFormatter,
                 new FakeSpreadsheetStoreRepository() {
@@ -633,7 +623,8 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
     }
 
     private SpreadsheetMetadata metadata() {
-        return SpreadsheetMetadata.EMPTY;
+        return SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.CELL_CHARACTER_WIDTH, WIDTH);
     }
 
     private Parser<SpreadsheetParserContext> valueParser() {
@@ -767,7 +758,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
         return Optional.of(Color.fromRgb(0x123456));
     }
 
-    private final static int WIDTH = 1;
     private final Function<BigDecimal, Fraction> FRACTIONER = new Function<>() {
         @Override
         public Fraction apply(final BigDecimal bigDecimal) {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1553
- SpreadsheetEngineContext.width() remove when metadata property is available