### PR TITLE
SpreadsheetMetadataPropertyNameViewportCell extends SpreadsheetMetada…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCell.java
@@ -20,10 +20,13 @@ package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 
+import java.util.Locale;
+import java.util.Optional;
+
 /**
  * Holds the home cell at the viewport-coordinates.
  */
-final class SpreadsheetMetadataPropertyNameViewportCell extends SpreadsheetMetadataPropertyNameSpreadsheetCellReference {
+final class SpreadsheetMetadataPropertyNameViewportCell extends SpreadsheetMetadataPropertyName<SpreadsheetCellReference> {
 
     /**
      * Singleton
@@ -37,6 +40,36 @@ final class SpreadsheetMetadataPropertyNameViewportCell extends SpreadsheetMetad
      */
     private SpreadsheetMetadataPropertyNameViewportCell() {
         super("viewport-cell");
+    }
+
+    /**
+     * After checking the type force the {@link SpreadsheetCellReference#toRelative()}
+     */
+    @Override
+    final SpreadsheetCellReference checkValue0(final Object value) {
+        return this.checkValueType(value,
+                v -> v instanceof SpreadsheetCellReference)
+                .toRelative();
+    }
+
+    @Override
+    final String expected() {
+        return SpreadsheetCellReference.class.getSimpleName();
+    }
+
+    @Override
+    final Optional<SpreadsheetCellReference> extractLocaleValue(final Locale locale) {
+        return Optional.empty();
+    }
+
+    @Override
+    final Class<SpreadsheetCellReference> type() {
+        return SpreadsheetCellReference.class;
+    }
+
+    @Override
+    final String compareToName() {
+        return this.value();
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCellTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCellTest.java
@@ -18,9 +18,22 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+
+import java.util.Locale;
 
 
-public final class SpreadsheetMetadataPropertyNameViewportCellTest extends SpreadsheetMetadataPropertyNameSpreadsheetCellReferenceTestCase<SpreadsheetMetadataPropertyNameViewportCell> {
+public final class SpreadsheetMetadataPropertyNameViewportCellTest extends SpreadsheetMetadataPropertyNameTestCase<SpreadsheetMetadataPropertyNameViewportCell, SpreadsheetCellReference> {
+
+    @Test
+    public final void testInvalidSpreadsheetCellReferenceFails() {
+        this.checkValueFails("invalid", "Expected SpreadsheetCellReference, but got \"invalid\" for \"" + this.createName().value() + "\"");
+    }
+
+    @Test
+    public final void testExtractLocaleValue() {
+        this.extractLocaleValueAndCheck(Locale.ENGLISH, null);
+    }
 
     @Test
     public void testToString() {
@@ -30,6 +43,16 @@ public final class SpreadsheetMetadataPropertyNameViewportCellTest extends Sprea
     @Override
     SpreadsheetMetadataPropertyNameViewportCell createName() {
         return SpreadsheetMetadataPropertyNameViewportCell.instance();
+    }
+
+    @Override
+    final SpreadsheetCellReference propertyValue() {
+        return SpreadsheetCellReference.parseCellReference("B99");
+    }
+
+    @Override
+    final String propertyValueType() {
+        return SpreadsheetCellReference.class.getSimpleName();
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
…taPropertyName

- required before changing SpreadsheetPropertyName.CELL from SpreadsheetCellReference to SpreadsheetExpressionReference