### PR TITLE
SpreadsheetExpressionReference.parse viewport support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReference.java
@@ -133,17 +133,28 @@ abstract public class SpreadsheetExpressionReference implements ExpressionRefere
     // parse............................................................................................................
 
     /**
-     * Parsers the given text into a {@link SpreadsheetCellReference}, {@link SpreadsheetLabelName} or {@link SpreadsheetRange}.
-     * Attempts to parse {@link SpreadsheetViewport} in text will fail.
+     * Parsers the given text into of the sub classes of {@link SpreadsheetExpressionReference}.
      */
     public static SpreadsheetExpressionReference parse(final String text) {
         Objects.requireNonNull(text, "text");
 
-        return text.contains(":") ?
-                parseRange(text) :
-                isCellReferenceText(text) ?
+        final SpreadsheetExpressionReference reference;
+
+        switch (text.split(":").length) {
+            case 1:
+                reference = isCellReferenceText(text) ?
                         parseCellReference(text) :
                         labelName(text);
+                break;
+            case 2:
+                reference = parseRange(text);
+                break;
+            default:
+                reference = parseViewport(text);
+                break;
+        }
+
+        return reference;
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
@@ -207,8 +207,9 @@ public final class SpreadsheetExpressionReferenceTest implements ClassTesting2<S
     }
 
     @Test
-    public void testParseViewportFails() {
-        this.parseStringFails(SpreadsheetExpressionReference.parseViewport("B9:40:50.75").toString(), IllegalArgumentException.class);
+    public void testParseViewport() {
+        final SpreadsheetViewport viewport = SpreadsheetExpressionReference.parseViewport("B9:40:50.75");
+        this.parseStringAndCheck(viewport.toString(), viewport);
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
- Previously only supported parsing cell, label and range, viewports would always fail.