### PR TITLE
BasicSpreadsheetEngine window overlapping home fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1033,13 +1033,13 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         SpreadsheetCellReference nonFrozenHome = context.resolveCellReference(viewport.cellOrLabel());
         if (null != frozenColumns) {
             final SpreadsheetColumnReference right = frozenColumns.end();
-            if (right.compareTo(nonFrozenHome.column()) > 0) {
+            if (right.compareTo(nonFrozenHome.column()) >= 0) {
                 nonFrozenHome = nonFrozenHome.setColumn(right.addSaturated(+1));
             }
         }
         if (null != frozenRows) {
             final SpreadsheetRowReference right = frozenRows.end();
-            if (right.compareTo(nonFrozenHome.row()) > 0) {
+            if (right.compareTo(nonFrozenHome.row()) >= 0) {
                 nonFrozenHome = nonFrozenHome.setRow(right.addSaturated(+1));
             }
         }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -8188,6 +8188,21 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     // A2
     // A3
     @Test
+    public void testWindowFrozenColumnsOnlyInvalidOverlappingHome() {
+        this.windowAndCheck(
+                "A1",
+                WIDTH * 1,
+                HEIGHT * 3,
+                1, // frozenColumns
+                0, // frozenRows
+                "A1:A3"
+        );
+    }
+
+    // A1
+    // A2
+    // A3
+    @Test
     public void testWindowFrozenColumnsOnly() {
         this.windowAndCheck(
                 "B1",
@@ -8286,6 +8301,19 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 2, // frozenColumns
                 0, // frozenRows
                 "A1:B3,F1:G3"
+        );
+    }
+
+    // A1 B1 C1 D1
+    @Test
+    public void testWindowFrozenRowsOnlyInvalidOverlappingHome() {
+        this.windowAndCheck(
+                "A1",
+                WIDTH * 4,
+                HEIGHT * 1,
+                0, // frozenColumns
+                1, // frozenRows
+                "A1:D1"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/552
- freeze columns/rows then load cells then load cells 2nd time fails
- Fails because home=A1 which is overlapped by frozen column/rows.