### PR TITLE
BasicSpreadsheetEngine.range label fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineRangeSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineRangeSpreadsheetSelectionVisitor.java
@@ -132,7 +132,7 @@ final class BasicSpreadsheetEngineRangeSpreadsheetSelectionVisitor extends Sprea
 
     @Override
     protected void visit(final SpreadsheetLabelName label) {
-        throw new UnsupportedOperationException("Label not expected: " + label);
+        this.accept(this.context.resolveCellReference(label));
     }
 
     @Override


### PR DESCRIPTION
- Previously passing selection=label would fail, now the label is resolved to a cell/cell-range.