### PR TITLE
SpreadsheetViewportSelectionNavigation.perform hidden column/row skip

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
@@ -22,6 +22,8 @@ import walkingkooka.collect.HasRangeBounds;
 import walkingkooka.collect.Range;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -289,42 +291,54 @@ public final class SpreadsheetCellRange extends SpreadsheetExpressionReference
     }
 
     @Override
-    SpreadsheetCellReference left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference left(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return anchor.cell(this)
-                .left(anchor);
+                .left(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetCellReference up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference up(final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore) {
         return anchor.cell(this)
-                .up(anchor);
+                .up(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetCellReference right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference right(final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore) {
         return anchor.cell(this)
-                .right(anchor);
+                .right(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetCellReference down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference down(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return anchor.cell(this)
-                .down(anchor);
+                .down(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendColumn(
                 anchor,
-                SpreadsheetColumnReference::left
+                (r) -> r.left(columnStore)
         );
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.extendColumn(
                 anchor,
-                SpreadsheetColumnReference::right
+                (r) -> r.right(columnStore)
         );
     }
 
@@ -350,18 +364,22 @@ public final class SpreadsheetCellRange extends SpreadsheetExpressionReference
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.extendRow(
                 anchor,
-                SpreadsheetRowReference::up
+                (r) -> r.up(rowStore)
         );
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRow(
                 anchor,
-                SpreadsheetRowReference::down
+                (r) -> r.down(rowStore)
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -24,6 +24,8 @@ import walkingkooka.spreadsheet.SpreadsheetFormula;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserException;
@@ -293,61 +295,77 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrLa
     }
 
     @Override
-    SpreadsheetCellReference left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference left(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return this.column()
-                .left()
+                .left(columnStore)
                 .setRow(this.row());
     }
 
     @Override
-    SpreadsheetCellReference up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference up(final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore) {
         return this.row()
-                .up()
+                .up(rowStore)
                 .setColumn(this.column());
     }
 
     @Override
-    SpreadsheetCellReference right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference right(final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore) {
         return this.column()
-                .right()
+                .right(columnStore)
                 .setRow(this.row());
     }
 
     @Override
-    SpreadsheetCellReference down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetCellReference down(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return this.row()
-                .down()
+                .down(rowStore)
                 .setColumn(this.column());
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.left(anchor),
+                this.left(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.up(anchor),
+                this.up(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT);
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.right(anchor),
+                this.right(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.TOP_LEFT);
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.down(anchor),
+                this.down(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.TOP_LEFT);
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -20,8 +20,11 @@ package walkingkooka.spreadsheet.reference;
 import walkingkooka.Cast;
 import walkingkooka.collect.Range;
 import walkingkooka.spreadsheet.SpreadsheetColumn;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Represents a column reference. The {@link Comparable} method ignores the {@link SpreadsheetReferenceKind} component
@@ -247,57 +250,73 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
         return SpreadsheetViewportSelectionAnchor.COLUMN;
     }
 
-    SpreadsheetColumnReference left() {
-        return this.addSaturated(-1);
+    SpreadsheetColumnReference left(final SpreadsheetColumnStore columnStore) {
+        return columnStore.leftSkipHidden(this);
     }
 
-    SpreadsheetColumnReference right() {
-        return this.addSaturated(1);
-    }
-
-    @Override
-    SpreadsheetColumnReference left(final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.left();
+    SpreadsheetColumnReference right(final SpreadsheetColumnStore columnStore) {
+        return columnStore.rightSkipHidden(this);
     }
 
     @Override
-    SpreadsheetColumnReference up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReference left(final SpreadsheetViewportSelectionAnchor anchor,
+                                    final SpreadsheetColumnStore columnStore,
+                                    final SpreadsheetRowStore rowStore) {
+        return this.left(columnStore);
+    }
+
+    @Override
+    SpreadsheetColumnReference up(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetColumnReference right(final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.right();
+    SpreadsheetColumnReference right(final SpreadsheetViewportSelectionAnchor anchor,
+                                     final SpreadsheetColumnStore columnStore,
+                                     final SpreadsheetRowStore rowStore) {
+        return this.right(columnStore);
     }
 
     @Override
-    SpreadsheetColumnReference down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReference down(final SpreadsheetViewportSelectionAnchor anchor,
+                                    final SpreadsheetColumnStore columnStore,
+                                    final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.left(anchor),
+                this.left(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.RIGHT);
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.right(anchor),
+                this.right(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.LEFT);
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRange.java
@@ -18,6 +18,8 @@
 package walkingkooka.spreadsheet.reference;
 
 import walkingkooka.collect.Range;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -118,40 +120,52 @@ public final class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOrRo
     }
 
     @Override
-    SpreadsheetColumnReference left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReference left(final SpreadsheetViewportSelectionAnchor anchor,
+                                    final SpreadsheetColumnStore columnStore,
+                                    final SpreadsheetRowStore rowStore) {
         return anchor.column(this)
-                .left(anchor);
+                .left(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetColumnReferenceRange up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReferenceRange up(final SpreadsheetViewportSelectionAnchor anchor,
+                                       final SpreadsheetColumnStore columnStore,
+                                       final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetColumnReference right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReference right(final SpreadsheetViewportSelectionAnchor anchor,
+                                     final SpreadsheetColumnStore columnStore,
+                                     final SpreadsheetRowStore rowStore) {
         return anchor.column(this)
-                .right(anchor);
+                .right(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetColumnReferenceRange down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetColumnReferenceRange down(final SpreadsheetViewportSelectionAnchor anchor,
+                                         final SpreadsheetColumnStore columnStore,
+                                         final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendColumn(
                 anchor,
-                SpreadsheetColumnReference::left
+                (c) -> c.left(columnStore)
         );
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.extendColumn(
                 anchor,
-                SpreadsheetColumnReference::right
+                (c) -> c.right(columnStore)
         );
     }
 
@@ -164,12 +178,16 @@ public final class SpreadsheetColumnReferenceRange extends SpreadsheetColumnOrRo
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
@@ -21,6 +21,8 @@ import walkingkooka.InvalidTextLengthException;
 import walkingkooka.naming.Name;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
 
@@ -152,42 +154,58 @@ final public class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabelN
     }
 
     @Override
-    SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor,
+                              final SpreadsheetColumnStore columnStore,
+                              final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor,
+                               final SpreadsheetColumnStore columnStore,
+                               final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor,
+                              final SpreadsheetColumnStore columnStore,
+                              final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.reference;
 import walkingkooka.Cast;
 import walkingkooka.collect.Range;
 import walkingkooka.spreadsheet.SpreadsheetRow;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Objects;
 
@@ -231,56 +233,72 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
         return SpreadsheetViewportSelectionAnchor.ROW;
     }
 
-    SpreadsheetRowReference up() {
-        return this.addSaturated(-1);
+    SpreadsheetRowReference up(final SpreadsheetRowStore store) {
+        return store.upSkipHidden(this);
     }
 
-    SpreadsheetRowReference down() {
-        return this.addSaturated(1);
+    SpreadsheetRowReference down(final SpreadsheetRowStore store) {
+        return store.downSkipHidden(this);
     }
 
     @Override
-    SpreadsheetRowReference left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReference left(final SpreadsheetViewportSelectionAnchor anchor,
+                                 final SpreadsheetColumnStore columnStore,
+                                 final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetRowReference up(final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.up();
+    SpreadsheetRowReference up(final SpreadsheetViewportSelectionAnchor anchor,
+                               final SpreadsheetColumnStore columnStore,
+                               final SpreadsheetRowStore rowStore) {
+        return this.up(rowStore);
     }
 
     @Override
-    SpreadsheetRowReference right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReference right(final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetRowReference down(final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.down();
+    SpreadsheetRowReference down(final SpreadsheetViewportSelectionAnchor anchor,
+                                 final SpreadsheetColumnStore columnStore,
+                                 final SpreadsheetRowStore rowStore) {
+        return this.down(rowStore);
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.up(anchor),
+                this.up(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.BOTTOM);
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRange(
-                this.down(anchor),
+                this.down(anchor, columnStore, rowStore),
                 anchor
         ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.TOP);
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRange.java
@@ -18,6 +18,8 @@
 package walkingkooka.spreadsheet.reference;
 
 import walkingkooka.collect.Range;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -130,40 +132,52 @@ public final class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRowRe
     }
 
     @Override
-    SpreadsheetRowReferenceRange left(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReferenceRange left(final SpreadsheetViewportSelectionAnchor anchor,
+                                      final SpreadsheetColumnStore columnStore,
+                                      final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetRowReference up(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReference up(final SpreadsheetViewportSelectionAnchor anchor,
+                               final SpreadsheetColumnStore columnStore,
+                               final SpreadsheetRowStore rowStore) {
         return anchor.row(this)
-                .up(anchor);
+                .up(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetRowReferenceRange right(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReferenceRange right(final SpreadsheetViewportSelectionAnchor anchor,
+                                       final SpreadsheetColumnStore columnStore,
+                                       final SpreadsheetRowStore rowStore) {
         return this;
     }
 
     @Override
-    SpreadsheetRowReference down(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetRowReference down(final SpreadsheetViewportSelectionAnchor anchor,
+                                 final SpreadsheetColumnStore columnStore,
+                                 final SpreadsheetRowStore rowStore) {
         return anchor.row(this)
-                .down(anchor);
+                .down(anchor, columnStore, rowStore);
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                          final SpreadsheetColumnStore columnStore,
+                                          final SpreadsheetRowStore rowStore) {
         return this.extendRow(
                 anchor,
-                SpreadsheetRowReference::up
+                r -> r.up(rowStore)
         );
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.extendRow(
                 anchor,
-                SpreadsheetRowReference::down
+                r -> r.down(rowStore)
         );
     }
 
@@ -176,12 +190,16 @@ public final class SpreadsheetRowReferenceRange extends SpreadsheetColumnOrRowRe
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                            final SpreadsheetColumnStore columnStore,
+                                            final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor) {
+    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                             final SpreadsheetColumnStore columnStore,
+                                             final SpreadsheetRowStore rowStore) {
         return this.setAnchor(anchor);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -29,6 +29,8 @@ import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
 import walkingkooka.spreadsheet.parser.SpreadsheetRowReferenceParserToken;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.CharacterConstant;
 import walkingkooka.text.cursor.TextCursors;
@@ -466,21 +468,37 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
      */
     public abstract SpreadsheetViewportSelectionAnchor defaultAnchor();
 
-    abstract SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor,
+                                       final SpreadsheetColumnStore columnStore,
+                                       final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor,
+                                     final SpreadsheetColumnStore columnStore,
+                                     final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor,
+                                       final SpreadsheetColumnStore columnStore,
+                                       final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                                     final SpreadsheetColumnStore columnStore,
+                                                     final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                                   final SpreadsheetColumnStore columnStore,
+                                                   final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor);
+    abstract SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                                     final SpreadsheetColumnStore columnStore,
+                                                     final SpreadsheetRowStore rowStore);
 
     /**
      * Factory that creates or extends a {@link SpreadsheetSelection} into a range. Note the other is either a

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.reference;
 
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.CharSequences;
 
 /**
@@ -26,61 +28,77 @@ public enum SpreadsheetViewportSelectionNavigation {
     LEFT {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.left(anchor)
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.left(anchor, columnStore, rowStore)
                     .setAnchorOrDefault(anchor);
         }
     },
     UP {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.up(anchor)
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.up(anchor, columnStore, rowStore)
                     .setAnchorOrDefault(anchor);
         }
     },
     RIGHT {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.right(anchor)
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.right(anchor, columnStore, rowStore)
                     .setAnchorOrDefault(anchor);
         }
     },
     DOWN {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.down(anchor)
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.down(anchor, columnStore, rowStore)
                     .setAnchorOrDefault(anchor);
         }
     },
     EXTEND_LEFT {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.extendLeft(anchor);
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.extendLeft(anchor, columnStore, rowStore);
         }
     },
     EXTEND_UP {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.extendUp(anchor);
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.extendUp(anchor, columnStore, rowStore);
         }
     },
     EXTEND_RIGHT {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.extendRight(anchor);
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.extendRight(anchor, columnStore, rowStore);
         }
     },
     EXTEND_DOWN {
         @Override
         public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor) {
-            return selection.extendDown(anchor);
+                                                    final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+            return selection.extendDown(anchor, columnStore, rowStore);
         }
     };
 
@@ -88,7 +106,9 @@ public enum SpreadsheetViewportSelectionNavigation {
      * Executes this navigation on the given selection and anchor returning the updated result.
      */
     public abstract SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                         final SpreadsheetViewportSelectionAnchor anchor);
+                                                         final SpreadsheetViewportSelectionAnchor anchor,
+                                                         final SpreadsheetColumnStore columnStore,
+                                                         final SpreadsheetRowStore rowStore);
 
     /**
      * Accepts text that has a more pretty form of any {@link SpreadsheetViewportSelectionNavigation enum value}.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -25,6 +25,10 @@ import walkingkooka.predicate.Predicates;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.IsMethodTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.test.ParseStringTesting;
 import walkingkooka.text.printer.TreePrintableTesting;
 import walkingkooka.tree.json.JsonNode;
@@ -151,9 +155,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void leftAndCheck(final S selection,
                             final SpreadsheetViewportSelectionAnchor anchor,
                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetSelection expected) {
         this.checkEquals(
                 expected.simplify(),
-                selection.left(anchor),
+                selection.left(anchor, columnStore, SpreadsheetRowStores.fake()),
                 () -> selection + " anchor=" + anchor + " navigate left"
         );
     }
@@ -208,12 +224,25 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void upAndCheck(final S selection,
                           final SpreadsheetViewportSelectionAnchor anchor,
                           final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                rowStore(),
+                expected
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                          final SpreadsheetViewportSelectionAnchor anchor,
+                          final SpreadsheetRowStore rowStore,
+                          final SpreadsheetSelection expected) {
         this.checkEquals(
                 expected.simplify(),
-                selection.up(anchor),
+                selection.up(anchor, SpreadsheetColumnStores.fake(), rowStore),
                 () -> selection + " anchor=" + anchor + " navigate up"
         );
     }
+
     // right.............................................................................................................
 
     final void rightAndCheck(final String selection) {
@@ -273,9 +302,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void rightAndCheck(final S selection,
                              final SpreadsheetViewportSelectionAnchor anchor,
                              final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
         this.checkEquals(
                 expected.simplify(),
-                selection.right(anchor),
+                selection.right(anchor, columnStore, SpreadsheetRowStores.fake()),
                 () -> selection + " anchor=" + anchor + " navigate right"
         );
     }
@@ -345,15 +386,34 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         );
     }
 
-
     final void downAndCheck(final S selection,
                             final SpreadsheetViewportSelectionAnchor anchor,
                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                rowStore(),
+                expected
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetRowStore rowStore,
+                            final SpreadsheetSelection expected) {
         this.checkEquals(
                 expected.simplify(),
-                selection.down(anchor),
+                selection.down(anchor, SpreadsheetColumnStores.fake(), rowStore),
                 () -> selection + " anchor=" + anchor + " navigate down"
         );
+    }
+
+    private SpreadsheetColumnStore columnStore() {
+        return SpreadsheetColumnStores.treeMap();
+    }
+
+    private SpreadsheetRowStore rowStore() {
+        return SpreadsheetRowStores.treeMap();
     }
 
     // extendRange......................................................................................................
@@ -502,9 +562,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void extendLeftAndCheck(final S selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
                                   final SpreadsheetViewportSelection expected) {
+        this.extendLeftAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void extendLeftAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetViewportSelection expected) {
         this.checkEquals(
                 expected,
-                selection.extendLeft(anchor),
+                selection.extendLeft(anchor, columnStore, SpreadsheetRowStores.fake()),
                 () -> selection + " anchor=" + anchor + " navigate extendLeft"
         );
     }
@@ -582,9 +654,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void extendUpAndCheck(final S selection,
                                 final SpreadsheetViewportSelectionAnchor anchor,
                                 final SpreadsheetViewportSelection expected) {
+        this.extendUpAndCheck(
+                selection,
+                anchor,
+                rowStore(),
+                expected
+        );
+    }
+
+    final void extendUpAndCheck(final S selection,
+                                final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetRowStore rowStore,
+                                final SpreadsheetViewportSelection expected) {
         this.checkEquals(
                 expected,
-                selection.extendUp(anchor),
+                selection.extendUp(anchor, SpreadsheetColumnStores.fake(), rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendUp"
         );
     }
@@ -662,9 +746,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void extendRightAndCheck(final S selection,
                                    final SpreadsheetViewportSelectionAnchor anchor,
                                    final SpreadsheetViewportSelection expected) {
+        this.extendRightAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void extendRightAndCheck(final S selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetViewportSelection expected) {
         this.checkEquals(
                 expected,
-                selection.extendRight(anchor),
+                selection.extendRight(anchor, columnStore, SpreadsheetRowStores.fake()),
                 () -> selection + " anchor=" + anchor + " navigate extendRight"
         );
     }
@@ -742,9 +838,21 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     final void extendDownAndCheck(final S selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
                                   final SpreadsheetViewportSelection expected) {
+        this.extendDownAndCheck(
+                selection,
+                anchor,
+                rowStore(),
+                expected
+        );
+    }
+
+    final void extendDownAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetRowStore rowStore,
+                                  final SpreadsheetViewportSelection expected) {
         this.checkEquals(
                 expected,
-                selection.extendDown(anchor),
+                selection.extendDown(anchor, SpreadsheetColumnStores.fake(), rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendDown"
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2077
- SpreadsheetViewportSelectionNavigation.perform support for skipping hidden columns/rows