### PR TITLE
https://github.com/mP1/walkingkooka-tree/pull/499 ExpressionFunctionC…

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -224,6 +224,9 @@ public class JunitTest {
                 return ExpressionFunctionContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
+                        (r) -> {
+                            throw new UnsupportedOperationException();
+                        },
                         this.references(),
                         SpreadsheetExpressionFunctionContexts.referenceNotFound(),
                         CaseSensitivity.INSENSITIVE,

--- a/src/main/java/walkingkooka/spreadsheet/HasSpreadsheetError.java
+++ b/src/main/java/walkingkooka/spreadsheet/HasSpreadsheetError.java
@@ -1,0 +1,27 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet;
+
+/**
+ * Declares that a container of some sort includes a {@link SpreadsheetError}.
+ */
+public interface HasSpreadsheetError {
+
+    SpreadsheetError spreadsheetError();
+}

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorConversionException.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorConversionException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet;
+
+import walkingkooka.convert.ConversionException;
+
+import java.util.Objects;
+
+/**
+ * This exception is thrown by SpreadsheetConverter when it is requested
+ * to convert a {@link SpreadsheetError} to some other type.
+ * <br>
+ * This behaviour guarantees that any formula or expression with an error will fail with the first {@link SpreadsheetError}.
+ */
+public final class SpreadsheetErrorConversionException extends ConversionException implements HasSpreadsheetError {
+
+    private static final long serialVersionUID = 1L;
+
+    protected SpreadsheetErrorConversionException() {
+        super();
+    }
+
+    public SpreadsheetErrorConversionException(final SpreadsheetError error) {
+        super();
+        this.error = Objects.requireNonNull(error, "error");
+    }
+
+    @Override
+    public SpreadsheetError spreadsheetError() {
+        return this.error;
+    }
+
+    private SpreadsheetError error;
+}

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
@@ -95,6 +95,16 @@ public enum SpreadsheetErrorKind implements HasText {
     public static SpreadsheetError translate(final Throwable cause) {
         Objects.requireNonNull(cause, "cause");
 
+        return cause instanceof HasSpreadsheetError ?
+                translate0((HasSpreadsheetError) cause) :
+                translate1(cause);
+    }
+
+    private static SpreadsheetError translate0(final HasSpreadsheetError has) {
+        return has.spreadsheetError();
+    }
+
+    private static SpreadsheetError translate1(final Throwable cause) {
         Throwable translate = cause;
 
         if (cause instanceof ExpressionEvaluationException) {
@@ -104,10 +114,10 @@ public enum SpreadsheetErrorKind implements HasText {
             }
         }
 
-        return translate0(translate);
+        return translate2(translate);
     }
 
-    private static SpreadsheetError translate0(final Throwable cause) {
+    private static SpreadsheetError translate2(final Throwable cause) {
         final SpreadsheetErrorKind kind;
 
         do {

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverter.java
@@ -22,6 +22,8 @@ import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
 import walkingkooka.predicate.Predicates;
+import walkingkooka.spreadsheet.SpreadsheetError;
+import walkingkooka.spreadsheet.SpreadsheetErrorConversionException;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePatterns;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeParsePatterns;
@@ -292,7 +294,8 @@ final class SpreadsheetConverter implements Converter<ExpressionNumberConverterC
                 LocalTime.class == type ||
                 ExpressionNumber.isClass(type) ||
                 Number.class == type ||
-                String.class == type;
+                String.class == type ||
+                SpreadsheetError.class == type;
     }
 
     @Override
@@ -325,6 +328,11 @@ final class SpreadsheetConverter implements Converter<ExpressionNumberConverterC
     private <T> Either<T, String> convertNonNull(final Object value,
                                                  final Class<T> targetType,
                                                  final ExpressionNumberConverterContext context) {
+        // errors are a special type we dont want to try and convert them and report them inside a ConversionException which loses the error.
+        if (value instanceof SpreadsheetError) {
+            throw new SpreadsheetErrorConversionException((SpreadsheetError) value);
+        }
+
         final Converter<ExpressionNumberConverterContext> converter = SpreadsheetConverterSpreadsheetValueVisitor.converter(
                 value,
                 targetType,

--- a/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
@@ -93,6 +93,11 @@ final class BasicSpreadsheetDataValidatorContext implements SpreadsheetDataValid
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        return this.context.handleException(exception);
+    }
+
+    @Override
     public boolean isPure(final FunctionExpressionName name) {
         return this.context.isPure(name);
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext.java
@@ -21,6 +21,7 @@ import walkingkooka.Either;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.SpreadsheetErrorKind;
 import walkingkooka.spreadsheet.function.SpreadsheetExpressionFunctionContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
@@ -143,6 +144,11 @@ final class BasicSpreadsheetEngineContextSpreadsheetExpressionFunctionContext im
                            final List<Object> parameters) {
         return this.function(name)
                 .apply(parameters, this);
+    }
+
+    @Override
+    public Object handleException(final RuntimeException exception) {
+        return SpreadsheetErrorKind.translate(exception);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineExpressionEvaluationContext.java
@@ -94,6 +94,11 @@ final class BasicSpreadsheetEngineExpressionEvaluationContext implements Express
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean canConvert(final Object value,
                               final Class<?> type) {
         return this.converterContext()

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext.java
@@ -84,6 +84,11 @@ final class SpreadsheetNumberParsePatternsConverterExpressionEvaluationContext i
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean canConvert(final Object value,
                               final Class<?> type) {
         return this.context.canConvert(value, type);

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParserPattern2ExpressionEvaluationContext.java
@@ -87,6 +87,11 @@ final class SpreadsheetParserPattern2ExpressionEvaluationContext implements Expr
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean canConvert(final Object value,
                               final Class<?> target) {
         return this.context.canConvert(value, target);

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersExpressionEvaluationContext.java
@@ -77,6 +77,11 @@ final class SpreadsheetParsersExpressionEvaluationContext implements ExpressionE
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isPure(final FunctionExpressionName name) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
@@ -89,6 +89,11 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpres
     }
 
     @Override
+    public Object handleException(final RuntimeException exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean canConvert(final Object value,
                               final Class<?> type) {
         throw new UnsupportedOperationException();

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorConversionExceptionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorConversionExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetErrorConversionExceptionTest implements ClassTesting<SpreadsheetErrorConversionException> {
+
+    private final static SpreadsheetError ERROR = SpreadsheetErrorKind.DIV0.setMessage("Hello");
+
+    @Test
+    public void testNewNullSpreadsheetErrorFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    new SpreadsheetErrorConversionException(null);
+                }
+        );
+    }
+
+    @Test
+    public void testNew() {
+        final SpreadsheetErrorConversionException exception = new SpreadsheetErrorConversionException(ERROR);
+        this.checkEquals(
+                ERROR,
+                exception.spreadsheetError(),
+                "spreadsheetError"
+        );
+    }
+
+    @Override
+    public Class<SpreadsheetErrorConversionException> type() {
+        return SpreadsheetErrorConversionException.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
@@ -40,6 +40,16 @@ public final class SpreadsheetErrorKindTest implements ClassTesting<SpreadsheetE
         );
     }
 
+    @Test
+    public void testTranslateSpreadsheetError() {
+        final SpreadsheetError error = SpreadsheetErrorKind.VALUE.setMessage("Custom message 123");
+
+        this.checkEquals(
+                error,
+                SpreadsheetErrorKind.translate(new SpreadsheetErrorConversionException(error))
+        );
+    }
+
     private final static String MESSAGE = "Hello 123";
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -9207,6 +9207,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 return ExpressionFunctionContexts.basic(
                         this.metadata().expressionNumberKind(),
                         this.functions(),
+                        SpreadsheetErrorKind::translate,
                         this.references(),
                         SpreadsheetExpressionFunctionContexts.referenceNotFound(),
                         CaseSensitivity.INSENSITIVE,

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParsersTest.java
@@ -2322,6 +2322,9 @@ public final class SpreadsheetParsersTest implements PublicStaticHelperTesting<S
                                                 (n) -> {
                                                     throw new UnsupportedOperationException();
                                                 },
+                                                (n) -> {
+                                                    throw new UnsupportedOperationException();
+                                                },
                                                 (r) -> {
                                                     throw new UnsupportedOperationException();
                                                 },

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -212,6 +212,9 @@ public final class Sample {
                 return ExpressionFunctionContexts.basic(
                         EXPRESSION_NUMBER_KIND,
                         this.functions(),
+                        (r) -> {
+                            throw new UnsupportedOperationException();
+                        },
                         this.references(),
                         SpreadsheetExpressionFunctionContexts.referenceNotFound(),
                         CaseSensitivity.INSENSITIVE,


### PR DESCRIPTION
…ontext.handleException

- https://github.com/mP1/walkingkooka-tree/pull/499
- ExpressionFunctionContext.handleException

- New HasSpreadsheetError interface, with SpreadsheetErrorConversionException implementing.
- SpreadsheetConverter now throws a SpreadsheetErrorConversionException when asked to convert SpreadsheetError, this prevents double wrapping.
- BasicSpreadsheetEngineContext handleException translates caught exceptions into SpreadsheetError/s.
- This should allow functions like isError(1/0) to receive a SpreadsheetError as its only parameter, rather than the ArithmeticException propogating past the function.