### PR TITLE
SpreadsheetEngine.navigate hidden selection support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1183,15 +1183,13 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         checkContext(context);
 
         final Optional<SpreadsheetViewportSelectionNavigation> maybeNavigation = selection.navigation();
-        return Optional.of(
-                maybeNavigation.isPresent() ?
+        return maybeNavigation.isPresent() ?
                         navigate0(selection, context) :
-                        selection
-        );
+               Optional.empty();
     }
 
-    private SpreadsheetViewportSelection navigate0(final SpreadsheetViewportSelection selection,
-                                                   final SpreadsheetEngineContext context) {
+    private Optional<SpreadsheetViewportSelection> navigate0(final SpreadsheetViewportSelection selection,
+                                                             final SpreadsheetEngineContext context) {
         final SpreadsheetStoreRepository repository = context.storeRepository();
 
         return selection.navigation()

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -183,6 +183,11 @@ public interface SpreadsheetEngine {
                                final SpreadsheetEngineContext context);
 
     /**
+     * An absent {@link SpreadsheetViewportSelection}.
+     */
+    Optional<SpreadsheetViewportSelection> NO_VIEWPORT_SELECTION = Optional.empty();
+
+    /**
      * Performs the given {@link SpreadsheetViewportSelection}, honouring any present {@link SpreadsheetViewportSelection#navigation()},
      * skipping hidden columns and rows.
      */

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
 import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -256,82 +257,96 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
         return hiddenColumnTester.test(this);
     }
 
-    SpreadsheetColumnReference left(final SpreadsheetColumnStore columnStore) {
-        return columnStore.leftSkipHidden(this).get();
-    }
-
-    SpreadsheetColumnReference right(final SpreadsheetColumnStore columnStore) {
-        return columnStore.rightSkipHidden(this).get();
+    @Override
+    Optional<SpreadsheetSelection> left(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
+        return Cast.to(
+                columnStore.leftSkipHidden(this)
+        );
     }
 
     @Override
-    SpreadsheetColumnReference left(final SpreadsheetViewportSelectionAnchor anchor,
-                                    final SpreadsheetColumnStore columnStore,
-                                    final SpreadsheetRowStore rowStore) {
-        return this.left(columnStore);
+    Optional<SpreadsheetSelection> right(final SpreadsheetViewportSelectionAnchor anchor,
+                                         final SpreadsheetColumnStore columnStore,
+                                         final SpreadsheetRowStore rowStore) {
+        return Cast.to(
+                columnStore.rightSkipHidden(this)
+        );
     }
 
     @Override
-    SpreadsheetColumnReference up(final SpreadsheetViewportSelectionAnchor anchor,
-                                  final SpreadsheetColumnStore columnStore,
-                                  final SpreadsheetRowStore rowStore) {
-        return this;
+    Optional<SpreadsheetSelection> up(final SpreadsheetViewportSelectionAnchor anchor,
+                                      final SpreadsheetColumnStore columnStore,
+                                      final SpreadsheetRowStore rowStore) {
+        return this.emptyIfHidden(
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetColumnReference right(final SpreadsheetViewportSelectionAnchor anchor,
-                                     final SpreadsheetColumnStore columnStore,
-                                     final SpreadsheetRowStore rowStore) {
-        return this.right(columnStore);
+    Optional<SpreadsheetSelection> down(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
+        return this.emptyIfHidden(
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetColumnReference down(final SpreadsheetViewportSelectionAnchor anchor,
-                                    final SpreadsheetColumnStore columnStore,
-                                    final SpreadsheetRowStore rowStore) {
-        return this;
-    }
-
-    @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
         return this.extendRange(
                 this.left(anchor, columnStore, rowStore),
                 anchor
-        ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.RIGHT);
+        ).map(
+                s -> s.setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.RIGHT)
+        );
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
-                                          final SpreadsheetColumnStore columnStore,
-                                          final SpreadsheetRowStore rowStore) {
-        return this.setAnchor(anchor);
-    }
-
-    @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
-                                             final SpreadsheetColumnStore columnStore,
-                                             final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                                       final SpreadsheetColumnStore columnStore,
+                                                       final SpreadsheetRowStore rowStore) {
         return this.extendRange(
                 this.right(anchor, columnStore, rowStore),
                 anchor
-        ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.LEFT);
+        ).map(
+                s -> s.setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.LEFT)
+        );
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
-        return this.setAnchor(anchor);
+    Optional<SpreadsheetViewportSelection> extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
+        return this.setAnchorEmptyIfHidden(
+                anchor,
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetSelection extendRange(final SpreadsheetSelection other,
-                                     final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.columnRange(
-                (SpreadsheetColumnReference) other
-        ).simplify();
+    Optional<SpreadsheetViewportSelection> extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
+        return this.setAnchorEmptyIfHidden(
+                anchor,
+                columnStore,
+                rowStore
+        );
+    }
+
+    @Override
+    Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
+                                               final SpreadsheetViewportSelectionAnchor anchor) {
+        return other.map(
+                o -> this.columnRange((SpreadsheetColumnReference) o).simplify()
+        );
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
@@ -26,6 +26,7 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -162,64 +163,64 @@ final public class SpreadsheetLabelName extends SpreadsheetCellReferenceOrLabelN
     }
 
     @Override
-    SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor,
-                              final SpreadsheetColumnStore columnStore,
-                              final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetSelection> left(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetColumnStore columnStore,
-                            final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetSelection> up(final SpreadsheetViewportSelectionAnchor anchor,
+                                      final SpreadsheetColumnStore columnStore,
+                                      final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor,
-                               final SpreadsheetColumnStore columnStore,
-                               final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetSelection> right(final SpreadsheetViewportSelectionAnchor anchor,
+                                         final SpreadsheetColumnStore columnStore,
+                                         final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor,
-                              final SpreadsheetColumnStore columnStore,
-                              final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetSelection> down(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
-                                          final SpreadsheetColumnStore columnStore,
-                                          final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
-                                             final SpreadsheetColumnStore columnStore,
-                                             final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                                       final SpreadsheetColumnStore columnStore,
+                                                       final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    SpreadsheetSelection extendRange(final SpreadsheetSelection other,
-                                     final SpreadsheetViewportSelectionAnchor anchor) {
+    Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
+                                               final SpreadsheetViewportSelectionAnchor anchor) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -250,73 +250,95 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
     }
 
     @Override
-    SpreadsheetRowReference left(final SpreadsheetViewportSelectionAnchor anchor,
-                                 final SpreadsheetColumnStore columnStore,
-                                 final SpreadsheetRowStore rowStore) {
-        return this;
+    Optional<SpreadsheetSelection> up(final SpreadsheetViewportSelectionAnchor anchor,
+                                      final SpreadsheetColumnStore columnStore,
+                                      final SpreadsheetRowStore rowStore) {
+        return Cast.to(
+                this.up(rowStore)
+        );
     }
 
     @Override
-    SpreadsheetRowReference up(final SpreadsheetViewportSelectionAnchor anchor,
-                               final SpreadsheetColumnStore columnStore,
-                               final SpreadsheetRowStore rowStore) {
-        return this.up(rowStore).get();
+    Optional<SpreadsheetSelection> down(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
+        return Cast.to(
+                this.down(rowStore)
+        );
     }
 
     @Override
-    SpreadsheetRowReference right(final SpreadsheetViewportSelectionAnchor anchor,
-                                  final SpreadsheetColumnStore columnStore,
-                                  final SpreadsheetRowStore rowStore) {
-        return this;
+    Optional<SpreadsheetSelection> left(final SpreadsheetViewportSelectionAnchor anchor,
+                                        final SpreadsheetColumnStore columnStore,
+                                        final SpreadsheetRowStore rowStore) {
+        return this.emptyIfHidden(
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetRowReference down(final SpreadsheetViewportSelectionAnchor anchor,
-                                 final SpreadsheetColumnStore columnStore,
-                                 final SpreadsheetRowStore rowStore) {
-        return this.down(rowStore).get();
+    Optional<SpreadsheetSelection> right(final SpreadsheetViewportSelectionAnchor anchor,
+                                         final SpreadsheetColumnStore columnStore,
+                                         final SpreadsheetRowStore rowStore) {
+        return this.emptyIfHidden(
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
-        return this.setAnchor(anchor);
+    Optional<SpreadsheetViewportSelection> extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
+        return this.setAnchorEmptyIfHidden(
+                anchor,
+                columnStore,
+                rowStore
+        );
     }
 
     @Override
-    SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
-                                          final SpreadsheetColumnStore columnStore,
-                                          final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                                       final SpreadsheetColumnStore columnStore,
+                                                       final SpreadsheetRowStore rowStore) {
+        return this.setAnchorEmptyIfHidden(
+                anchor,
+                columnStore,
+                rowStore
+        );
+    }
+
+    @Override
+    Optional<SpreadsheetViewportSelection> extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                                    final SpreadsheetColumnStore columnStore,
+                                                    final SpreadsheetRowStore rowStore) {
         return this.extendRange(
                 this.up(anchor, columnStore, rowStore),
                 anchor
-        ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.BOTTOM);
+        ).map(
+                s -> s.setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.BOTTOM)
+        );
     }
 
     @Override
-    SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
-                                             final SpreadsheetColumnStore columnStore,
-                                             final SpreadsheetRowStore rowStore) {
-        return this.setAnchor(anchor);
-    }
-
-    @Override
-    SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
-                                            final SpreadsheetColumnStore columnStore,
-                                            final SpreadsheetRowStore rowStore) {
+    Optional<SpreadsheetViewportSelection> extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                                      final SpreadsheetColumnStore columnStore,
+                                                      final SpreadsheetRowStore rowStore) {
         return this.extendRange(
                 this.down(anchor, columnStore, rowStore),
                 anchor
-        ).setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.TOP);
+        ).map(
+                s -> s.setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.TOP)
+        );
     }
 
     @Override
-    SpreadsheetSelection extendRange(final SpreadsheetSelection other,
-                                     final SpreadsheetViewportSelectionAnchor anchor) {
-        return this.rowRange(
-                (SpreadsheetRowReference) other
-        ).simplify();
+    Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
+                                               final SpreadsheetViewportSelectionAnchor anchor) {
+        return other.map(
+                o -> this.rowRange((SpreadsheetRowReference) o).simplify()
+        );
     }
 
     // TreePrintable....................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -476,6 +476,14 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
     public abstract boolean isHidden(final Predicate<SpreadsheetColumnReference> hiddenColumnTester,
                                      final Predicate<SpreadsheetRowReference> hiddenRowTester);
 
+    final boolean isHidden(final SpreadsheetColumnStore columnStore,
+                           final SpreadsheetRowStore rowStore) {
+        return this.isHidden(
+                columnStore::isHidden,
+                rowStore::isHidden
+        );
+    }
+
     /**
      * Helper used by all three ranges to test if either bound is hidden.
      */
@@ -490,37 +498,37 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
                         end.isHidden(hiddenColumnTester, hiddenRowTester));
     }
 
-    abstract SpreadsheetSelection left(final SpreadsheetViewportSelectionAnchor anchor,
-                                       final SpreadsheetColumnStore columnStore,
-                                       final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetSelection> left(final SpreadsheetViewportSelectionAnchor anchor,
+                                                 final SpreadsheetColumnStore columnStore,
+                                                 final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection up(final SpreadsheetViewportSelectionAnchor anchor,
-                                     final SpreadsheetColumnStore columnStore,
-                                     final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetSelection> up(final SpreadsheetViewportSelectionAnchor anchor,
+                                               final SpreadsheetColumnStore columnStore,
+                                               final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection right(final SpreadsheetViewportSelectionAnchor anchor,
-                                        final SpreadsheetColumnStore columnStore,
-                                        final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetSelection> right(final SpreadsheetViewportSelectionAnchor anchor,
+                                                  final SpreadsheetColumnStore columnStore,
+                                                  final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetSelection down(final SpreadsheetViewportSelectionAnchor anchor,
-                                       final SpreadsheetColumnStore columnStore,
-                                       final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetSelection> down(final SpreadsheetViewportSelectionAnchor anchor,
+                                                 final SpreadsheetColumnStore columnStore,
+                                                 final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
-                                                     final SpreadsheetColumnStore columnStore,
-                                                     final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetViewportSelection> extendLeft(final SpreadsheetViewportSelectionAnchor anchor,
+                                                               final SpreadsheetColumnStore columnStore,
+                                                               final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendUp(final SpreadsheetViewportSelectionAnchor anchor,
-                                                   final SpreadsheetColumnStore columnStore,
-                                                   final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetViewportSelection> extendUp(final SpreadsheetViewportSelectionAnchor anchor,
+                                                             final SpreadsheetColumnStore columnStore,
+                                                             final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendRight(final SpreadsheetViewportSelectionAnchor anchor,
-                                                      final SpreadsheetColumnStore columnStore,
-                                                      final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetViewportSelection> extendRight(final SpreadsheetViewportSelectionAnchor anchor,
+                                                                final SpreadsheetColumnStore columnStore,
+                                                                final SpreadsheetRowStore rowStore);
 
-    abstract SpreadsheetViewportSelection extendDown(final SpreadsheetViewportSelectionAnchor anchor,
-                                                     final SpreadsheetColumnStore columnStore,
-                                                     final SpreadsheetRowStore rowStore);
+    abstract Optional<SpreadsheetViewportSelection> extendDown(final SpreadsheetViewportSelectionAnchor anchor,
+                                                               final SpreadsheetColumnStore columnStore,
+                                                               final SpreadsheetRowStore rowStore);
 
     /**
      * Factory that creates or extends a {@link SpreadsheetSelection} into a range. Note the other is either a
@@ -528,8 +536,26 @@ public abstract class SpreadsheetSelection implements Predicate<SpreadsheetCellR
      * <br>
      * This method is intended for use by functions such as SpreadsheetSelection#extendLeft and other directions.,
      */
-    abstract SpreadsheetSelection extendRange(final SpreadsheetSelection other,
-                                              final SpreadsheetViewportSelectionAnchor anchor);
+    abstract Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
+                                                        final SpreadsheetViewportSelectionAnchor anchor);
+
+    final Optional<SpreadsheetSelection> emptyIfHidden(final SpreadsheetColumnStore columnStore,
+                                                       final SpreadsheetRowStore rowStore) {
+        return this.isHidden(
+                columnStore,
+                rowStore
+        ) ?
+                Optional.empty() :
+                Optional.of(this);
+    }
+
+    final Optional<SpreadsheetViewportSelection> setAnchorEmptyIfHidden(final SpreadsheetViewportSelectionAnchor anchor,
+                                                                        final SpreadsheetColumnStore columnStore,
+                                                                        final SpreadsheetRowStore rowStore) {
+        return this.isHidden(columnStore, rowStore) ?
+                Optional.empty() :
+                Optional.of(this.setAnchor(anchor));
+    }
 
     // textLabel........................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
@@ -21,83 +21,85 @@ import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
 import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.text.CharSequences;
 
+import java.util.Optional;
+
 /**
  * Captures a users input movement relative to a selection, such as a cursor-left from a selection in the viewport.
  */
 public enum SpreadsheetViewportSelectionNavigation {
     LEFT {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.left(anchor, columnStore, rowStore)
-                    .setAnchorOrDefault(anchor);
+                    .map(s -> s.setAnchorOrDefault(anchor));
         }
     },
     UP {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.up(anchor, columnStore, rowStore)
-                    .setAnchorOrDefault(anchor);
+                    .map(s -> s.setAnchorOrDefault(anchor));
         }
     },
     RIGHT {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.right(anchor, columnStore, rowStore)
-                    .setAnchorOrDefault(anchor);
+                    .map(s -> s.setAnchorOrDefault(anchor));
         }
     },
     DOWN {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.down(anchor, columnStore, rowStore)
-                    .setAnchorOrDefault(anchor);
+                    .map(s -> s.setAnchorOrDefault(anchor));
         }
     },
     EXTEND_LEFT {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.extendLeft(anchor, columnStore, rowStore);
         }
     },
     EXTEND_UP {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.extendUp(anchor, columnStore, rowStore);
         }
     },
     EXTEND_RIGHT {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.extendRight(anchor, columnStore, rowStore);
         }
     },
     EXTEND_DOWN {
         @Override
-        public SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                                    final SpreadsheetColumnStore columnStore,
-                                                    final SpreadsheetRowStore rowStore) {
+        public Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                              final SpreadsheetViewportSelectionAnchor anchor,
+                                                              final SpreadsheetColumnStore columnStore,
+                                                              final SpreadsheetRowStore rowStore) {
             return selection.extendDown(anchor, columnStore, rowStore);
         }
     };
@@ -117,10 +119,10 @@ public enum SpreadsheetViewportSelectionNavigation {
     /**
      * Executes this navigation on the given selection and anchor returning the updated result.
      */
-    public abstract SpreadsheetViewportSelection perform(final SpreadsheetSelection selection,
-                                                         final SpreadsheetViewportSelectionAnchor anchor,
-                                                         final SpreadsheetColumnStore columnStore,
-                                                         final SpreadsheetRowStore rowStore);
+    public abstract Optional<SpreadsheetViewportSelection> perform(final SpreadsheetSelection selection,
+                                                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                                                   final SpreadsheetColumnStore columnStore,
+                                                                   final SpreadsheetRowStore rowStore);
 
     /**
      * Accepts text that has a more pretty form of any {@link SpreadsheetViewportSelectionNavigation enum value}.

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -9132,6 +9132,40 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     //  navigate........................................................................................................
 
     @Test
+    public void testNavigateHidden() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        final SpreadsheetColumnStore store = context.storeRepository()
+                .columns();
+
+        store.save(
+                SpreadsheetSelection.parseColumn("A")
+                        .column()
+                        .setHidden(true)
+        );
+
+        store.save(
+                SpreadsheetSelection.parseColumn("B")
+                        .column()
+                        .setHidden(true)
+        );
+
+        this.navigateAndCheck(
+                engine,
+                SpreadsheetSelection.parseColumn("B")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+                        .setNavigation(
+                                Optional.of(
+                                        SpreadsheetViewportSelectionNavigation.LEFT
+                                )
+                        ),
+                context,
+                SpreadsheetEngine.NO_VIEWPORT_SELECTION
+        );
+    }
+
+    @Test
     public void testNavigateSkipsHiddenColumn() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext();
@@ -9155,6 +9189,33 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                         ),
                 context,
                 SpreadsheetSelection.parseColumn("C").setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    @Test
+    public void testNavigateSkipsHiddenRow() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        context.storeRepository()
+                .rows()
+                .save(
+                        SpreadsheetSelection.parseRow("3")
+                                .row()
+                                .setHidden(true)
+                );
+
+        this.navigateAndCheck(
+                engine,
+                SpreadsheetSelection.parseRow("2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+                        .setNavigation(
+                                Optional.of(
+                                        SpreadsheetViewportSelectionNavigation.DOWN
+                                )
+                        ),
+                context,
+                SpreadsheetSelection.parseRow("4").setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -25,6 +25,10 @@ import walkingkooka.predicate.PredicateTesting2;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -1357,15 +1361,21 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendLeftAndCheck(
                 "C3:D3",
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT,
-                "C3"
+                "C3",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
     @Test
     public void testExtendLeftAnchorTopRightFirstColumn() {
+        final String range = "A1:A2";
+        final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAnchor.TOP_RIGHT;
+
         this.extendLeftAndCheck(
-                "A1:A2",
-                SpreadsheetViewportSelectionAnchor.TOP_RIGHT
+                range,
+                anchor,
+                range,
+                anchor
         );
     }
 
@@ -1395,6 +1405,44 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         ); // actual=c3:c4
     }
 
+    @Test
+    public void testExtendLeftSkipsHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.extendLeftAndCheck(
+                "D4:E5",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store,
+                "B4:E5",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT
+        );
+    }
+
+    @Test
+    public void testExtendLeftHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendLeftAndCheck(
+                "C3:D4",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
+    @Test
+    public void testExtendLeftHiddenRow2() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("4").row().setHidden(true));
+
+        this.extendLeftAndCheck(
+                "C3:D4",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
     // extendRight......................................................................................................
 
     @Test
@@ -1412,7 +1460,8 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendRightAndCheck(
                 "C3:D3",
                 SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
-                "D3"
+                "D3",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
@@ -1432,10 +1481,14 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
     @Test
     public void testExtendRightAnchorBottomLeftLastColumn() {
         final SpreadsheetColumnReference column = SpreadsheetReferenceKind.RELATIVE.lastColumn();
+final String cell = column.add(-1) + "1:" + column + "1";
+final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAnchor.BOTTOM_LEFT;
 
         this.extendRightAndCheck(
-                column.add(-1) + "1:" + column + "1",
-                SpreadsheetViewportSelectionAnchor.BOTTOM_LEFT
+                cell,
+                anchor,
+                cell,
+                anchor
         );
     }
 
@@ -1446,7 +1499,8 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendRightAndCheck(
                 column.add(-1) + "1:" + column + "1",
                 SpreadsheetViewportSelectionAnchor.TOP_RIGHT,
-                column + "1"
+                column + "1",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
@@ -1489,6 +1543,44 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         );
     }
 
+    @Test
+    public void testExtendRightSkipsHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("D").column().setHidden(true));
+
+        this.extendRightAndCheck(
+                "B2:C3",
+                SpreadsheetViewportSelectionAnchor.TOP_LEFT,
+                store,
+                "B2:E3",
+                SpreadsheetViewportSelectionAnchor.TOP_LEFT
+        );
+    }
+
+    @Test
+    public void testExtendRightHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendRightAndCheck(
+                "C3:D4",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
+    @Test
+    public void testExtendRightHiddenRow2() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("4").row().setHidden(true));
+
+        this.extendRightAndCheck(
+                "C3:D4",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
     // extendUp.......................................................................................................
 
     @Test
@@ -1506,7 +1598,8 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendUpAndCheck(
                 "C3:C4",
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT,
-                "C3"
+                "C3",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
@@ -1565,6 +1658,44 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         );
     }
 
+    @Test
+    public void testExtendUpSkipsHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendUpAndCheck(
+                "D4:E5",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store,
+                "D2:E5",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT
+        );
+    }
+
+    @Test
+    public void testExtendUpHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("B").column().setHidden(true));
+
+        this.extendUpAndCheck(
+                "B3:C3",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
+    @Test
+    public void testExtendUpHiddenColumn2() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.extendUpAndCheck(
+                "B3:C3",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
     // extendDown.......................................................................................................
 
     @Test
@@ -1592,17 +1723,22 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendDownAndCheck(
                 "C3:C4",
                 SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
-                "C4"
+                "C4",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
     @Test
     public void testExtendDownAnchorTopLeftLastRow() {
         final SpreadsheetRowReference row = SpreadsheetReferenceKind.RELATIVE.lastRow();
+        final String cell = "A" + row + ":B" + row;
+final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAnchor.TOP_LEFT;
 
         this.extendDownAndCheck(
-                "A" + row + ":B" + row,
-                SpreadsheetViewportSelectionAnchor.TOP_LEFT
+               cell,
+                anchor,
+                cell,
+                anchor
         );
     }
 
@@ -1613,7 +1749,8 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
         this.extendDownAndCheck(
                 "A" + row.add(-1) + ":A" + row,
                 SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
-                "A" + row
+                "A" + row,
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
@@ -1642,6 +1779,44 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferen
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT,
                 "C3:D4",
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT
+        );
+    }
+
+    @Test
+    public void testExtendDownSkipsHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("4").row().setHidden(true));
+
+        this.extendDownAndCheck(
+                "B2:C3",
+                SpreadsheetViewportSelectionAnchor.TOP_LEFT,
+                store,
+                "B2:C5",
+                SpreadsheetViewportSelectionAnchor.TOP_LEFT
+        );
+    }
+
+    @Test
+    public void testExtendDownHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("B").column().setHidden(true));
+
+        this.extendDownAndCheck(
+                "B3:C3",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
+        );
+    }
+
+    @Test
+    public void testExtendDownHiddenColumn2() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.extendDownAndCheck(
+                "B3:C3",
+                SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
+                store
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -23,6 +23,10 @@ import walkingkooka.net.http.server.hateos.HateosResourceTesting;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -807,6 +811,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     @Test
     public void testLeftFirstColumn() {
         this.leftAndCheck(
+                "A2",
                 "A2"
         );
     }
@@ -822,6 +827,29 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
+    public void testLeftSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.leftAndCheck(
+                "D1",
+                store,
+                "B1"
+        );
+    }
+
+    @Test
+    public void testLeftHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("1").row().setHidden(true));
+
+        this.leftAndCheck(
+                "D1",
+                store
+        );
+    }
+    
+    @Test
     public void testUp() {
         this.upAndCheck(
                 "B2",
@@ -832,6 +860,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     @Test
     public void testUpFirstRow() {
         this.upAndCheck(
+                "B1",
                 "B1"
         );
     }
@@ -846,6 +875,29 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         );
     }
 
+    @Test
+    public void testUpSkipsHidden() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.upAndCheck(
+                "B4",
+                store,
+                "B2"
+        );
+    }
+
+    @Test
+    public void testUpHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("B").column().setHidden(true));
+
+        this.upAndCheck(
+                "B2",
+                store
+        );
+    }
+    
     @Test
     public void testRight() {
         this.rightAndCheck(
@@ -867,7 +919,31 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         final SpreadsheetColumnReference column = SpreadsheetReferenceKind.RELATIVE.lastColumn();
 
         this.rightAndCheck(
+                column + "1",
                 column + "1"
+        );
+    }
+
+    @Test
+    public void testRightSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.rightAndCheck(
+                "B1",
+                store,
+                "D1"
+        );
+    }
+
+    @Test
+    public void testRightHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("1").row().setHidden(true));
+
+        this.rightAndCheck(
+                "D1",
+                store
         );
     }
 
@@ -892,7 +968,31 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         final SpreadsheetRowReference row = SpreadsheetReferenceKind.RELATIVE.lastRow();
 
         this.downAndCheck(
+                "B" + row,
                 "B" + row
+        );
+    }
+
+    @Test
+    public void testDownSkipsHidden() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.downAndCheck(
+                "B2",
+                store,
+                "B4"
+        );
+    }
+
+    @Test
+    public void testDownHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("B").column().setHidden(true));
+
+        this.downAndCheck(
+                "B2",
+                store
         );
     }
 
@@ -943,6 +1043,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     public void testExtendLeft() {
         this.extendLeftAndCheck(
                 "C3",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "B3:C3",
                 SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT
         );
@@ -950,15 +1051,21 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testExtendLeftFirstColumn() {
+        final String cell = "A1";
+
         this.extendLeftAndCheck(
-                "A1"
+                cell,
+                cell
         );
     }
 
     @Test
     public void testExtendLeftFirstColumn2() {
+        final String cell =  "A2";
+
         this.extendLeftAndCheck(
-                "A2"
+               cell,
+                cell
         );
     }
 
@@ -966,6 +1073,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     public void testExtendUp() {
         this.extendUpAndCheck(
                 "C3",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "C2:C3",
                 SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT
         );
@@ -973,15 +1081,21 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testExtendUpFirstRow() {
+        final String cell =  "A1";
+
         this.extendUpAndCheck(
-                "A1"
+               cell,
+                cell
         );
     }
 
     @Test
     public void testExtendUpFirstRow2() {
+        final String cell = "B1";
+
         this.extendUpAndCheck(
-                "B1"
+                cell,
+                cell
         );
     }
 
@@ -989,6 +1103,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     public void testExtendRight() {
         this.extendRightAndCheck(
                 "C3",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "C3:D3",
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT
         );
@@ -996,21 +1111,27 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testExtendRightLastColumn() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseRow("1")
+                .setColumn(
+                        SpreadsheetReferenceKind.RELATIVE.lastColumn()
+                );
+
         this.extendRightAndCheck(
-                SpreadsheetSelection.parseRow("1")
-                        .setColumn(
-                                SpreadsheetReferenceKind.RELATIVE.lastColumn()
-                        )
+                cell,
+                cell
         );
     }
 
     @Test
     public void testExtendRightLastColumn2() {
+        final SpreadsheetCellReference cell =  SpreadsheetSelection.parseRow("2")
+                .setColumn(
+                        SpreadsheetReferenceKind.RELATIVE.lastColumn()
+                );
+
         this.extendRightAndCheck(
-                SpreadsheetSelection.parseRow("2")
-                        .setColumn(
-                                SpreadsheetReferenceKind.RELATIVE.lastColumn()
-                        )
+               cell,
+                cell
         );
     }
 
@@ -1018,6 +1139,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     public void testExtendDown() {
         this.extendDownAndCheck(
                 "B2",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "B2:B3",
                 SpreadsheetViewportSelectionAnchor.TOP_LEFT
         );
@@ -1025,21 +1147,27 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testExtendDownLastRow() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseColumn("A")
+                .setRow(
+                        SpreadsheetReferenceKind.RELATIVE.lastRow()
+                );
+
         this.extendDownAndCheck(
-                SpreadsheetSelection.parseColumn("A")
-                        .setRow(
-                                SpreadsheetReferenceKind.RELATIVE.lastRow()
-                        )
+                cell,
+                cell
         );
     }
 
     @Test
     public void testExtendDownLastRow2() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseColumn("B")
+                .setRow(
+                        SpreadsheetReferenceKind.RELATIVE.lastRow()
+                );
+
         this.extendDownAndCheck(
-                SpreadsheetSelection.parseColumn("B")
-                        .setRow(
-                                SpreadsheetReferenceKind.RELATIVE.lastRow()
-                        )
+                cell,
+                cell
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRangeTest.java
@@ -22,6 +22,8 @@ import walkingkooka.collect.Range;
 import walkingkooka.collect.RangeBound;
 import walkingkooka.collect.iterable.IterableTesting;
 import walkingkooka.predicate.Predicates;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import walkingkooka.visit.Visiting;
@@ -493,10 +495,37 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     }
 
     @Test
+    public void testLeftSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.leftAndCheck(
+                "D:E",
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                store,
+                "B"
+        );
+    }
+
+    @Test
     public void testUpAnchorLeft() {
+        final String range = "B:C";
+
         this.upAndCheck(
-                "B:C",
-                SpreadsheetViewportSelectionAnchor.LEFT
+                range,
+                SpreadsheetViewportSelectionAnchor.LEFT,
+                range
+        );
+    }
+
+    @Test
+    public void testUpHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.upAndCheck(
+                "C:D",
+                store
         );
     }
 
@@ -537,10 +566,37 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     }
 
     @Test
+    public void testRightSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("E").column().setHidden(true));
+
+        this.rightAndCheck(
+                "C:D",
+                SpreadsheetViewportSelectionAnchor.LEFT,
+                store,
+                "F"
+        );
+    }
+
+    @Test
     public void testDownAnchorLeft() {
+        final String range = "B:C";
+
         this.downAndCheck(
-                "B:C",
-                SpreadsheetViewportSelectionAnchor.LEFT
+                range,
+                SpreadsheetViewportSelectionAnchor.LEFT,
+                range
+        );
+    }
+
+    @Test
+    public void testDownHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.downAndCheck(
+                "C:D",
+                store
         );
     }
 
@@ -630,14 +686,19 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
         this.extendLeftAndCheck(
                 "C:D",
                 SpreadsheetViewportSelectionAnchor.LEFT,
-                "C"
+                "C",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
     @Test
     public void testExtendLeftAnchorRightFirstColumn() {
+        final String range = "A:B";
+
         this.extendLeftAndCheck(
-                "A:B",
+                range,
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                range,
                 SpreadsheetViewportSelectionAnchor.RIGHT
         );
     }
@@ -668,7 +729,8 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
 
         this.extendRightAndCheck(
                 column.add(-1).columnRange(column),
-                SpreadsheetViewportSelectionAnchor.LEFT
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                column.setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
         );
     }
 
@@ -714,15 +776,25 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
 
     @Test
     public void testExtendUp() {
+        final String row = "B:C";
+
         this.extendUpAndCheck(
-                "B:C"
+                row,
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                row,
+                SpreadsheetViewportSelectionAnchor.RIGHT
         );
     }
 
     @Test
     public void testExtendDown() {
+        final String row = "B:C";
+
         this.extendDownAndCheck(
-                "B:C"
+                row,
+                SpreadsheetViewportSelectionAnchor.RIGHT,
+                row,
+                SpreadsheetViewportSelectionAnchor.RIGHT
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.Range;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.SpreadsheetColumn;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStore;
+import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import walkingkooka.visit.Visiting;
@@ -624,6 +626,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     @Test
     public void testLeftFirstColumn() {
         this.leftAndCheck(
+                "A",
                 "A"
         );
     }
@@ -639,8 +642,32 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     }
 
     @Test
+    public void testLeftSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.leftAndCheck(
+                "D",
+                store,
+                "B"
+        );
+    }
+
+    @Test
+    public void testUpColumnHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.upAndCheck(
+                "C",
+                store
+        );
+    }
+
+    @Test
     public void testUp() {
         this.upAndCheck(
+                "B",
                 "B"
         );
     }
@@ -663,15 +690,42 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
 
     @Test
     public void testRightLastColumn() {
+        final SpreadsheetColumnReference column = SpreadsheetReferenceKind.RELATIVE.lastColumn();
+
         this.rightAndCheck(
-                SpreadsheetReferenceKind.RELATIVE.lastColumn()
+                column,
+                column
         );
     }
 
     @Test
+    public void testRightSkipsHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.rightAndCheck(
+                "B",
+                store,
+                "D"
+        );
+    }
+    
+    @Test
     public void testDown() {
         this.downAndCheck(
+                "B",
                 "B"
+        );
+    }
+
+    @Test
+    public void testDownColumnHidden() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("C").column().setHidden(true));
+
+        this.downAndCheck(
+                "C",
+                store
         );
     }
 
@@ -714,6 +768,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     public void testExtendLeft() {
         this.extendLeftAndCheck(
                 "C",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "B:C",
                 SpreadsheetViewportSelectionAnchor.RIGHT
         );
@@ -721,8 +776,25 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
 
     @Test
     public void testExtendLeftFirstColumn() {
+        final String column =     "A";
+
         this.extendLeftAndCheck(
-                "A"
+            column,
+                column
+        );
+    }
+
+    @Test
+    public void testExtendLeftSkipsHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("c").column().setHidden(true));
+
+        this.extendLeftAndCheck(
+                "D",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store,
+                "B:D",
+                SpreadsheetViewportSelectionAnchor.RIGHT
         );
     }
 
@@ -730,6 +802,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     public void testExtendRight() {
         this.extendRightAndCheck(
                 "C",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "C:D",
                 SpreadsheetViewportSelectionAnchor.LEFT
         );
@@ -737,22 +810,69 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
 
     @Test
     public void testExtendRightLastColumn() {
+        final SpreadsheetColumnReference column = SpreadsheetReferenceKind.RELATIVE.lastColumn();
+
         this.extendRightAndCheck(
-                SpreadsheetReferenceKind.RELATIVE.lastColumn()
+                column,
+                column
+        );
+    }
+
+    @Test
+    public void testExtendRightSkipsHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("c").column().setHidden(true));
+
+        this.extendRightAndCheck(
+                "B",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store,
+                "B:D",
+                SpreadsheetViewportSelectionAnchor.LEFT
         );
     }
 
     @Test
     public void testExtendUp() {
+        final String column = "B";
+
         this.extendUpAndCheck(
-                "B"
+                column,
+                column
+        );
+    }
+
+    @Test
+    public void testExtendUpHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("c").column().setHidden(true));
+
+        this.extendUpAndCheck(
+                "C",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store
         );
     }
 
     @Test
     public void testExtendDown() {
+        final String column = "B";
+
         this.extendDownAndCheck(
-                "B"
+                column,
+                column
+        );
+    }
+
+    @Test
+    public void testExtendDownHiddenColumn() {
+        final SpreadsheetColumnStore store = SpreadsheetColumnStores.treeMap();
+        store.save(SpreadsheetSelection.parseColumn("c").column().setHidden(true));
+
+        this.extendDownAndCheck(
+                "C",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
@@ -27,6 +27,8 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import walkingkooka.util.PropertiesPath;
 import walkingkooka.visit.Visiting;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -219,10 +221,11 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetCellReferenceOrLa
     public void testExtendRange() {
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> this.createSelection().extendRange(
-                        SpreadsheetSelection.parseCell("A1"),
-                        SpreadsheetViewportSelectionAnchor.NONE
-                )
+                () -> this.createSelection()
+                        .extendRange(
+                                Optional.empty(),
+                                SpreadsheetViewportSelectionAnchor.NONE
+                        )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRangeTest.java
@@ -469,7 +469,8 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
     public void testLeftAnchorTop() {
         this.leftAndCheck(
                 "2:3",
-                SpreadsheetViewportSelectionAnchor.TOP
+                SpreadsheetViewportSelectionAnchor.TOP,
+                "2:3"
         );
     }
 
@@ -514,15 +515,18 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
         this.upAndCheck(
                 "1:2",
                 SpreadsheetViewportSelectionAnchor.BOTTOM,
-                "1:1"
+                "1"
         );
     }
 
     @Test
     public void testRightAnchorTop() {
+        final String row = "2:3";
+
         this.leftAndCheck(
-                "2:3",
-                SpreadsheetViewportSelectionAnchor.TOP
+                row,
+                SpreadsheetViewportSelectionAnchor.TOP,
+                row
         );
     }
 
@@ -567,7 +571,7 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
         final SpreadsheetRowReference row = SpreadsheetReferenceKind.RELATIVE.lastRow();
 
         this.downAndCheck(
-                "1:" + row,
+                SpreadsheetSelection.parseRowRange("1:" + row),
                 SpreadsheetViewportSelectionAnchor.TOP,
                 row
         );
@@ -710,15 +714,21 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
         this.extendUpAndCheck(
                 "3:4",
                 SpreadsheetViewportSelectionAnchor.TOP,
-                "3"
+                "3",
+                SpreadsheetViewportSelectionAnchor.NONE
         );
     }
 
     @Test
     public void testExtendUpAnchorBottomFirstRow() {
+        final String row = "1:2";
+        final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAnchor.BOTTOM;
+
         this.extendUpAndCheck(
-                "1:2",
-                SpreadsheetViewportSelectionAnchor.BOTTOM
+                row,
+                anchor,
+                row,
+                anchor
         );
     }
 
@@ -749,21 +759,32 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
         this.extendDownAndCheck(
                 row.add(-1)
                         .rowRange(row),
-                SpreadsheetViewportSelectionAnchor.TOP
+                SpreadsheetViewportSelectionAnchor.BOTTOM,
+                row.setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
         );
     }
 
     @Test
     public void testExtendLeft() {
+        final String range = "2:3";
+
         this.extendLeftAndCheck(
-                "2:3"
+                range,
+                SpreadsheetViewportSelectionAnchor.BOTTOM,
+                range,
+                SpreadsheetViewportSelectionAnchor.BOTTOM
         );
     }
 
     @Test
     public void testExtendRight() {
+        final String range = "2:3";
+
         this.extendRightAndCheck(
-                "2:3"
+                range,
+                SpreadsheetViewportSelectionAnchor.BOTTOM,
+                range,
+                SpreadsheetViewportSelectionAnchor.BOTTOM
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.Range;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.SpreadsheetRow;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
+import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
@@ -543,7 +545,21 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     @Test
     public void testLeft() {
         this.leftAndCheck(
+                "1",
                 "1"
+        );
+    }
+
+    @Test
+    public void testLeftHiddenColumn() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
+        store.save(row.row().setHidden(true));
+
+        this.leftAndCheck(
+                row,
+                store
         );
     }
 
@@ -558,7 +574,20 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     @Test
     public void testUpFirstRow() {
         this.upAndCheck(
+                "1",
                 "1"
+        );
+    }
+
+    @Test
+    public void testUpSkipsHidden() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.upAndCheck(
+                "4",
+                store,
+                "2"
         );
     }
 
@@ -575,7 +604,21 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     @Test
     public void testRight() {
         this.rightAndCheck(
+                "2",
                 "2"
+        );
+    }
+
+    @Test
+    public void testRightHiddenColumn() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("2");
+        store.save(row.row().setHidden(true));
+
+        this.rightAndCheck(
+                row,
+                store
         );
     }
 
@@ -597,11 +640,26 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
 
     @Test
     public void testDownLastRow() {
+        final SpreadsheetRowReference row = SpreadsheetReferenceKind.RELATIVE.lastRow();
+
         this.downAndCheck(
-                SpreadsheetReferenceKind.RELATIVE.lastRow()
+                row,
+                row
         );
     }
 
+    @Test
+    public void testDownSkipsHidden() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.downAndCheck(
+                "2",
+                store,
+                "4"
+        );
+    }
+    
     // extendRange......................................................................................................
 
     @Test
@@ -632,8 +690,11 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
 
     @Test
     public void testExtendRangeSame() {
+        final String range = "123";
+
         this.extendRangeAndCheck(
-                "123"
+                range,
+                range
         );
     }
 
@@ -648,6 +709,7 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     public void testExtendUp() {
         this.extendUpAndCheck(
                 "3",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "2:3",
                 SpreadsheetViewportSelectionAnchor.BOTTOM
         );
@@ -655,8 +717,25 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
 
     @Test
     public void testExtendUpFirstRow() {
+        final String row = "1";
+
         this.extendUpAndCheck(
-                "1"
+                row,
+                row
+        );
+    }
+
+    @Test
+    public void testExtendUpSkipsHiddenColumn() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendUpAndCheck(
+                "4",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store,
+                "2:4",
+                SpreadsheetViewportSelectionAnchor.BOTTOM
         );
     }
 
@@ -664,6 +743,7 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     public void testExtendDown() {
         this.extendDownAndCheck(
                 "3",
+                SpreadsheetViewportSelectionAnchor.NONE,
                 "3:4",
                 SpreadsheetViewportSelectionAnchor.TOP
         );
@@ -671,22 +751,69 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
 
     @Test
     public void testExtendDownLastRow() {
+        final SpreadsheetRowReference row = SpreadsheetReferenceKind.RELATIVE.lastRow();
+
         this.extendDownAndCheck(
-                SpreadsheetReferenceKind.RELATIVE.lastRow()
+                row,
+                row
+        );
+    }
+
+    @Test
+    public void testExtendDownSkipsHiddenColumn() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendDownAndCheck(
+                "2",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store,
+                "2:4",
+                SpreadsheetViewportSelectionAnchor.TOP
         );
     }
 
     @Test
     public void testExtendLeft() {
+        final String row = "2";
+
         this.extendLeftAndCheck(
-                "2"
+                row,
+                row
+        );
+    }
+
+    @Test
+    public void testExtendLeftHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendLeftAndCheck(
+                "3",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store
         );
     }
 
     @Test
     public void testExtendRight() {
+        final String row = "2";
+
         this.extendRightAndCheck(
-                "2"
+                row,
+                row
+        );
+    }
+
+    @Test
+    public void testExtendRightHiddenRow() {
+        final SpreadsheetRowStore store = SpreadsheetRowStores.treeMap();
+        store.save(SpreadsheetSelection.parseRow("3").row().setHidden(true));
+
+        this.extendRightAndCheck(
+                "3",
+                SpreadsheetViewportSelectionAnchor.NONE,
+                store
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.reference;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 import walkingkooka.predicate.PredicateTesting2;
@@ -34,6 +35,7 @@ import walkingkooka.text.printer.TreePrintableTesting;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -132,54 +134,151 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     // left.............................................................................................................
 
-    final void leftAndCheck(final String selection) {
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore) {
         this.leftAndCheck(
                 selection,
-                selection
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void leftAndCheck(final String selection,
-                            final String expected) {
-        final S parsed = this.parseString(selection);
+                             final SpreadsheetRowStore rowStore) {
         this.leftAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseString(expected)
+                selection,
+                this.columnStore(),
+                rowStore
         );
     }
 
     final void leftAndCheck(final String selection,
-                            final SpreadsheetViewportSelectionAnchor anchor) {
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
         this.leftAndCheck(
-                selection,
-                anchor,
-                selection
-        );
-    }
-
-    final void leftAndCheck(final String text,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final String expected) {
-        this.leftAndCheck(
-                this.parseString(text),
-                anchor,
-                this.parseString(expected)
+                this.parseString(selection),
+                columnStore,
+                rowStore
         );
     }
 
     final void leftAndCheck(final S selection,
-                            final SpreadsheetSelection expected) {
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
         this.leftAndCheck(
                 selection,
-                selection.defaultAnchor(),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final String expected) {
+        this.leftAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.parseString(expected)
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final String expected) {
+        this.leftAndCheck(
+                this.parseString(selection),
+                anchor,
+                this.parseString(expected)
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
+        this.leftAndCheck(
+                selection,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.leftAndCheck(
+                selection,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.leftAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void leftAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.leftAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
                 expected
         );
     }
 
     final void leftAndCheck(final S selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetSelection expected) {
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetSelection expected) {
         this.leftAndCheck(
                 selection,
                 anchor,
@@ -189,47 +288,163 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     }
 
     final void leftAndCheck(final S selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetColumnStore columnStore,
-                            final SpreadsheetSelection expected) {
+                             final SpreadsheetColumnStore columnStore) {
+        this.leftAndCheck(
+                selection,
+                columnStore,
+                Optional.empty()
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetRowStore rowStore) {
+        this.leftAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                expected
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.leftAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                expected
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.leftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void leftAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.simplify(),
-                selection.left(anchor, columnStore, SpreadsheetRowStores.fake()),
+                expected.map(s -> s.simplify()),
+                selection.left(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate left"
         );
     }
 
     // up.............................................................................................................
-
-    final void upAndCheck(final String selection) {
+    final void upAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore) {
         this.upAndCheck(
                 selection,
-                selection
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void upAndCheck(final String selection,
-                          final String expected) {
-        final S parsed = this.parseString(selection);
+                             final SpreadsheetRowStore rowStore) {
         this.upAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
+                selection,
+                this.columnStore(),
+                rowStore
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
+        this.upAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
+        this.upAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final String expected) {
+        this.upAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
                 this.parseString(expected)
         );
     }
 
     final void upAndCheck(final String selection,
-                          final SpreadsheetViewportSelectionAnchor anchor) {
-        this.upAndCheck(
-                selection,
-                anchor,
-                selection
-        );
-    }
-
-    final void upAndCheck(final String selection,
-                          final SpreadsheetViewportSelectionAnchor anchor,
-                          final String expected) {
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final String expected) {
         this.upAndCheck(
                 this.parseString(selection),
                 anchor,
@@ -237,96 +452,351 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         );
     }
 
-    final void upAndCheck(final S selection,
-                          final SpreadsheetSelection expected) {
+    final void upAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
         this.upAndCheck(
                 selection,
-                selection.defaultAnchor(),
+                columnStore,
+                this.rowStore(),
                 expected
         );
     }
 
-    final void upAndCheck(final S selection,
-                          final SpreadsheetViewportSelectionAnchor anchor,
-                          final SpreadsheetSelection expected) {
+    final void upAndCheck(final String selection,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.upAndCheck(
+                selection,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.upAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
         this.upAndCheck(
                 selection,
                 anchor,
-                rowStore(),
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void upAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.upAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
                 expected
         );
     }
 
     final void upAndCheck(final S selection,
-                          final SpreadsheetViewportSelectionAnchor anchor,
-                          final SpreadsheetRowStore rowStore,
-                          final SpreadsheetSelection expected) {
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore) {
+        this.upAndCheck(
+                selection,
+                columnStore,
+                Optional.empty()
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetRowStore rowStore) {
+        this.upAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                expected
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.upAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                expected
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.upAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void upAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.simplify(),
-                selection.up(anchor, SpreadsheetColumnStores.fake(), rowStore),
+                expected.map(s -> s.simplify()),
+                selection.up(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate up"
         );
     }
-
     // right.............................................................................................................
 
-    final void rightAndCheck(final String selection) {
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetColumnStore columnStore) {
         this.rightAndCheck(
                 selection,
-                selection
-        );
-    }
-
-    final void rightAndCheck(final S selection) {
-        this.rightAndCheck(
-                selection,
-                selection
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void rightAndCheck(final String selection,
-                             final String expected) {
-        final S parsed = this.parseString(selection);
-
+                            final SpreadsheetRowStore rowStore) {
         this.rightAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseString(expected)
+                selection,
+                this.columnStore(),
+                rowStore
         );
     }
 
     final void rightAndCheck(final String selection,
-                             final SpreadsheetViewportSelectionAnchor anchor,
-                             final String expected) {
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore) {
         this.rightAndCheck(
-                selection,
-                anchor,
-                this.parseString(expected)
+                this.parseString(selection),
+                columnStore,
+                rowStore
         );
     }
 
     final void rightAndCheck(final S selection,
-                             final SpreadsheetSelection expected) {
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore) {
         this.rightAndCheck(
                 selection,
-                selection.defaultAnchor(),
-                expected
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
         );
     }
 
     final void rightAndCheck(final String selection,
-                             final SpreadsheetViewportSelectionAnchor anchor,
-                             final SpreadsheetSelection expected) {
+                            final String expected) {
+        this.rightAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.parseString(expected)
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final String expected) {
         this.rightAndCheck(
                 this.parseString(selection),
                 anchor,
+                this.parseString(expected)
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetColumnStore columnStore,
+                            final String expected) {
+        this.rightAndCheck(
+                selection,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetRowStore rowStore,
+                            final String expected) {
+        this.rightAndCheck(
+                selection,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore,
+                            final String expected) {
+        this.rightAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final String expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetRowStore rowStore,
+                            final String expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void rightAndCheck(final String selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore,
+                            final String expected) {
+        this.rightAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
                 expected
         );
     }
 
     final void rightAndCheck(final S selection,
-                             final SpreadsheetViewportSelectionAnchor anchor,
-                             final SpreadsheetSelection expected) {
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetSelection expected) {
         this.rightAndCheck(
                 selection,
                 anchor,
@@ -336,55 +806,162 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     }
 
     final void rightAndCheck(final S selection,
-                             final SpreadsheetViewportSelectionAnchor anchor,
-                             final SpreadsheetColumnStore columnStore,
-                             final SpreadsheetSelection expected) {
+                            final SpreadsheetColumnStore columnStore) {
+        this.rightAndCheck(
+                selection,
+                columnStore,
+                Optional.empty()
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetRowStore rowStore) {
+        this.rightAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore,
+                            final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                expected
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore,
+                            final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetColumnStore columnStore,
+                            final Optional<SpreadsheetSelection> expected) {
+        this.rightAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                expected
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetSelection expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final Optional<SpreadsheetSelection> expected) {
+        this.rightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void rightAndCheck(final S selection,
+                            final SpreadsheetViewportSelectionAnchor anchor,
+                            final SpreadsheetColumnStore columnStore,
+                            final SpreadsheetRowStore rowStore,
+                            final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.simplify(),
-                selection.right(anchor, columnStore, SpreadsheetRowStores.fake()),
+                expected.map(s -> s.simplify()),
+                selection.right(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate right"
         );
     }
-
     // down.............................................................................................................
-
-    final void downAndCheck(final String selection) {
+    final void downAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore) {
         this.downAndCheck(
                 selection,
-                selection
-        );
-    }
-
-    final void downAndCheck(final S selection) {
-        this.downAndCheck(
-                selection,
-                selection
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void downAndCheck(final String selection,
-                            final String expected) {
-        final S parsed = this.parseString(selection);
-
+                             final SpreadsheetRowStore rowStore) {
         this.downAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
+                selection,
+                this.columnStore(),
+                rowStore
+        );
+    }
+
+    final void downAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
+        this.downAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore) {
+        this.downAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void downAndCheck(final String selection,
+                             final String expected) {
+        this.downAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
                 this.parseString(expected)
         );
     }
 
     final void downAndCheck(final String selection,
-                            final SpreadsheetViewportSelectionAnchor anchor) {
-        this.downAndCheck(
-                selection,
-                anchor,
-                selection
-        );
-    }
-
-    final void downAndCheck(final String selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final String expected) {
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final String expected) {
         this.downAndCheck(
                 this.parseString(selection),
                 anchor,
@@ -392,43 +969,201 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         );
     }
 
-    final void downAndCheck(final S selection,
-                            final SpreadsheetSelection expected) {
+    final void downAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
         this.downAndCheck(
                 selection,
-                selection.defaultAnchor(),
+                columnStore,
+                this.rowStore(),
                 expected
         );
     }
 
     final void downAndCheck(final String selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetSelection expected) {
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
         this.downAndCheck(
-                this.parseString(selection),
-                anchor,
+                selection,
+                this.columnStore(),
+                rowStore,
                 expected
         );
     }
 
-    final void downAndCheck(final S selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetSelection expected) {
+    final void downAndCheck(final String selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.downAndCheck(
+                this.parseString(selection),
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void downAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final String expected) {
         this.downAndCheck(
                 selection,
                 anchor,
-                rowStore(),
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void downAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                this.columnStore(),
+                rowStore,
+                expected
+        );
+    }
+
+    final void downAndCheck(final String selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final String expected) {
+        this.downAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expected)
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
                 expected
         );
     }
 
     final void downAndCheck(final S selection,
-                            final SpreadsheetViewportSelectionAnchor anchor,
-                            final SpreadsheetRowStore rowStore,
-                            final SpreadsheetSelection expected) {
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                columnStore(),
+                expected
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore) {
+        this.downAndCheck(
+                selection,
+                columnStore,
+                Optional.empty()
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetRowStore rowStore) {
+        this.downAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                expected
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.downAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                expected
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetSelection expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final Optional<SpreadsheetSelection> expected) {
+        this.downAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void downAndCheck(final S selection,
+                             final SpreadsheetViewportSelectionAnchor anchor,
+                             final SpreadsheetColumnStore columnStore,
+                             final SpreadsheetRowStore rowStore,
+                             final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.simplify(),
-                selection.down(anchor, SpreadsheetColumnStores.fake(), rowStore),
+                expected.map(s -> s.simplify()),
+                selection.down(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate down"
         );
     }
@@ -442,14 +1177,6 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     }
 
     // extendRange......................................................................................................
-
-    final void extendRangeAndCheck(final String selection) {
-        this.extendRangeAndCheck(
-                selection,
-                selection
-        );
-    }
-
 
     final void extendRangeAndCheck(final String selection,
                                    final String moved) {
@@ -500,14 +1227,28 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                    final SpreadsheetSelection moved,
                                    final SpreadsheetViewportSelectionAnchor anchor,
                                    final SpreadsheetSelection expected) {
-        this.checkEquals(
-                true,
-                moved instanceof SpreadsheetCellReference || moved instanceof SpreadsheetColumnReference || moved instanceof SpreadsheetRowReference,
-                () -> moved + " must be either cell/column/row"
+        this.extendRangeAndCheck(
+                selection,
+                Optional.of(moved),
+                anchor,
+                Optional.of(expected)
         );
+    }
+
+    final void extendRangeAndCheck(final S selection,
+                                   final Optional<SpreadsheetSelection> moved,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final Optional<SpreadsheetSelection> expected) {
+        if(moved.isPresent()) {
+            this.checkEquals(
+                    true,
+                    moved.map(m -> m instanceof SpreadsheetCellReference || m instanceof SpreadsheetColumnReference || m instanceof SpreadsheetRowReference).get(),
+                    () -> moved + " must be either cell/column/row"
+            );
+        }
         this.checkEquals(
-                expected.simplify(),
-                selection.extendRange(moved, anchor),
+                expected.map(s -> s.simplify()),
+                selection.extendRange(Cast.to(moved), anchor),
                 () -> selection + " extendRange " + moved + " " + anchor
         );
     }
@@ -516,161 +1257,229 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     // extendLeft.......................................................................................................
 
-    final void extendLeftAndCheck(final String selection) {
-        this.extendLeftAndCheck(
-                this.parseString(selection)
-        );
-    }
-
     final void extendLeftAndCheck(final String selection,
-                                  final SpreadsheetViewportSelectionAnchor anchor) {
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetRowStore rowStore) {
         this.extendLeftAndCheck(
-                this.parseString(selection),
-                anchor
+                selection,
+                anchor,
+                this.columnStore(),
+                rowStore
         );
     }
 
     final void extendLeftAndCheck(final String selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
-                                  final String expected) {
-        final SpreadsheetSelection parsed = this.parseRange(expected)
-                .simplify();
-
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         this.extendLeftAndCheck(
                 this.parseString(selection),
                 anchor,
-                parsed.setAnchor(parsed.defaultAnchor())
-        );
-    }
-
-    final void extendLeftAndCheck(final S selection) {
-        this.extendLeftAndCheck(
-                selection,
-                selection.defaultAnchor()
-        );
-    }
-
-    final void extendLeftAndCheck(final S selection,
-                                  final SpreadsheetViewportSelectionAnchor anchor) {
-        this.extendLeftAndCheck(
-                selection,
-                anchor,
-                selection.setAnchor(anchor)
+                columnStore,
+                rowStore,
+                Optional.empty()
         );
     }
 
     final void extendLeftAndCheck(final String selection,
+                                  final String expectedSelection) {
+        this.extendLeftAndCheck(
+                selection,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection
+        );
+    }
+
+    final void extendLeftAndCheck(final String selection,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final String expectedSelection) {
+        this.extendLeftAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                this.parseString(expectedSelection)
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    final void extendLeftAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
                                   final String expectedSelection,
                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        final S parsed = this.parseString(selection);
-
-        this.extendLeftAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseRange(expectedSelection).setAnchor(expectedAnchor)
-        );
-    }
-
-    final void extendLeftAndCheck(final String text,
-                                  final SpreadsheetViewportSelectionAnchor anchor,
-                                  final String expected,
-                                  final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        this.extendLeftAndCheck(
-                this.parseString(text),
-                anchor,
-                this.parseRange(expected)
-                        .simplify()
-                        .setAnchor(expectedAnchor)
-        );
-    }
-
-    final void extendLeftAndCheck(final S selection,
-                                  final SpreadsheetViewportSelectionAnchor anchor,
-                                  final SpreadsheetViewportSelection expected) {
         this.extendLeftAndCheck(
                 selection,
                 anchor,
-                columnStore(),
-                expected
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendLeftAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final String expectedSelection,
+                                  final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendLeftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendLeftAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final String expectedSelection,
+                                  final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendLeftAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expectedSelection)
+                        .simplify()
+                        .setAnchor(expectedAnchor)
         );
     }
 
     final void extendLeftAndCheck(final S selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
                                   final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
                                   final SpreadsheetViewportSelection expected) {
+        this.extendLeftAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void extendLeftAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final Optional<SpreadsheetViewportSelection> expected) {
         this.checkEquals(
                 expected,
-                selection.extendLeft(anchor, columnStore, SpreadsheetRowStores.fake()),
+                selection.extendLeft(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendLeft"
         );
     }
 
     // extendUp.......................................................................................................
 
-    final void extendUpAndCheck(final String selection) {
-        this.extendUpAndCheck(
-                this.parseString(selection)
-        );
-    }
-
     final void extendUpAndCheck(final String selection,
-                                final SpreadsheetViewportSelectionAnchor anchor) {
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore) {
         this.extendUpAndCheck(
                 this.parseString(selection),
-                anchor
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
         );
     }
 
     final void extendUpAndCheck(final String selection,
                                 final SpreadsheetViewportSelectionAnchor anchor,
-                                final String expected) {
-        final SpreadsheetSelection parsed = this.parseRange(expected)
-                .simplify();
-
-        this.extendUpAndCheck(
-                this.parseString(selection),
-                anchor,
-                parsed.setAnchor(parsed.defaultAnchor())
-        );
-    }
-
-    final void extendUpAndCheck(final S selection) {
-        this.extendUpAndCheck(
-                selection,
-                selection.defaultAnchor()
-        );
-    }
-
-    final void extendUpAndCheck(final S selection,
-                                final SpreadsheetViewportSelectionAnchor anchor) {
+                                final SpreadsheetColumnStore columnStore) {
         this.extendUpAndCheck(
                 selection,
                 anchor,
-                selection.setAnchor(anchor)
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void extendUpAndCheck(final String selection,
+                                final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore) {
+        this.extendUpAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void extendUpAndCheck(final String selection,
+                                final String expectedSelection) {
+        this.extendUpAndCheck(
+                selection,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection
+        );
+    }
+
+    final void extendUpAndCheck(final String selection,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore,
+                                final String expectedSelection) {
+        this.extendUpAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                this.parseString(expectedSelection)
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    final void extendUpAndCheck(final String selection,
+                                final SpreadsheetViewportSelectionAnchor anchor,
                                 final String expectedSelection,
                                 final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        final S parsed = this.parseString(selection);
-
         this.extendUpAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseRange(expectedSelection).setAnchor(expectedAnchor)
+                selection,
+                anchor,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
         );
     }
 
-    final void extendUpAndCheck(final String text,
+    final void extendUpAndCheck(final String selection,
                                 final SpreadsheetViewportSelectionAnchor anchor,
-                                final String expected,
+                                final SpreadsheetRowStore rowStore,
+                                final String expectedSelection,
                                 final SpreadsheetViewportSelectionAnchor expectedAnchor) {
         this.extendUpAndCheck(
-                this.parseString(text),
+                selection,
                 anchor,
-                this.parseRange(expected)
+                this.columnStore(),
+                rowStore,
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendUpAndCheck(final String selection,
+                                final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore,
+                                final String expectedSelection,
+                                final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendUpAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expectedSelection)
                         .simplify()
                         .setAnchor(expectedAnchor)
         );
@@ -678,93 +1487,147 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     final void extendUpAndCheck(final S selection,
                                 final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
+                                final SpreadsheetRowStore rowStore,
                                 final SpreadsheetViewportSelection expected) {
         this.extendUpAndCheck(
                 selection,
                 anchor,
-                rowStore(),
-                expected
+                columnStore,
+                rowStore,
+                Optional.of(expected)
         );
     }
 
     final void extendUpAndCheck(final S selection,
                                 final SpreadsheetViewportSelectionAnchor anchor,
+                                final SpreadsheetColumnStore columnStore,
                                 final SpreadsheetRowStore rowStore,
-                                final SpreadsheetViewportSelection expected) {
+                                final Optional<SpreadsheetViewportSelection> expected) {
         this.checkEquals(
                 expected,
-                selection.extendUp(anchor, SpreadsheetColumnStores.fake(), rowStore),
+                selection.extendUp(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendUp"
         );
     }
 
     // extendRight.......................................................................................................
 
-    final void extendRightAndCheck(final String selection) {
-        this.extendRightAndCheck(
-                this.parseString(selection)
-        );
-    }
-
     final void extendRightAndCheck(final String selection,
-                                   final SpreadsheetViewportSelectionAnchor anchor) {
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore) {
         this.extendRightAndCheck(
                 this.parseString(selection),
-                anchor
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
         );
     }
 
     final void extendRightAndCheck(final String selection,
                                    final SpreadsheetViewportSelectionAnchor anchor,
-                                   final String expected) {
-        final SpreadsheetSelection parsed = this.parseRange(expected)
-                .simplify();
-
+                                   final SpreadsheetRowStore rowStore) {
         this.extendRightAndCheck(
-                this.parseString(selection),
+                selection,
                 anchor,
-                parsed.setAnchor(parsed.defaultAnchor())
+                this.columnStore(),
+                rowStore
         );
     }
 
-    final void extendRightAndCheck(final S selection) {
+    final void extendRightAndCheck(final String selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore) {
+        this.extendRightAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void extendRightAndCheck(final String selection,
+                                   final String expectedSelection) {
         this.extendRightAndCheck(
                 selection,
-                selection.defaultAnchor()
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection
+        );
+    }
+
+    final void extendRightAndCheck(final String selection,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore,
+                                   final String expectedSelection) {
+        this.extendRightAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                this.parseString(expectedSelection)
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    final void extendRightAndCheck(final String selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final String expectedSelection,
+                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendRightAndCheck(
+                selection,
+                anchor,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendRightAndCheck(final String selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final String expectedSelection,
+                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendRightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendRightAndCheck(final String selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore,
+                                   final String expectedSelection,
+                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendRightAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expectedSelection)
+                        .simplify()
+                        .setAnchor(expectedAnchor)
         );
     }
 
     final void extendRightAndCheck(final S selection,
-                                   final SpreadsheetViewportSelectionAnchor anchor) {
+                                   final SpreadsheetSelection expectedSelection) {
         this.extendRightAndCheck(
                 selection,
-                anchor,
-                selection.setAnchor(anchor)
-        );
-    }
-
-    final void extendRightAndCheck(final String selection,
-                                   final String expectedSelection,
-                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        final S parsed = this.parseString(selection);
-
-        this.extendRightAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseRange(expectedSelection).setAnchor(expectedAnchor)
-        );
-    }
-
-    final void extendRightAndCheck(final String text,
-                                   final SpreadsheetViewportSelectionAnchor anchor,
-                                   final String expected,
-                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        this.extendRightAndCheck(
-                this.parseString(text),
-                anchor,
-                this.parseRange(expected)
-                        .simplify()
-                        .setAnchor(expectedAnchor)
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection.simplify()
+                        .setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.NONE)
         );
     }
 
@@ -783,9 +1646,37 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                    final SpreadsheetViewportSelectionAnchor anchor,
                                    final SpreadsheetColumnStore columnStore,
                                    final SpreadsheetViewportSelection expected) {
+        this.extendRightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void extendRightAndCheck(final S selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore,
+                                   final SpreadsheetViewportSelection expected) {
+        this.extendRightAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void extendRightAndCheck(final S selection,
+                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                   final SpreadsheetColumnStore columnStore,
+                                   final SpreadsheetRowStore rowStore,
+                                   final Optional<SpreadsheetViewportSelection> expected) {
         this.checkEquals(
                 expected,
-                selection.extendRight(anchor, columnStore, SpreadsheetRowStores.fake()),
+                selection.extendRight(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendRight"
         );
     }
@@ -794,90 +1685,189 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     final void extendDownAndCheck(final String selection) {
         this.extendDownAndCheck(
-                this.parseString(selection)
+                selection,
+                this.columnStore(),
+                this.rowStore()
         );
     }
 
     final void extendDownAndCheck(final String selection,
-                                  final SpreadsheetViewportSelectionAnchor anchor) {
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
         this.extendDownAndCheck(
                 this.parseString(selection),
-                anchor
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                Optional.empty()
         );
     }
 
     final void extendDownAndCheck(final String selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
-                                  final String expected) {
-        final SpreadsheetSelection parsed = this.parseRange(expected)
-                .simplify();
-
-        this.extendDownAndCheck(
-                this.parseString(selection),
-                anchor,
-                parsed.setAnchor(parsed.defaultAnchor())
-        );
-    }
-
-    final void extendDownAndCheck(final S selection) {
-        this.extendDownAndCheck(
-                selection,
-                selection.defaultAnchor()
-        );
-    }
-
-    final void extendDownAndCheck(final S selection,
-                                  final SpreadsheetViewportSelectionAnchor anchor) {
+                                  final SpreadsheetColumnStore columnStore) {
         this.extendDownAndCheck(
                 selection,
                 anchor,
-                selection.setAnchor(anchor)
+                columnStore,
+                this.rowStore()
         );
     }
 
     final void extendDownAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore) {
+        this.extendDownAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.empty()
+        );
+    }
+
+    final void extendDownAndCheck(final String selection,
+                                  final String expectedSelection) {
+        this.extendDownAndCheck(
+                selection,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection
+        );
+    }
+
+    final void extendDownAndCheck(final String selection,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final String expectedSelection) {
+        this.extendDownAndCheck(
+                this.parseString(selection),
+                SpreadsheetViewportSelectionAnchor.NONE,
+                columnStore,
+                rowStore,
+                this.parseString(expectedSelection)
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    final void extendDownAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
                                   final String expectedSelection,
                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
-        final S parsed = this.parseString(selection);
-
         this.extendDownAndCheck(
-                parsed,
-                parsed.defaultAnchor(),
-                this.parseRange(expectedSelection).setAnchor(expectedAnchor)
+                selection,
+                anchor,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection,
+                expectedAnchor
         );
     }
 
-    final void extendDownAndCheck(final String text,
+    final void extendDownAndCheck(final String selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
-                                  final String expected,
+                                  final SpreadsheetRowStore rowStore,
+                                  final String expectedSelection,
                                   final SpreadsheetViewportSelectionAnchor expectedAnchor) {
         this.extendDownAndCheck(
-                this.parseString(text),
+                selection,
                 anchor,
-                this.parseRange(expected)
+                this.columnStore(),
+                rowStore,
+                expectedSelection,
+                expectedAnchor
+        );
+    }
+
+    final void extendDownAndCheck(final String selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final String expectedSelection,
+                                  final SpreadsheetViewportSelectionAnchor expectedAnchor) {
+        this.extendDownAndCheck(
+                this.parseString(selection),
+                anchor,
+                columnStore,
+                rowStore,
+                this.parseRange(expectedSelection)
                         .simplify()
                         .setAnchor(expectedAnchor)
         );
     }
 
     final void extendDownAndCheck(final S selection,
+                                  final SpreadsheetSelection expectedSelection) {
+        this.extendDownAndCheck(
+                selection,
+                SpreadsheetViewportSelectionAnchor.NONE,
+                this.columnStore(),
+                this.rowStore(),
+                expectedSelection.simplify()
+                        .setAnchorOrDefault(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    final void extendDownAndCheck(final S selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
                                   final SpreadsheetViewportSelection expected) {
         this.extendDownAndCheck(
                 selection,
                 anchor,
-                rowStore(),
+                columnStore(),
                 expected
         );
     }
 
     final void extendDownAndCheck(final S selection,
                                   final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetViewportSelection expected) {
+        this.extendDownAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void extendDownAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
                                   final SpreadsheetRowStore rowStore,
                                   final SpreadsheetViewportSelection expected) {
+        this.extendDownAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    final void extendDownAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final Optional<SpreadsheetViewportSelection> expected) {
+        this.extendDownAndCheck(
+                selection,
+                anchor,
+                columnStore,
+                this.rowStore(),
+                expected
+        );
+    }
+
+    final void extendDownAndCheck(final S selection,
+                                  final SpreadsheetViewportSelectionAnchor anchor,
+                                  final SpreadsheetColumnStore columnStore,
+                                  final SpreadsheetRowStore rowStore,
+                                  final Optional<SpreadsheetViewportSelection> expected) {
         this.checkEquals(
                 expected,
-                selection.extendDown(anchor, SpreadsheetColumnStores.fake(), rowStore),
+                selection.extendDown(anchor, columnStore, rowStore),
                 () -> selection + " anchor=" + anchor + " navigate extendDown"
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationTest.java
@@ -26,6 +26,8 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.text.CharSequences;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetViewportSelectionNavigationTest implements ClassTesting<SpreadsheetViewportSelectionNavigation> {
@@ -350,6 +352,23 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ClassTe
             final SpreadsheetColumnStore columnStore,
             final SpreadsheetRowStore rowStore,
             final SpreadsheetViewportSelection expected) {
+        this.performAndCheck(
+                navigation,
+                selection,
+                anchor,
+                columnStore,
+                rowStore,
+                Optional.of(expected)
+        );
+    }
+
+    private void performAndCheck(
+            final SpreadsheetViewportSelectionNavigation navigation,
+            final SpreadsheetSelection selection,
+            final SpreadsheetViewportSelectionAnchor anchor,
+            final SpreadsheetColumnStore columnStore,
+            final SpreadsheetRowStore rowStore,
+            final Optional<SpreadsheetViewportSelection> expected) {
         this.checkEquals(
                 expected,
                 navigation.perform(selection, anchor, columnStore, rowStore),


### PR DESCRIPTION
- SpreadsheetSelection#left | up | right | down | extendXXX all now return Optional.
- Doing the navigation component should skip hidden columns & rows.
- If the final selection is hidden return Optional.empty.