### PR TITLE
Really BasicSpreadsheetEngine honour Expression purity

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -167,6 +167,12 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
     private final SpreadsheetParserContext parserContext;
 
     @Override
+    public boolean isPure(final FunctionExpressionName function) {
+        return this.functions.apply(function)
+                .isPure(this);
+    }
+
+    @Override
     public Object evaluate(final Expression expression,
                            final Optional<SpreadsheetCell> cell) {
         Objects.requireNonNull(expression, "expression");

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -29,6 +29,7 @@ import walkingkooka.spreadsheet.store.repo.SpreadsheetStoreRepository;
 import walkingkooka.test.Fake;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.FunctionExpressionName;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -49,6 +50,11 @@ public class FakeSpreadsheetEngineContext extends FakeConverterContext implement
     @Override
     public SpreadsheetParserToken parseFormula(final TextCursor formula) {
         Objects.requireNonNull(formula, "formula");
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPure(final FunctionExpressionName function) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -28,13 +28,14 @@ import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.store.repo.SpreadsheetStoreRepository;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ExpressionPurityContext;
 
 import java.util.Optional;
 
 /**
  * Context that accompanies a value format, holding local sensitive attributes such as the decimal point character.
  */
-public interface SpreadsheetEngineContext extends Context {
+public interface SpreadsheetEngineContext extends Context, ExpressionPurityContext {
 
     /**
      * Returns the current {@link SpreadsheetMetadata}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -504,7 +504,10 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         final SpreadsheetCell second = this.loadCellOrFail(engine, cellReference, SpreadsheetEngineEvaluation.COMPUTE_IF_NECESSARY, context);
         assertSame(first, second, "different instances of SpreadsheetCell returned not cached");
 
-        this.checkFormattedText(second);
+        this.checkFormattedText(
+                second,
+                "End of text at (6,1) \"=1+2+\" expected BINARY_SUB_EXPRESSION"
+        );
     }
 
     @Test
@@ -9273,6 +9276,13 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                 this.converterContext()
                         )
                 );
+            }
+
+            @Override
+            public boolean isPure(final FunctionExpressionName function) {
+                return this.functions()
+                        .apply(function)
+                        .isPure(this);
             }
 
             private Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions() {


### PR DESCRIPTION
- Previous PR had changes but forgot to check SpreadsheetEngineEvaluation
- SpreadsheetEngineEvaluation really honoured when evaluating expression, previously ignored.
- SpreadsheetEngineContext now implements PurityContext
- SpreadsheetEngineValuation internal method renaming.
- BasicSpreadsheetEngine.saveCell now COMPUTES_IF_NECESSARY previously FORCE_RECOMPUTE