### PR TITLE
SpreadsheetExpressionReferenceVisitor.visit(SpreadsheetViewport) removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceVisitor.java
@@ -80,8 +80,4 @@ public abstract class SpreadsheetExpressionReferenceVisitor extends Visitor<Expr
     protected void visit(final SpreadsheetRange range) {
         // nop
     }
-
-    protected final void visit(final SpreadsheetViewport viewport) {
-        // nop
-    }
 }


### PR DESCRIPTION
- SpreadsheetViewport no longer extends SpreadsheetExpressionReference.