### PR TITLE
GeneralSpreadsheetConverterSpreadsheetValueVisitor refactoring

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueVisitor.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.convert;
 
 import walkingkooka.ToStringBuilder;
-import walkingkooka.convert.ConversionException;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.spreadsheet.SpreadsheetValueVisitor;
@@ -29,7 +28,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetColumnReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReferenceRange;
-import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumber;
 
 import java.math.BigDecimal;
@@ -176,13 +174,7 @@ final class GeneralSpreadsheetConverterSpreadsheetValueVisitor<C extends Convert
 
     @Override
     protected void visit(final Object value) {
-        final Class<?> targetType = this.targetType;
-
-        throw new ConversionException(
-                "Unable to convert " + CharSequences.quoteIfChars(value) + " to " + targetType.getName(),
-                value,
-                targetType
-        );
+        // fail!
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueVisitorTest.java
@@ -19,11 +19,8 @@ package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
-import walkingkooka.convert.ConversionException;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.spreadsheet.SpreadsheetValueVisitorTesting;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class GeneralSpreadsheetConverterSpreadsheetValueVisitorTest extends GeneralSpreadsheetConverterTestCase<GeneralSpreadsheetConverterSpreadsheetValueVisitor<ConverterContext>>
         implements SpreadsheetValueVisitorTesting<GeneralSpreadsheetConverterSpreadsheetValueVisitor<ConverterContext>> {
@@ -33,15 +30,14 @@ public final class GeneralSpreadsheetConverterSpreadsheetValueVisitorTest extend
     }
 
     @Test
-    public void testAcceptUnknownValue() {
-        final ConversionException thrown = assertThrows(
-                ConversionException.class,
-                () -> this.createVisitor().accept(this)
-        );
+    public void testConverterUnknownValue() {
         this.checkEquals(
-                "Unable to convert " + this + " to java.lang.String",
-                thrown.getMessage(),
-                "message"
+                null,
+                GeneralSpreadsheetConverterSpreadsheetValueVisitor.converter(
+                        this,
+                        Void.class,
+                        null
+                )
         );
     }
 


### PR DESCRIPTION
- visit(Object) no longer throws.