### PR TITLE
SpreadsheetSelection.parseRow row range fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -277,7 +277,9 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
     /**
      * Leverages the {@link SpreadsheetParsers#row()} combined with an error reporter.
      */
-    private static final Parser<SpreadsheetParserContext> ROW_PARSER = SpreadsheetParsers.row().orReport(ParserReporters.basic());
+    private static final Parser<SpreadsheetParserContext> ROW_PARSER = SpreadsheetParsers.row()
+            .orFailIfCursorNotEmpty(ParserReporters.basic())
+            .orReport(ParserReporters.basic());
 
     /**
      * Parsers the text expecting a valid {@link SpreadsheetRowReference} or fails.

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetRowReferenceParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetRowReferenceParserTest.java
@@ -97,6 +97,11 @@ public final class SpreadsheetRowReferenceParserTest extends SpreadsheetParserTe
     }
 
     @Test
+    public void testRange() {
+        this.parseAndCheck2("2:34", SpreadsheetReferenceKind.RELATIVE, 2, ":34");
+    }
+
+    @Test
     public void testMaxValue() {
         this.parseAndCheck2("1048576", SpreadsheetReferenceKind.RELATIVE, SpreadsheetRowReference.MAX_VALUE);
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -312,6 +312,29 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
         );
     }
 
+    // parseRow.........................................................................................................
+
+    @Test
+    public void testParseRowWithRangeFails() {
+        assertThrows(IllegalArgumentException.class, () -> SpreadsheetSelection.parseRow("12:3"));
+    }
+
+    @Test
+    public void testParseRow() {
+        assertEquals(
+                SpreadsheetReferenceKind.RELATIVE.row(2 - 1),
+                SpreadsheetSelection.parseRow("2")
+        );
+    }
+
+    @Test
+    public void testParseRow2() {
+        assertEquals(
+                SpreadsheetReferenceKind.RELATIVE.row(23 - 1),
+                SpreadsheetSelection.parseRow("23")
+        );
+    }
+
     // ClassTesting.....................................................................................................
 
     @Override


### PR DESCRIPTION
- Previously the range separator and end row were not consumed and ignored and only the beginning row returned.