### PR TITLE
SpreadsheetExpressionFunctionContexts

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/function/FakeSpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/function/FakeSpreadsheetExpressionFunctionContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.function;
+
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
+
+public class FakeSpreadsheetExpressionFunctionContext extends FakeExpressionFunctionContext implements SpreadsheetExpressionFunctionContext {
+    @Override
+    public SpreadsheetCellReference cell() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.function;
+
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
+
+/**
+ * Enhances {@link ExpressionFunctionContext} adding a few extra methods required by a spreadsheet during
+ * function execution.
+ */
+public interface SpreadsheetExpressionFunctionContext extends ExpressionFunctionContext {
+
+    /**
+     * Returns the current cell that owns the expression or formula being executed.
+     */
+    SpreadsheetCellReference cell();
+}

--- a/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContexts.java
@@ -1,0 +1,38 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.function;
+
+import walkingkooka.reflect.PublicStaticHelper;
+
+public final class SpreadsheetExpressionFunctionContexts implements PublicStaticHelper {
+
+    /**
+     * {@see FakeSpreadsheetExpressionFunctionContext}
+     */
+    public static FakeSpreadsheetExpressionFunctionContext fake() {
+        return new FakeSpreadsheetExpressionFunctionContext();
+    }
+
+    /**
+     * Stop creation
+     */
+    private SpreadsheetExpressionFunctionContexts() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContextsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContextsTest.java
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.function;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.ClassTesting2;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.reflect.PublicStaticHelperTesting;
+
+import java.lang.reflect.Method;
+import java.math.MathContext;
+
+public final class SpreadsheetExpressionFunctionContextsTest implements ClassTesting2<SpreadsheetExpressionFunctionContexts>,
+        PublicStaticHelperTesting<SpreadsheetExpressionFunctionContexts> {
+
+    @Test
+    public void testPublicStaticMethodsWithoutMathContextParameter() {
+        this.publicStaticMethodParametersTypeCheck(MathContext.class);
+    }
+
+    @Override
+    public Class<SpreadsheetExpressionFunctionContexts> type() {
+        return SpreadsheetExpressionFunctionContexts.class;
+    }
+
+    @Override
+    public boolean canHavePublicTypes(final Method method) {
+        return false;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- Necessary to support functions sucb as row() without parameters default to using the current cell.