### PR TITLE
SpreadsheetSelection.parseCellReferenceRange removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -207,13 +207,6 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
     }
 
     /**
-     * Parsers a range of cell referencs.
-     */
-    public static Range<SpreadsheetCellReference> parseCellReferenceRange(final String text) {
-        return SpreadsheetCellReference.parseCellReferenceRange0(text);
-    }
-
-    /**
      * Parsers the text expecting a valid {@link SpreadsheetCellReference} or fails.
      */
     public static SpreadsheetCellReference parseCellReference(final String text) {

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -701,31 +701,6 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         );
     }
 
-    // parseCellReferenceRange..........................................................................................
-
-    @Test
-    public void testParseRange() {
-        assertEquals(Range.greaterThanEquals(SpreadsheetExpressionReference.parseCellReference("B2"))
-                        .and(Range.lessThanEquals(SpreadsheetExpressionReference.parseCellReference("D4"))),
-                SpreadsheetCellReference.parseCellReferenceRange("B2:D4"));
-    }
-
-    @Test
-    public void testParseRange2() {
-        assertEquals(Range.greaterThanEquals(SpreadsheetExpressionReference.parseCellReference("$B$2"))
-                        .and(Range.lessThanEquals(SpreadsheetExpressionReference.parseCellReference("$D$4"))),
-                SpreadsheetCellReference.parseCellReferenceRange("$B$2:$D$4"));
-    }
-
-    @Test
-    public void testParseRange3() {
-        assertEquals(Range.greaterThanEquals(SpreadsheetExpressionReference.parseCellReference("$B2"))
-                        .and(Range.lessThanEquals(SpreadsheetExpressionReference.parseCellReference("D$4"))),
-                SpreadsheetCellReference.parseCellReferenceRange("$B2:D$4"));
-    }
-
-
-
     // JsonNodeMarshallingTesting.......................................................................................
 
     @Test


### PR DESCRIPTION
- Unnecessary because of SpreadsheetSelection.parseCellRange()