### PR TITLE
SpreadsheetMetadata.set fixes

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmpty.java
@@ -79,6 +79,12 @@ final class SpreadsheetMetadataEmpty extends SpreadsheetMetadata {
     }
 
     @Override
+    final <V> SpreadsheetMetadata setSameValue(final SpreadsheetMetadataPropertyName<V> propertyName,
+                                               final V value) {
+        return SpreadsheetMetadataNonEmpty.with(Maps.of(propertyName, value), this.defaults);
+    }
+
+    @Override
     SpreadsheetMetadata remove0(final SpreadsheetMetadataPropertyName<?> propertyName) {
         return this;
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmpty.java
@@ -119,6 +119,31 @@ final class SpreadsheetMetadataNonEmpty extends SpreadsheetMetadata {
         return Optional.ofNullable(Cast.to(this.value.get(propertyName)));
     }
 
+    // set..............................................................................................................
+
+    /**
+     * Could be setting a property that has the same effective value but it could be in the defaults.
+     * If the value is only in the defaults create a new instance with the value.
+     */
+    @Override
+    <V> SpreadsheetMetadata setSameValue(final SpreadsheetMetadataPropertyName<V> propertyName,
+                                         final V value) {
+        SpreadsheetMetadata result = this;
+
+        final Map<SpreadsheetMetadataPropertyName<?>, Object> properties = this.value;
+
+        // save value anyway if previousValue was from defaults.
+        if (!properties.containsKey(propertyName)) {
+            final Map<SpreadsheetMetadataPropertyName<?>, Object> copy = Maps.sorted();
+            copy.putAll(properties);
+            copy.put(propertyName, value);
+
+            result = SpreadsheetMetadataNonEmpty.with(Maps.immutable(copy), this.defaults);
+        }
+
+        return result;
+    }
+
     // remove...........................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -174,6 +174,37 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
         this.setAndCheck(
                 SpreadsheetMetadataNonEmpty.with(
+                        Maps.empty(),
+                        SpreadsheetMetadataNonEmpty.with(
+                                Maps.of(
+                                        decimalSeparator, comma
+                                ),
+                                null)
+                ),
+                decimalSeparator,
+                comma,
+                SpreadsheetMetadataNonEmpty.with(
+                        Maps.of(
+                                decimalSeparator, comma
+                        ),
+                        SpreadsheetMetadataNonEmpty.with(
+                                Maps.of(
+                                        decimalSeparator, comma
+                                ),
+                                null
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testSetPropertyValueSameDefaultValue2() {
+        final SpreadsheetMetadataPropertyName<Character> decimalSeparator = SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR;
+        final Character dot = '.';
+        final Character comma = ',';
+
+        this.setAndCheck(
+                SpreadsheetMetadataNonEmpty.with(
                         Maps.of(
                                 decimalSeparator, dot
                         ),


### PR DESCRIPTION
- Setting a value that already exists in defaults would be lost, causing problems in react web app which ignores defaults.
- Incorrect handling of swapping when value present only in defaults