### PR TITLE
SpreadsheetCellRangeParserToken.toExpression empty fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.visit.Visiting;
 
@@ -32,7 +33,32 @@ public final class SpreadsheetCellRangeParserToken extends SpreadsheetBinaryPars
 
     private SpreadsheetCellRangeParserToken(final List<ParserToken> value, final String text) {
         super(value, text);
+
+        final SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor visitor = SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor.with();
+        visitor.accept(this);
+
+        final List<SpreadsheetCellReferenceParserToken> components = visitor.components;
+        final int count = components.size();
+
+        switch (count) {
+            case 0:
+                throw new IllegalArgumentException("Missing begin");
+            case 1:
+                throw new IllegalArgumentException("Missing end");
+            case 2:
+                this.cellRange = components.get(0).cell()
+                        .cellRange(components.get(1).cell());
+                break;
+            default:
+                throw new IllegalArgumentException("Ranges must only have begin & end");
+        }
     }
+
+    public SpreadsheetCellRange toCellRange() {
+        return this.cellRange;
+    }
+
+    private final SpreadsheetCellRange cellRange;
 
     // SpreadsheetParserTokenVisitor....................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor.java
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Used to collect the begin and end components for a {@link SpreadsheetCellRangeParserToken}.
+ */
+final class SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+
+    static SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor with() {
+        return new SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor();
+    }
+
+    private SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor() {
+        super();
+    }
+
+    protected Visiting startVisit(final SpreadsheetCellReferenceParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final SpreadsheetCellReferenceParserToken token) {
+        this.components.add(token);
+    }
+
+    final List<SpreadsheetCellReferenceParserToken> components = Lists.array();
+}

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
@@ -80,7 +80,7 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
 
     @Override
     protected void endVisit(final SpreadsheetCellRangeParserToken token) {
-        this.exit();
+        this.exitReference(token.toCellRange(), token);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitorTest.java
@@ -1,0 +1,34 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.reflect.ClassTesting2;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitorTest implements ClassTesting2<SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor> {
+    @Override
+    public Class<SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor> type() {
+        return SpreadsheetCellRangeParserTokenSpreadsheetParserTokenVisitor.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpressionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpressionTest.java
@@ -19,6 +19,11 @@ package walkingkooka.spreadsheet.parser;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionEvaluationContexts;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -35,6 +40,81 @@ public final class SpreadsheetParserTokenVisitorToExpressionTest extends Spreads
                                 ),
                                 "1"),
                         null));
+    }
+
+    @Test
+    public void testCellReference() {
+        this.toExpressionAndCheck(
+                SpreadsheetParserToken.cellReference(
+                        Lists.of(
+                                SpreadsheetParserToken.columnReference(
+                                        SpreadsheetSelection.parseColumn("A"),
+                                        "A"
+                                ),
+                                SpreadsheetParserToken.rowReference(
+                                        SpreadsheetSelection.parseRow("1"),
+                                        "1"
+                                )
+                        ),
+                        "A1"
+                ),
+                Expression.reference(
+                        SpreadsheetSelection.parseCell("A1")
+                )
+        );
+    }
+
+    @Test
+    public void testCellRange() {
+        this.toExpressionAndCheck(
+                SpreadsheetParserToken.cellRange(
+                        Lists.of(
+                                SpreadsheetParserToken.cellReference(
+                                        Lists.of(
+                                                SpreadsheetParserToken.columnReference(
+                                                        SpreadsheetSelection.parseColumn("A"),
+                                                        "A"
+                                                ),
+                                                SpreadsheetParserToken.rowReference(
+                                                        SpreadsheetSelection.parseRow("1"),
+                                                        "1"
+                                                )
+                                        ),
+                                        "A1"
+                                ),
+                                SpreadsheetParserToken.cellReference(
+                                        Lists.of(
+                                                SpreadsheetParserToken.columnReference(
+                                                        SpreadsheetSelection.parseColumn("B"),
+                                                        "B"
+                                                ),
+                                                SpreadsheetParserToken.rowReference(
+                                                        SpreadsheetSelection.parseRow("2"),
+                                                        "2"
+                                                )
+                                        ),
+                                        "A1"
+                                )
+                        ),
+                        "A1:B2"
+                ),
+                Expression.reference(
+                        SpreadsheetSelection.parseCellRange("A1:B2")
+                )
+        );
+    }
+
+    private void toExpressionAndCheck(final SpreadsheetParserToken token,
+                                      final Expression expression) {
+        this.checkEquals(
+                Optional.of(
+                        expression
+                ),
+                SpreadsheetParserTokenVisitorToExpression.toExpression(
+                        token,
+                        ExpressionEvaluationContexts.fake()
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
- Previously the Expression returned was empty rather than an Expression with a SpreadsheetCellRange.
- SpreadsheetParsersTest added extra using SpreadsheetParserToken.toExpression.
- Disabled some SpreadsheetParserTests for cell ranges including a label.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2189 SpreadsheetParserTokenVisitorToExpression: cell ranges disappearing from resulting expression.