### PR TITLE
SpreadsheetExpressionFunctionContext SpreadsheetCell was SpreadsheetC…

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -199,7 +199,7 @@ public class JunitTest {
 
             @Override
             public Object evaluate(final Expression node,
-                                   final Optional<SpreadsheetCellReference> cell) {
+                                   final Optional<SpreadsheetCell> cell) {
                 return node.toValue(
                         ExpressionEvaluationContexts.basic(
                                 EXPRESSION_NUMBER_KIND,

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -21,6 +21,7 @@ import walkingkooka.Cast;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.math.Fraction;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
@@ -158,7 +159,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
 
     @Override
     public Object evaluate(final Expression node,
-                           final Optional<SpreadsheetCellReference> cell) {
+                           final Optional<SpreadsheetCell> cell) {
         final SpreadsheetMetadata metadata = this.metadata;
 
         final ExpressionNumberKind kind = metadata.expressionNumberKind();

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
@@ -19,8 +19,8 @@ package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.Either;
 import walkingkooka.convert.ConverterContext;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.function.SpreadsheetExpressionFunctionContext;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
@@ -35,7 +35,7 @@ import java.util.function.Function;
 
 final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext implements SpreadsheetExpressionFunctionContext {
 
-    static BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext with(final Optional<SpreadsheetCellReference> cell,
+    static BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext with(final Optional<SpreadsheetCell> cell,
                                                                                   final ExpressionNumberKind expressionNumberKind,
                                                                                   final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
                                                                                   final ConverterContext converterContext) {
@@ -49,7 +49,7 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
         );
     }
 
-    private BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext(final Optional<SpreadsheetCellReference> cell,
+    private BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext(final Optional<SpreadsheetCell> cell,
                                                                               final ExpressionNumberKind expressionNumberKind,
                                                                               final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
                                                                               final ConverterContext converterContext) {
@@ -75,11 +75,11 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
     }
 
     @Override
-    public Optional<SpreadsheetCellReference> cell() {
+    public Optional<SpreadsheetCell> cell() {
         return this.cell;
     }
 
-    private final Optional<SpreadsheetCellReference> cell;
+    private final Optional<SpreadsheetCell> cell;
 
     @Override
     public boolean canConvert(final Object value,

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
@@ -133,7 +133,7 @@ abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
                                          final SpreadsheetEngineContext context) {
         final SpreadsheetCell fixed = cell.setFormula(
                 this.engine.parseFormulaIfNecessary(
-                        cell.formula(),
+                        cell,
                         this::fixCellReferencesWithinExpression,
                         context));
         if (!cell.equals(fixed)) {

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
@@ -19,7 +19,6 @@ package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.SpreadsheetCell;
-import walkingkooka.spreadsheet.SpreadsheetFormula;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 
@@ -128,17 +127,19 @@ final class BasicSpreadsheetEngineFillCells {
                           final int xOffset,
                           final int yOffset) {
         final SpreadsheetCell updatedReference = cell.setReference(cell.reference().add(xOffset, yOffset));
-        final SpreadsheetFormula formula = updatedReference.formula();
 
         final BasicSpreadsheetEngine engine = this.engine;
         final SpreadsheetEngineContext context = this.context;
 
         // possibly fix references, and then parse the formula and evaluate etc.
-        final SpreadsheetCell save = updatedReference.setFormula(engine.parseFormulaIfNecessary(formula,
-                token -> BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.expressionFixReferences(token,
+        final SpreadsheetCell save = updatedReference.setFormula(engine.parseFormulaIfNecessary(
+                updatedReference,
+                token -> BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.expressionFixReferences(
+                        token,
                         xOffset,
                         yOffset),
-                context));
+                context)
+        );
         this.engine.maybeParseAndEvaluateAndFormat(save,
                 SpreadsheetEngineEvaluation.CLEAR_VALUE_ERROR_SKIP_EVALUATE,
                 context);

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.convert.FakeConverterContext;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -52,7 +53,7 @@ public class FakeSpreadsheetEngineContext extends FakeConverterContext implement
 
     @Override
     public Object evaluate(final Expression node,
-                           final Optional<SpreadsheetCellReference> cell) {
+                           final Optional<SpreadsheetCell> cell) {
         Objects.requireNonNull(node, "node");
         Objects.requireNonNull(cell, "cell");
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.Context;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -54,7 +55,7 @@ public interface SpreadsheetEngineContext extends Context {
     /**
      * Evaluates the expression into a value.
      */
-    Object evaluate(final Expression node, final Optional<SpreadsheetCellReference> cell);
+    Object evaluate(final Expression node, final Optional<SpreadsheetCell> cell);
 
     /**
      * Accepts a pattern and returns the equivalent {@link SpreadsheetFormatter}.

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.ContextTesting;
 import walkingkooka.locale.HasLocaleTesting;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetText;
@@ -167,7 +168,7 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
 
     default void evaluateAndCheck(final SpreadsheetEngineContext context,
                                   final Expression expression,
-                                  final Optional<SpreadsheetCellReference> cell,
+                                  final Optional<SpreadsheetCell> cell,
                                   final Object expected) {
         this.checkEquals(
                 expected,

--- a/src/main/java/walkingkooka/spreadsheet/function/FakeSpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/function/FakeSpreadsheetExpressionFunctionContext.java
@@ -17,14 +17,14 @@
 
 package walkingkooka.spreadsheet.function;
 
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
 import java.util.Optional;
 
 public class FakeSpreadsheetExpressionFunctionContext extends FakeExpressionFunctionContext implements SpreadsheetExpressionFunctionContext {
     @Override
-    public Optional<SpreadsheetCellReference> cell() {
+    public Optional<SpreadsheetCell> cell() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/function/SpreadsheetExpressionFunctionContext.java
@@ -17,7 +17,7 @@
 
 package walkingkooka.spreadsheet.function;
 
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.Optional;
@@ -31,5 +31,5 @@ public interface SpreadsheetExpressionFunctionContext extends ExpressionFunction
     /**
      * Returns the current cell that owns the expression or formula being executed.
      */
-    Optional<SpreadsheetCellReference> cell();
+    Optional<SpreadsheetCell> cell();
 }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -7891,7 +7891,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
             @Override
             public Object evaluate(final Expression node,
-                                   final Optional<SpreadsheetCellReference> cell) {
+                                   final Optional<SpreadsheetCell> cell) {
                 return node.toValue(
                         ExpressionEvaluationContexts.basic(
                                 this.metadata().expressionNumberKind(),

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -410,7 +410,7 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
 
             @Override
             public Object evaluate(final Expression node,
-                                   final Optional<SpreadsheetCellReference> cell) {
+                                   final Optional<SpreadsheetCell> cell) {
                 return FORMULA_VALUE;
             }
 

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -187,7 +187,7 @@ public final class Sample {
 
             @Override
             public Object evaluate(final Expression node,
-                                   final Optional<SpreadsheetCellReference> cell) {
+                                   final Optional<SpreadsheetCell> cell) {
                 return node.toValue(
                         ExpressionEvaluationContexts.basic(
                                 EXPRESSION_NUMBER_KIND,


### PR DESCRIPTION
…ellReference

- cell() Optional<SpreadsheetCell> was Optional<SpreadsheetCellReference>.
- SpreadsheetEngineContext.evaluate, Optional<SpreadsheetCell> was Optional<SpreadsheetCellReference>.
- necessary because functions like function: formulatext require various SpreadsheetCell properties