### PR TITLE
SpreadsheetSelection.parseColumn column range fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -252,7 +252,9 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
     /**
      * Leverages the {@link SpreadsheetParsers#column()} combined with an error reporter.
      */
-    private static final Parser<SpreadsheetParserContext> COLUMN_PARSER = SpreadsheetParsers.column().orReport(ParserReporters.basic());
+    private static final Parser<SpreadsheetParserContext> COLUMN_PARSER = SpreadsheetParsers.column()
+            .orFailIfCursorNotEmpty(ParserReporters.basic())
+            .orReport(ParserReporters.basic());
 
     /**
      * Parsers a range of columns.

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceParserTest.java
@@ -98,6 +98,11 @@ public final class SpreadsheetColumnReferenceParserTest extends SpreadsheetParse
     }
 
     @Test
+    public void testRange() {
+        this.parseAndCheck2("A", SpreadsheetReferenceKind.RELATIVE, A_VALUE, ":B");
+    }
+
+    @Test
     public void testMax() {
         this.parseAndCheck(
                 "XFD",

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -155,6 +155,21 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
                         SpreadsheetSelection.parseRow("1")));
     }
 
+    // parseColumn......................................................................................................
+
+    @Test
+    public void testParseColumnWithRangeFails() {
+        assertThrows(IllegalArgumentException.class, () -> SpreadsheetSelection.parseColumn("B:C"));
+    }
+
+    @Test
+    public void testParseColumn() {
+        assertEquals(
+                SpreadsheetSelection.parseColumn("B"),
+                SpreadsheetReferenceKind.RELATIVE.column(1)
+        );
+    }
+
     // parseColumnReference...............................................................................................
 
     @Test


### PR DESCRIPTION
- Previously the beginning column was consumed and the separator and end column were ignored instead of throwing.