### PR TITLE
SpreadsheetErrorKind.translate HasExpressionReference aware

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
@@ -28,6 +28,7 @@ package walkingkooka.spreadsheet;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.text.cursor.parser.ParserException;
+import walkingkooka.tree.expression.HasExpressionReference;
 
 import java.util.Objects;
 
@@ -96,6 +97,12 @@ public enum SpreadsheetErrorKind implements HasText {
         SpreadsheetErrorKind kind = null;
 
         do {
+            // REF!
+            if (cause instanceof HasExpressionReference) {
+                kind = REF;
+                break;
+            }
+
             // Trying to divide by 0
             if (cause instanceof ArithmeticException) {
                 kind = DIV0;

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
@@ -20,7 +20,10 @@ package walkingkooka.spreadsheet;
 import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.store.SpreadsheetExpressionReferenceLoadStoreException;
 import walkingkooka.text.cursor.parser.ParserException;
+import walkingkooka.tree.expression.ExpressionEvaluationReferenceException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -37,6 +40,28 @@ public final class SpreadsheetErrorKindTest implements ClassTesting<SpreadsheetE
     }
 
     private final static String MESSAGE = "Hello 123";
+
+    @Test
+    public void testTranslateHasExpressionReferenceException() {
+        this.translateAndCheck(
+                new ExpressionEvaluationReferenceException(
+                        MESSAGE,
+                        SpreadsheetSelection.parseCell("A1")
+                ),
+                SpreadsheetErrorKind.REF
+        );
+    }
+
+    @Test
+    public void testTranslateHasExpressionReferenceException2() {
+        this.translateAndCheck(
+                new SpreadsheetExpressionReferenceLoadStoreException(
+                        MESSAGE,
+                        SpreadsheetSelection.parseCell("B2")
+                ),
+                SpreadsheetErrorKind.REF
+        );
+    }
 
     @Test
     public void testTranslateArithmeticException() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1915
- when translating exception HasReference should be tested and translated to #REF