### PR TITLE
SpreadsheetColumnStore.left returns Optional<SpreadsheetColumnReference>

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -24,7 +24,6 @@ import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
 import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Objects;
-import java.util.function.Predicate;
 
 /**
  * Represents a column reference. The {@link Comparable} method ignores the {@link SpreadsheetReferenceKind} component
@@ -251,7 +250,7 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
     }
 
     SpreadsheetColumnReference left(final SpreadsheetColumnStore columnStore) {
-        return columnStore.leftSkipHidden(this);
+        return columnStore.leftSkipHidden(this).get();
     }
 
     SpreadsheetColumnReference right(final SpreadsheetColumnStore columnStore) {

--- a/src/main/java/walkingkooka/spreadsheet/store/FakeSpreadsheetColumnStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/FakeSpreadsheetColumnStore.java
@@ -21,6 +21,8 @@ import walkingkooka.spreadsheet.SpreadsheetColumn;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.store.FakeStore;
 
+import java.util.Optional;
+
 public class FakeSpreadsheetColumnStore extends FakeStore<SpreadsheetColumnReference, SpreadsheetColumn> implements SpreadsheetColumnStore {
 
     public FakeSpreadsheetColumnStore() {
@@ -33,7 +35,7 @@ public class FakeSpreadsheetColumnStore extends FakeStore<SpreadsheetColumnRefer
     }
 
     @Override
-    public SpreadsheetColumnReference leftSkipHidden(final SpreadsheetColumnReference reference) {
+    public Optional<SpreadsheetColumnReference> leftSkipHidden(final SpreadsheetColumnReference reference) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetColumnStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetColumnStore.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet.store;
 import walkingkooka.spreadsheet.SpreadsheetColumn;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 
+import java.util.Optional;
+
 /**
  * A store that contains {@link SpreadsheetColumn} including some methods that for frequent queries.
  */
@@ -27,9 +29,10 @@ public interface SpreadsheetColumnStore extends SpreadsheetColumnOrRowStore<Spre
 
     /**
      * Returns the first column moving left from the given starting point that is not hidden.
-     * If all columns to the left are hidden, the original {@link SpreadsheetColumnReference} is returned.
+     * If all columns to the left are hidden, the original {@link SpreadsheetColumnReference}, if this is hidden an
+     * {@link Optional#empty()}.
      */
-    SpreadsheetColumnReference leftSkipHidden(final SpreadsheetColumnReference reference);
+    Optional<SpreadsheetColumnReference> leftSkipHidden(final SpreadsheetColumnReference reference);
 
     /**
      * Returns the first column moving right from the given starting point that is not hidden.

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetColumnStoreTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetColumnStoreTesting.java
@@ -24,12 +24,15 @@ import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
+import java.util.Optional;
+
 public interface SpreadsheetColumnStoreTesting<S extends SpreadsheetColumnStore> extends SpreadsheetColumnOrRowStoreTesting<S, SpreadsheetColumnReference, SpreadsheetColumn> {
 
     @Test
     default void testLeftSkipHiddenFirstColumn() {
         this.leftSkipHiddenAndCheck(
                 this.createStore(),
+                "A",
                 "A"
         );
     }
@@ -38,7 +41,8 @@ public interface SpreadsheetColumnStoreTesting<S extends SpreadsheetColumnStore>
                                         final String reference) {
         this.leftSkipHiddenAndCheck(
                 store,
-                SpreadsheetSelection.parseColumn(reference)
+                SpreadsheetSelection.parseColumn(reference),
+                Optional.empty()
         );
     }
 
@@ -57,13 +61,23 @@ public interface SpreadsheetColumnStoreTesting<S extends SpreadsheetColumnStore>
         this.leftSkipHiddenAndCheck(
                 store,
                 reference,
-                reference
+                Optional.empty()
         );
     }
 
     default void leftSkipHiddenAndCheck(final S store,
                                         final SpreadsheetColumnReference reference,
                                         final SpreadsheetColumnReference expected) {
+        this.leftSkipHiddenAndCheck(
+                store,
+                reference,
+                Optional.of(expected)
+        );
+    }
+
+    default void leftSkipHiddenAndCheck(final S store,
+                                        final SpreadsheetColumnReference reference,
+                                        final Optional<SpreadsheetColumnReference> expected) {
         this.checkEquals(
                 expected,
                 store.leftSkipHidden(reference),

--- a/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetColumnStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetColumnStore.java
@@ -98,12 +98,14 @@ final class TreeMapSpreadsheetColumnStore implements SpreadsheetColumnStore {
     }
 
     @Override
-    public SpreadsheetColumnReference leftSkipHidden(final SpreadsheetColumnReference reference) {
+    public Optional<SpreadsheetColumnReference> leftSkipHidden(final SpreadsheetColumnReference reference) {
         SpreadsheetColumnReference left = reference;
 
         for (; ; ) {
             if (left.isFirst()) {
-                left = reference;
+                left = this.isHidden(reference) ?
+                        null :
+                        reference;
                 break;
             }
 
@@ -114,7 +116,7 @@ final class TreeMapSpreadsheetColumnStore implements SpreadsheetColumnStore {
             }
         }
 
-        return left;
+        return Optional.ofNullable(left);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetColumnStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetColumnStoreTest.java
@@ -30,6 +30,30 @@ final class TreeMapSpreadsheetColumnStoreTest extends SpreadsheetColumnStoreTest
     // leftSkipHidden...................................................................................................
 
     @Test
+    public void testLeftFirstColumnHidden() {
+        final TreeMapSpreadsheetColumnStore store = this.createStore();
+        store.save(SpreadsheetSelection.parseColumn("A").column().setHidden(true));
+
+        this.leftSkipHiddenAndCheck(
+                store,
+                "A"
+        );
+    }
+
+    @Test
+    public void testLeftAllColumnsHiddenIncludingGiven() {
+        final TreeMapSpreadsheetColumnStore store = this.createStore();
+        store.save(SpreadsheetSelection.parseColumn("A").column().setHidden(true));
+        store.save(SpreadsheetSelection.parseColumn("B").column().setHidden(true));
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.leftSkipHiddenAndCheck(
+                store,
+                "C"
+        );
+    }
+
+    @Test
     public void testLeftSkipHidden() {
         this.leftSkipHiddenAndCheck(
                 this.createStore(),


### PR DESCRIPTION
- left now never returns a hidden column.