### PR TITLE
mP1/walkingkooka-text-cursor-parser-ebnf/pull/35 EbnfParserCombinator…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformerTest.java
@@ -24,7 +24,7 @@ import walkingkooka.text.cursor.parser.ebnf.combinator.EbnfParserCombinatorSynta
 import walkingkooka.text.cursor.parser.ebnf.combinator.EbnfParserCombinatorSyntaxTreeTransformerTesting;
 
 public final class SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformerTest implements ClassTesting2<SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer>,
-        EbnfParserCombinatorSyntaxTreeTransformerTesting<SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer>,
+        EbnfParserCombinatorSyntaxTreeTransformerTesting<SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer, SpreadsheetParserContext>,
         TypeNameTesting<SpreadsheetParsersEbnfParserCombinatorSyntaxTreeTransformer> {
 
     // Class............................................................................................................


### PR DESCRIPTION
…SyntaxTreeTransformerTesting added missing ParserContext type parameter

- https://github.com/mP1/walkingkooka-text-cursor-parser-ebnf/pull/35
- EbnfParserCombinatorSyntaxTreeTransformerTesting added missing ParserContext type parameter