### PR TITLE
SpreadsheetDelta cells, columns, labels, rows set equality fixes

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
@@ -1078,12 +1078,34 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
                 .column();
         final SpreadsheetDelta before = SpreadsheetDelta.EMPTY
                 .setColumns(
-                        Sets.of(column)
+                        Sets.of(column.setHidden(false))
                 );
 
         final SpreadsheetDelta after = before.setColumns(
                 Sets.of(
-                        column.setHidden(!column.hidden())
+                        column.setHidden(true)
+                )
+        );
+
+        this.patchColumnsAndCheck(
+                before,
+                marshall(after),
+                after
+        );
+    }
+
+    @Test
+    public void testPatchColumnsReplacesColumn2() {
+        final SpreadsheetColumn column = SpreadsheetSelection.parseColumn("Z")
+                .column();
+        final SpreadsheetDelta before = SpreadsheetDelta.EMPTY
+                .setColumns(
+                        Sets.of(column.setHidden(true))
+                );
+
+        final SpreadsheetDelta after = before.setColumns(
+                Sets.of(
+                        column.setHidden(false)
                 )
         );
 
@@ -1347,12 +1369,36 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
                 .row();
         final SpreadsheetDelta before = SpreadsheetDelta.EMPTY
                 .setRows(
-                        Sets.of(row)
+                        Sets.of(
+                                row.setHidden(false)
+                        )
                 );
 
         final SpreadsheetDelta after = before.setRows(
                 Sets.of(
-                        row.setHidden(!row.hidden())
+                        row.setHidden(true)
+                )
+        );
+
+        this.patchRowsAndCheck(
+                before,
+                marshall(after),
+                after
+        );
+    }
+
+    @Test
+    public void testPatchRowsReplacesRow2() {
+        final SpreadsheetRow row = SpreadsheetSelection.parseRow("9")
+                .row();
+        final SpreadsheetDelta before = SpreadsheetDelta.EMPTY
+                .setRows(
+                        Sets.of(row.setHidden(true))
+                );
+
+        final SpreadsheetDelta after = before.setRows(
+                Sets.of(
+                        row.setHidden(false)
                 )
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
@@ -841,7 +841,12 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         final Set<SpreadsheetLabelMapping> labels = this.differentLabels();
         this.checkNotEquals(this.labels(), labels, "labels() and differentLabels() must be un equal");
 
-        this.checkNotEquals(this.createSpreadsheetDelta().setLabels(labels));
+        final SpreadsheetDelta delta = this.createSpreadsheetDelta();
+
+        this.checkNotEquals(
+                delta,
+                delta.setLabels(labels)
+        );
     }
 
     @Test
@@ -929,12 +934,18 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
     // cells............................................................................................................
 
     final Set<SpreadsheetCell> cells() {
-        return Sets.of(this.a1(), this.b2(), this.c3());
+        return Sets.of(
+                this.a1(),
+                this.b2(),
+                this.c3()
+        );
     }
 
     final Set<SpreadsheetCell> differentCells() {
         return Sets.of(
-                this.cell("E5", "5")
+                this.a1().setFormula(SpreadsheetFormula.EMPTY.setText("'different A1")),
+                this.b2().setFormula(SpreadsheetFormula.EMPTY.setText("'different B2")),
+                this.c3().setFormula(SpreadsheetFormula.EMPTY.setText("'different C3"))
         );
     }
 
@@ -983,11 +994,21 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
     // columns.........................................................................................................
 
     final Set<SpreadsheetColumn> columns() {
-        return Sets.of(this.a(), this.b(), this.c());
+        return Sets.of(
+                this.a(),
+                this.b(),
+                this.c(),
+                this.hiddenD()
+        );
     }
 
     final Set<SpreadsheetColumn> differentColumns() {
-        return Sets.of(this.a());
+        return Sets.of(
+                this.a(),
+                this.b(),
+                this.c(),
+                this.hiddenD().setHidden(false)
+        );
     }
 
     final SpreadsheetColumn a() {
@@ -1038,6 +1059,17 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         );
     }
 
+    final Set<SpreadsheetLabelMapping> differentLabels() {
+        final SpreadsheetCellReference a1 = this.a1().reference();
+
+        return Sets.of(
+                this.label1a().mapping(a1),
+                this.label1b().mapping(a1),
+                this.label2().mapping(a1),
+                this.label3().mapping(a1)
+        );
+    }
+
     final void checkLabels(final SpreadsheetDelta delta) {
         this.checkLabels(delta, this.labels());
     }
@@ -1047,12 +1079,6 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         this.checkEquals(labels, delta.labels(), "labels");
         assertThrows(UnsupportedOperationException.class, () -> delta.labels()
                 .add(SpreadsheetLabelName.labelName("LabelZ").mapping(SpreadsheetCellReference.parseCell("Z9")))
-        );
-    }
-
-    final Set<SpreadsheetLabelMapping> differentLabels() {
-        return Sets.of(
-                SpreadsheetLabelName.labelName("different").mapping(this.a1().reference())
         );
     }
 
@@ -1075,11 +1101,21 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
     // rows.........................................................................................................
 
     final Set<SpreadsheetRow> rows() {
-        return Sets.of(this.row1(), this.row2(), this.row3());
+        return Sets.of(
+                this.row1(),
+                this.row2(),
+                this.row3(),
+                this.hiddenRow4()
+        );
     }
 
     final Set<SpreadsheetRow> differentRows() {
-        return Sets.of(this.row1());
+        return Sets.of(
+                this.row1(),
+                this.row2(),
+                this.row3(),
+                this.hiddenRow4().setHidden(false)
+        );
     }
 
     final SpreadsheetRow row1() {
@@ -1357,6 +1393,7 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         object = columnsJson0(this.a(), context, object);
         object = columnsJson0(this.b(), context, object);
         object = columnsJson0(this.c(), context, object);
+        object = columnsJson0(this.hiddenD(), context, object);
 
         return object;
     }
@@ -1393,6 +1430,7 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         object = rowsJson0(this.row1(), context, object);
         object = rowsJson0(this.row2(), context, object);
         object = rowsJson0(this.row3(), context, object);
+        object = rowsJson0(this.hiddenRow4(), context, object);
 
         return object;
     }


### PR DESCRIPTION
- Previously all sets were compared often only testing the SpreadsheetSelection and ignoring other properties. This meant if the SpreadsheetDelta.setColumns was set with the same columns but different hidden properties the set would be ignored and the original SpreadsheetDelta returned.