### PR TITLE
BasicSpreadsheetEngine honour Expression purity

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -931,9 +931,13 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
                 () -> "values from returned cell=" + cell);
     }
 
+    default void checkFormattedText(final SpreadsheetCell cell) {
+        this.checkEquals(Optional.empty(), cell.formatted(), "formatted text absent");
+    }
+
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     default void checkFormattedText(final SpreadsheetCell cell, final String text) {
-        this.checkNotEquals(Optional.empty(), cell.formatted(), "formatted text absent");
+        this.checkNotEquals(Optional.empty(), cell.formatted(), "formatted text present");
         this.checkEquals(text, cell.formatted().get().text(), "formattedText");
     }
 


### PR DESCRIPTION
- Expression purity now checked when SpreadsheetExpressionEvaluation#COMPUTE_IF_NECESSARY
- Formatting & styling only happens if expression was re-evaluated.
- BasicSpreadsheetEngine internal method naming improvements.
- SpreadsheetEngineEvaluation constants javadoc improvements.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1935
- BasicSpreadsheetEngine should honour Expression.isPure