### PR TITLE
empty formula text without empty apostrophe

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -457,10 +457,9 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
     final static Optional<SpreadsheetParserToken> EMPTY_TOKEN = Optional.of(
             SpreadsheetParserToken.text(
                     Lists.<ParserToken>of( // J2clTranspiler: Error:BasicSpreadsheetEngine.java:386: The method of(T...) of type Lists is not applicable as the formal varargs element type T is not accessible here
-                            SpreadsheetParserToken.apostropheSymbol("\"", "\""),
                             SpreadsheetParserToken.textLiteral("", "")
                     ),
-                    "\"")
+                    "")
     );
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetTextParserToken.java
@@ -20,6 +20,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Holds a text expression in both forms an apostrophe prefixed string literal and a double quoted string.
@@ -27,7 +28,10 @@ import java.util.List;
 public final class SpreadsheetTextParserToken extends SpreadsheetParentParserToken {
 
     static SpreadsheetTextParserToken with(final List<ParserToken> value, final String text) {
-        return new SpreadsheetTextParserToken(copyAndCheckTokens(value), checkText(text));
+        return new SpreadsheetTextParserToken(
+                copyAndCheckTokens(value),
+                Objects.requireNonNull(text, "text") // empty text is allowed to support a formula with empty text
+        );
     }
 
     private SpreadsheetTextParserToken(final List<ParserToken> value, final String text) {


### PR DESCRIPTION
- Updated SpreadsheetTextParserToken to allow unconditionally empty text

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1839
- parsing empty string should give SpreadsheetTextParserToken with only SpreadsheetTextLiteralParserToken and not include SpreadsheetApostropheSymbolParserToken