### PR TITLE
SpreadsheetLabelMappingExpressionReference

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.parser.SpreadsheetRowReferenceParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReferenceVisitor;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelMappingExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
@@ -376,7 +377,7 @@ abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
         this.saveLabelIfUpdated(this.fixCellReference(reference), mapping);
     }
 
-    final void saveLabelIfUpdated(final ExpressionReference reference, final SpreadsheetLabelMapping mapping) {
+    final void saveLabelIfUpdated(final SpreadsheetLabelMappingExpressionReference reference, final SpreadsheetLabelMapping mapping) {
         final SpreadsheetLabelMapping updated = mapping.setReference(reference);
         if (mapping != updated) {
             this.labelStore().save(updated);

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -38,6 +38,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelMappingExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
@@ -530,7 +531,7 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
 
     default void loadLabelAndCheck(final SpreadsheetLabelStore labelStore,
                                    final SpreadsheetLabelName label,
-                                   final ExpressionReference reference) {
+                                   final SpreadsheetLabelMappingExpressionReference reference) {
         this.loadLabelAndCheck(labelStore,
                 label,
                 SpreadsheetLabelMapping.with(label, reference));

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrLabelName.java
@@ -23,7 +23,8 @@ package walkingkooka.spreadsheet.reference;
  * able to handle type parameters with multiple bounds.
  */
 abstract public class SpreadsheetCellReferenceOrLabelName<C extends SpreadsheetCellReferenceOrLabelName<C>> extends SpreadsheetExpressionReference
-        implements Comparable<C> {
+        implements SpreadsheetLabelMappingExpressionReference,
+        Comparable<C> {
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMapping.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMapping.java
@@ -37,7 +37,7 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
     /**
      * Creates a new {@link SpreadsheetLabelMapping}
      */
-    public static SpreadsheetLabelMapping with(final SpreadsheetLabelName label, final ExpressionReference reference) {
+    public static SpreadsheetLabelMapping with(final SpreadsheetLabelName label, final SpreadsheetLabelMappingExpressionReference reference) {
         checkLabel(label);
         checkReference(reference);
         return new SpreadsheetLabelMapping(label, reference);
@@ -46,7 +46,7 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
     /**
      * Private ctor use factory
      */
-    private SpreadsheetLabelMapping(final SpreadsheetLabelName label, final ExpressionReference reference) {
+    private SpreadsheetLabelMapping(final SpreadsheetLabelName label, final SpreadsheetLabelMappingExpressionReference reference) {
         this.label = label;
         this.reference = reference;
     }
@@ -59,7 +59,7 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
         checkLabel(label);
         return this.label.equals(label) ?
                 this :
-                this.replace(label, reference);
+                this.replace(label, this.reference);
     }
 
     private static void checkLabel(final SpreadsheetLabelName label) {
@@ -68,24 +68,25 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
 
     private final SpreadsheetLabelName label;
 
-    public ExpressionReference reference() {
+    public SpreadsheetLabelMappingExpressionReference reference() {
         return this.reference;
     }
 
-    public SpreadsheetLabelMapping setReference(final ExpressionReference reference) {
+    public SpreadsheetLabelMapping setReference(final SpreadsheetLabelMappingExpressionReference reference) {
         checkReference(reference);
         return this.reference.equals(reference) ?
                 this :
                 this.replace(this.label, reference);
     }
 
-    private final ExpressionReference reference;
+    private final SpreadsheetLabelMappingExpressionReference reference;
 
-    private static void checkReference(final ExpressionReference reference) {
+    private static void checkReference(final SpreadsheetLabelMappingExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
     }
 
-    private SpreadsheetLabelMapping replace(final SpreadsheetLabelName label, final ExpressionReference reference) {
+    private SpreadsheetLabelMapping replace(final SpreadsheetLabelName label,
+                                            final SpreadsheetLabelMappingExpressionReference reference) {
         return new SpreadsheetLabelMapping(label, reference);
     }
 
@@ -111,7 +112,7 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
         Objects.requireNonNull(node, "node");
 
         SpreadsheetLabelName labelName = null;
-        ExpressionReference reference = null;
+        SpreadsheetLabelMappingExpressionReference reference = null;
 
         for (JsonNode child : node.objectOrFail().children()) {
             final JsonPropertyName name = child.name();
@@ -120,7 +121,7 @@ public final class SpreadsheetLabelMapping implements HateosResource<Spreadsheet
                     labelName = context.unmarshall(child, SpreadsheetLabelName.class);
                     break;
                 case REFERENCE_PROPERTY_STRING:
-                    reference = context.unmarshall(child, SpreadsheetCellReference.class);
+                    reference = context.unmarshall(child, SpreadsheetLabelMappingExpressionReference.class);
                     break;
                 default:
                     JsonNodeUnmarshallContext.unknownPropertyPresent(name, node);

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingExpressionReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingExpressionReference.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
+
+/**
+ * A tag interface that selects some sub classes of {@link SpreadsheetExpressionReference} as
+ * candidates for {@link SpreadsheetLabelMapping#reference()}.
+ */
+public interface SpreadsheetLabelMappingExpressionReference extends ExpressionReference {
+
+    // This method is not intended to be consumed and should be considered internal.
+    JsonNode marshall(final JsonNodeMarshallContext context);
+}

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
@@ -85,7 +85,7 @@ final public class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabelN
     /**
      * Creates a {@link SpreadsheetLabelMapping} using this label and the given {@link SpreadsheetExpressionReference}.
      */
-    public SpreadsheetLabelMapping mapping(final SpreadsheetExpressionReference reference) {
+    public SpreadsheetLabelMapping mapping(final SpreadsheetLabelMappingExpressionReference reference) {
         return SpreadsheetLabelMapping.with(this, reference);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRange.java
@@ -35,7 +35,8 @@ import java.util.stream.Stream;
  * Holds a range. Note the begin component is always before the end, with rows being the significant axis before column.
  */
 @SuppressWarnings("lgtm[java/inconsistent-equals-and-hashcode]")
-public final class SpreadsheetRange extends SpreadsheetRectangle implements Predicate<SpreadsheetCellReference> {
+public final class SpreadsheetRange extends SpreadsheetRectangle implements SpreadsheetLabelMappingExpressionReference,
+        Predicate<SpreadsheetCellReference> {
 
     /**
      * Factory that parses some text holding a range.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingExpressionReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingExpressionReferenceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.ClassTesting2;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.test.ParseStringTesting;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
+import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+
+public final class SpreadsheetLabelMappingExpressionReferenceTest implements ClassTesting2<SpreadsheetLabelMappingExpressionReference>,
+        JsonNodeMarshallingTesting<SpreadsheetLabelMappingExpressionReference>,
+        ParseStringTesting<SpreadsheetLabelMappingExpressionReference> {
+
+    // unmarshall.....................................................................................................
+
+    @Test
+    public void testJsonNodeUnmarshallViewportFails() {
+        this.unmarshallFails(JsonNode.string(viewportString()));
+    }
+
+    @Test
+    public void testJsonRoundtripCellReference() {
+        this.marshallRoundTripTwiceAndCheck(SpreadsheetExpressionReference.parseCellReference("A1"));
+    }
+
+    @Test
+    public void testJsonRoundtripLabel() {
+        this.marshallRoundTripTwiceAndCheck(SpreadsheetExpressionReference.labelName("Label123"));
+    }
+
+    @Test
+    public void testJsonRoundtripRange() {
+        this.marshallRoundTripTwiceAndCheck(SpreadsheetExpressionReference.parseRange("B2:C3"));
+    }
+
+    // parse............................................................................................................
+
+    @Test
+    public void testParseCellReferenceUpperCaseRelativeRelative() {
+        final String reference = "A2";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(0).setRow(SpreadsheetReferenceKind.RELATIVE.row(1)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseRelativeAbsolute() {
+        final String reference = "C$4";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(2).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(3)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseAbsoluteRelative() {
+        final String reference = "$E6";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(4).setRow(SpreadsheetReferenceKind.RELATIVE.row(5)));
+    }
+
+    @Test
+    public void testParseCellReferenceUpperCaseAbsoluteAbsolute() {
+        final String reference = "$G$8";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(6).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(7)));
+    }
+
+    @Test
+    public void testParseCellReferenceLowercaseRelativeRelative() {
+        final String reference = "i10";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.RELATIVE.column(8).setRow(SpreadsheetReferenceKind.RELATIVE.row(9)));
+    }
+
+    @Test
+    public void testParseCellReferenceLowercaseAbsolute() {
+        final String reference = "$k12";
+        this.parseStringAndCheck(reference, SpreadsheetReferenceKind.ABSOLUTE.column(10).setRow(SpreadsheetReferenceKind.RELATIVE.row(11)));
+    }
+
+    @Test
+    public void testParseLabel() {
+        final String label = "label123";
+        this.parseStringAndCheck(label, SpreadsheetExpressionReference.labelName(label));
+    }
+
+    @Test
+    public void testParseRange() {
+        final String range = "A2:B2";
+        this.parseStringAndCheck(range, SpreadsheetExpressionReference.parseRange(range));
+    }
+
+    @Test
+    public void testParseViewportFails() {
+        this.parseStringFails(
+                viewportString(),
+                IllegalArgumentException.class
+        );
+    }
+
+    private String viewportString() {
+        return SpreadsheetExpressionReference.parseViewport("B9:40:50.75").toString();
+    }
+
+    // ClassTesting.....................................................................................................
+
+    @Override
+    public Class<SpreadsheetLabelMappingExpressionReference> type() {
+        return SpreadsheetLabelMappingExpressionReference.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+
+    // JsonNodeTesting...................................................................................................
+
+    @Override
+    public SpreadsheetLabelMappingExpressionReference unmarshall(final JsonNode node,
+                                                                 final JsonNodeUnmarshallContext context) {
+        return SpreadsheetExpressionReference.unmarshallSpreadsheetLabelMappingExpressionReference(node, context);
+    }
+
+    @Override
+    public SpreadsheetLabelMappingExpressionReference createJsonNodeMappingValue() {
+        return SpreadsheetExpressionReference.parseSpreadsheetLabelMappingExpressionReference("A1");
+    }
+
+    // ParseStringTesting...............................................................................................
+
+    @Override
+    public SpreadsheetLabelMappingExpressionReference parseString(final String text) {
+        return SpreadsheetExpressionReference.parseSpreadsheetLabelMappingExpressionReference(text);
+    }
+
+    @Override
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> throwing) {
+        return throwing;
+    }
+
+    @Override
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
+        return expected;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelMappingTest.java
@@ -40,7 +40,7 @@ public final class SpreadsheetLabelMappingTest implements ClassTesting2<Spreadsh
         ToStringTesting<SpreadsheetLabelMapping> {
 
     private final static SpreadsheetLabelName LABEL = SpreadsheetExpressionReference.labelName("label");
-    private final static ExpressionReference REFERENCE = cell(1);
+    private final static SpreadsheetLabelMappingExpressionReference REFERENCE = cell(1);
 
     @Test
     public void testWithNullLabelFails() {
@@ -99,7 +99,7 @@ public final class SpreadsheetLabelMappingTest implements ClassTesting2<Spreadsh
     @Test
     public void testSetReferenceDifferent() {
         final SpreadsheetLabelMapping mapping = this.createObject();
-        final ExpressionReference differentReference = cell(999);
+        final SpreadsheetLabelMappingExpressionReference differentReference = cell(999);
         final SpreadsheetLabelMapping different = mapping.setReference(differentReference);
 
         assertNotSame(mapping, different);
@@ -122,6 +122,27 @@ public final class SpreadsheetLabelMappingTest implements ClassTesting2<Spreadsh
                         "  \"label\": \"label\",\n" +
                         "  \"reference\": \"$B3\"\n" +
                         "}"
+        );
+    }
+
+    @Test
+    public void testJsonRoundtripCellReference() {
+        this.marshallRoundTrip2(SpreadsheetExpressionReference.parseCellReference("A1"));
+    }
+
+    @Test
+    public void testJsonRoundtripLabelName() {
+        this.marshallRoundTrip2(SpreadsheetLabelName.labelName("LABEL123"));
+    }
+
+    @Test
+    public void testJsonRoundtripRange() {
+        this.marshallRoundTrip2(SpreadsheetExpressionReference.parseRange("A1:B2"));
+    }
+
+    private void marshallRoundTrip2(final SpreadsheetLabelMappingExpressionReference reference) {
+        this.marshallRoundTripTwiceAndCheck(
+                SpreadsheetLabelName.with("Label123").mapping(reference)
         );
     }
 
@@ -164,11 +185,12 @@ public final class SpreadsheetLabelMappingTest implements ClassTesting2<Spreadsh
         assertEquals(label, mapping.label(), "label");
     }
 
-    private void checkReference(final SpreadsheetLabelMapping mapping, final ExpressionReference reference) {
+    private void checkReference(final SpreadsheetLabelMapping mapping,
+                                final SpreadsheetLabelMappingExpressionReference reference) {
         assertEquals(reference, mapping.reference(), "reference");
     }
 
-    private static ExpressionReference cell(final int column) {
+    private static SpreadsheetCellReference cell(final int column) {
         return SpreadsheetReferenceKind.ABSOLUTE.column(column)
                 .setRow(SpreadsheetReferenceKind.RELATIVE.row(2));
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
@@ -106,9 +106,22 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetCellReferenceOrLa
     }
 
     @Test
-    public void testMapping() {
+    public void testMappingCellReference() {
+        this.mappingAndCheck(SpreadsheetExpressionReference.parseCellReference("A1"));
+    }
+
+    @Test
+    public void testMappingLabel() {
+        this.mappingAndCheck(SpreadsheetExpressionReference.labelName("LABEL456"));
+    }
+
+    @Test
+    public void testMappingRange() {
+        this.mappingAndCheck(SpreadsheetExpressionReference.parseRange("A1:b2"));
+    }
+
+    private void mappingAndCheck(final SpreadsheetLabelMappingExpressionReference reference) {
         final SpreadsheetLabelName label = SpreadsheetLabelName.with("LABEL123");
-        final SpreadsheetExpressionReference reference = SpreadsheetExpressionReference.parse("A1");
 
         final SpreadsheetLabelMapping mapping = label.mapping(reference);
         assertSame(label, mapping.label(), "label");


### PR DESCRIPTION
- SpreadsheetLabelMapping.reference now typed SpreadsheetLabelMappingExpressionReference
- Few minor fixes relating to above change.
- SpreadsheetLabelMapping.reference now handles SpreadsheetLabelMappingExpressionReference, previously only did SpreadsheetCellReference.