### PR TITLE
SpreadsheetEngine navigate returns Optional<SpreadsheetViewportSelect…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1177,15 +1177,17 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
     }
 
     @Override
-    public SpreadsheetViewportSelection navigate(final SpreadsheetViewportSelection selection,
-                                                 final SpreadsheetEngineContext context) {
+    public Optional<SpreadsheetViewportSelection> navigate(final SpreadsheetViewportSelection selection,
+                                                           final SpreadsheetEngineContext context) {
         Objects.requireNonNull(selection, "selection");
         checkContext(context);
 
         final Optional<SpreadsheetViewportSelectionNavigation> maybeNavigation = selection.navigation();
-        return maybeNavigation.isPresent() ?
-                navigate0(selection, context) :
-                selection;
+        return Optional.of(
+                maybeNavigation.isPresent() ?
+                        navigate0(selection, context) :
+                        selection
+        );
     }
 
     private SpreadsheetViewportSelection navigate0(final SpreadsheetViewportSelection selection,

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
@@ -161,8 +161,8 @@ public class FakeSpreadsheetEngine implements SpreadsheetEngine, Fake {
     }
 
     @Override
-    public SpreadsheetViewportSelection navigate(final SpreadsheetViewportSelection selection,
-                                                 final SpreadsheetEngineContext context) {
+    public Optional<SpreadsheetViewportSelection> navigate(final SpreadsheetViewportSelection selection,
+                                                           final SpreadsheetEngineContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -186,6 +186,6 @@ public interface SpreadsheetEngine {
      * Performs the given {@link SpreadsheetViewportSelection}, honouring any present {@link SpreadsheetViewportSelection#navigation()},
      * skipping hidden columns and rows.
      */
-    SpreadsheetViewportSelection navigate(final SpreadsheetViewportSelection selection,
-                                          final SpreadsheetEngineContext context);
+    Optional<SpreadsheetViewportSelection> navigate(final SpreadsheetViewportSelection selection,
+                                                    final SpreadsheetEngineContext context);
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngine.java
@@ -226,8 +226,8 @@ final class SpreadsheetMetadataStampingSpreadsheetEngine implements SpreadsheetE
     }
 
     @Override
-    public SpreadsheetViewportSelection navigate(final SpreadsheetViewportSelection selection,
-                                                 final SpreadsheetEngineContext context) {
+    public Optional<SpreadsheetViewportSelection> navigate(final SpreadsheetViewportSelection selection,
+                                                           final SpreadsheetEngineContext context) {
         return this.engine.navigate(selection, context);
     }
 


### PR DESCRIPTION
…ion>

- Necessary change because final selection could be hidden meaning Optional#empty.