### PR TITLE
https://github.com/mP1/walkingkooka-tree/pull/409 ExpressionFunctionC…

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -204,7 +204,6 @@ public class JunitTest {
                         ExpressionEvaluationContexts.basic(
                                 EXPRESSION_NUMBER_KIND,
                                 functions(),
-                                references(),
                                 this.functionContext()
                         )
                 );
@@ -216,20 +215,20 @@ public class JunitTest {
                 };
             }
 
-            private Function<ExpressionReference, Optional<Expression>> references() {
-                return SpreadsheetEngines.expressionEvaluationContextExpressionReferenceExpressionFunction(
-                        engine,
-                        this.storeRepository().labels(),
-                        this
-                );
-            }
-
             private ExpressionFunctionContext functionContext() {
                 return ExpressionFunctionContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
                         this.references(),
                         metadata.converterContext()
+                );
+            }
+
+            private Function<ExpressionReference, Optional<Object>> references() {
+                return SpreadsheetEngines.expressionEvaluationContextExpressionReferenceExpressionFunction(
+                        engine,
+                        this.storeRepository().labels(),
+                        this
                 );
             }
 

--- a/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
@@ -59,9 +59,7 @@ final class BasicSpreadsheetDataValidatorContext implements SpreadsheetDataValid
                                                  final ExpressionEvaluationContext context) {
         super();
         this.cellReference = cellReference;
-        this.value = Optional.of(
-                Expression.value(value)
-        );
+        this.value = Optional.of(value);
         this.context = context;
     }
 
@@ -98,13 +96,13 @@ final class BasicSpreadsheetDataValidatorContext implements SpreadsheetDataValid
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
+    public Optional<Object> reference(final ExpressionReference reference) {
         return this.cellReference().equals(reference) ?
                 this.value :
                 this.context.reference(reference);
     }
 
-    private final Optional<Expression> value;
+    private final Optional<Object> value;
 
     @Override
     public Locale locale() {

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -40,10 +40,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetRowReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetLabelStore;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
-import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.Expression;
-import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.text.Length;
 import walkingkooka.tree.text.TextNode;
 import walkingkooka.tree.text.TextStyle;
@@ -511,7 +509,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                 );
             }
 
-        } catch (final ExpressionEvaluationException cause) {
+        } catch (final Exception cause) {
             formula = this.setError(formula, cause);
         }
         return formula;

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -170,13 +170,13 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                 ExpressionEvaluationContexts.basic(
                         metadata.expressionNumberKind(),
                         this.functions,
-                        this.function,
                         BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.with(
                                 cell,
                                 this.storeRepository.cells(),
                                 this.serverUrl,
                                 metadata,
-                                this.functions
+                                this.functions,
+                                this.function
                         )
                 )
         );

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -43,7 +44,8 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
                                                                                   final SpreadsheetCellStore cellStore,
                                                                                   final AbsoluteUrl serverUrl,
                                                                                   final SpreadsheetMetadata spreadsheetMetadata,
-                                                                                  final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions) {
+                                                                                  final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
+                                                                                  final Function<ExpressionReference, Optional<Object>> references) {
         Objects.requireNonNull(cell, "cell");
 
         return new BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext(
@@ -51,7 +53,8 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
                 cellStore,
                 serverUrl,
                 spreadsheetMetadata,
-                functions
+                functions,
+                references
         );
     }
 
@@ -59,13 +62,15 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
                                                                               final SpreadsheetCellStore cellStore,
                                                                               final AbsoluteUrl serverUrl,
                                                                               final SpreadsheetMetadata spreadsheetMetadata,
-                                                                              final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions) {
+                                                                              final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionFunctionContext>> functions,
+                                                                              final Function<ExpressionReference, Optional<Object>> references) {
         super();
         this.cell = cell;
         this.cellStore = cellStore;
         this.serverUrl = serverUrl;
         this.spreadsheetMetadata = spreadsheetMetadata;
         this.functions = functions;
+        this.references = references;
     }
 
     // SpreadsheetExpressionFunctionContext............................................................................
@@ -113,6 +118,13 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
         return this.function(name)
                 .apply(parameters, this);
     }
+
+    @Override
+    public Optional<Object> reference(final ExpressionReference reference) {
+        return this.references.apply(reference);
+    }
+
+    private final Function<ExpressionReference, Optional<Object>> references;
 
     @Override
     public boolean canConvert(final Object value,

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineExpressionEvaluationContext.java
@@ -63,7 +63,7 @@ final class BasicSpreadsheetEngineExpressionEvaluationContext implements Express
     }
 
     @Override
-    public Optional<Expression> reference(ExpressionReference expressionReference) {
+    public Optional<Object> reference(ExpressionReference expressionReference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.engine;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetLabelStore;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.Optional;
@@ -53,9 +52,9 @@ public final class SpreadsheetEngines implements PublicStaticHelper {
     /**
      * {@see SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunction}
      */
-    public static Function<ExpressionReference, Optional<Expression>> expressionEvaluationContextExpressionReferenceExpressionFunction(final SpreadsheetEngine engine,
-                                                                                                                                       final SpreadsheetLabelStore labelStore,
-                                                                                                                                       final SpreadsheetEngineContext context) {
+    public static Function<ExpressionReference, Optional<Object>> expressionEvaluationContextExpressionReferenceExpressionFunction(final SpreadsheetEngine engine,
+                                                                                                                                   final SpreadsheetLabelStore labelStore,
+                                                                                                                                   final SpreadsheetEngineContext context) {
         return SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunction.with(engine, labelStore, context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
@@ -55,7 +55,7 @@ final class SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext i
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference expressionReference) {
+    public Optional<Object> reference(final ExpressionReference expressionReference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
@@ -58,7 +58,7 @@ final class SpreadsheetParserPattern2ExpressionEvaluationContext implements Expr
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference expressionReference) {
+    public Optional<Object> reference(final ExpressionReference expressionReference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
@@ -48,7 +48,7 @@ final class SpreadsheetParsersExpressionEvaluationContext implements ExpressionE
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
+    public Optional<Object> reference(final ExpressionReference reference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
@@ -59,7 +59,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpres
     }
 
     @Override
-    public Optional<Expression> reference(final ExpressionReference reference) {
+    public Optional<Object> reference(final ExpressionReference reference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunctionTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.engine;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetLabelStore;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetLabelStores;
-import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.util.FunctionTesting;
 
@@ -29,7 +28,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunctionTest
-        implements FunctionTesting<SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunction, ExpressionReference, Optional<Expression>> {
+        implements FunctionTesting<SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionFunction, ExpressionReference, Optional<Object>> {
 
     @Test
     public void testWithNullEngineFails() {

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
@@ -2227,8 +2227,8 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
             }
 
             @Override
-            public Optional<Expression> reference(final ExpressionReference reference) {
-                throw new UnsupportedOperationException();//return context.reference(reference);
+            public Optional<Object> reference(final ExpressionReference reference) {
+                throw new UnsupportedOperationException();
             }
 
             @Override

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -192,7 +192,6 @@ public final class Sample {
                         ExpressionEvaluationContexts.basic(
                                 EXPRESSION_NUMBER_KIND,
                                 functions(),
-                                references(),
                                 this.functionContext()
                         )
                 );
@@ -204,20 +203,20 @@ public final class Sample {
                 };
             }
 
-            private Function<ExpressionReference, Optional<Expression>> references() {
-                return SpreadsheetEngines.expressionEvaluationContextExpressionReferenceExpressionFunction(
-                        engine,
-                        this.storeRepository().labels(),
-                        this
-                );
-            }
-
             private ExpressionFunctionContext functionContext() {
                 return ExpressionFunctionContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
                         this.references(),
                         metadata.converterContext()
+                );
+            }
+
+            private Function<ExpressionReference, Optional<Object>> references() {
+                return SpreadsheetEngines.expressionEvaluationContextExpressionReferenceExpressionFunction(
+                        engine,
+                        this.storeRepository().labels(),
+                        this
                 );
             }
 


### PR DESCRIPTION
…ontext.reference pulled from ExpressionEvaluationContext

- BasicSpreadsheetEngine when evaluating now catches Exception was ExpressionEvaluationException.
- BasicSpreadsheetEngineTest updated error messages when unable to find cell-reference or label. Need to match Excel

- https://github.com/mP1/walkingkooka-tree/pull/409
- ExpressionFunctionContext.reference pulled from ExpressionEvaluationContext