### PR TITLE
BasicSpreadsheetEngine.loadCell support SpreadsheetDeltaProperty COLU…

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -71,6 +71,9 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.text.Length;
+import walkingkooka.tree.text.TextStyle;
+import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
@@ -163,6 +166,11 @@ public class JunitTest {
                     .set(SpreadsheetMetadataPropertyName.PRECISION, 123)
                     .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.FLOOR)
                     .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, SpreadsheetId.with(123))
+                    .set(SpreadsheetMetadataPropertyName.STYLE,
+                            TextStyle.EMPTY.set(TextStylePropertyName.WIDTH, Length.pixel(50.0))
+                                    .set(TextStylePropertyName.HEIGHT, Length.pixel(50.0))
+                                    .set(TextStylePropertyName.HEIGHT, Length.pixel(50.0))
+                    )
                     .set(SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN, SpreadsheetPattern.parseTextFormatPattern("@@"))
                     .set(SpreadsheetMetadataPropertyName.TIME_FORMAT_PATTERN, SpreadsheetPattern.parseTimeFormatPattern("hh:mm"))
                     .set(SpreadsheetMetadataPropertyName.TIME_PARSE_PATTERNS, SpreadsheetPattern.parseTimeParsePatterns("hh:mmhh:mm:ss.000"))

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -601,8 +601,78 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         if (addDeletedRows) {
             delta = delta.setDeletedRows(changes.deletedRows());
         }
+        if (deltaProperties.contains(SpreadsheetDeltaProperties.COLUMN_WIDTHS)) {
+            final Map<SpreadsheetColumnReference, Double> columnsWidths = Maps.sorted(SpreadsheetRowReference.COLUMN_OR_ROW_REFERENCE_KIND_IGNORED_COMPARATOR);
+
+            for (final SpreadsheetCell cell : updatedCells) {
+                this.addColumnWidthIfNecessary(
+                        cell.reference()
+                                .column()
+                                .setReferenceKind(SpreadsheetReferenceKind.RELATIVE),
+                        columnsWidths,
+                        context
+                );
+            }
+
+            for (final SpreadsheetCellReference cell : deletedCells) {
+                this.addColumnWidthIfNecessary(
+                        cell.column()
+                                .setReferenceKind(SpreadsheetReferenceKind.RELATIVE),
+                        columnsWidths,
+                        context
+                );
+            }
+
+            delta = delta.setColumnWidths(columnsWidths);
+        }
+        if (deltaProperties.contains(SpreadsheetDeltaProperties.ROW_HEIGHTS)) {
+            final Map<SpreadsheetRowReference, Double> rowsHeights = Maps.sorted(SpreadsheetRowReference.COLUMN_OR_ROW_REFERENCE_KIND_IGNORED_COMPARATOR);
+
+            for (final SpreadsheetCell cell : updatedCells) {
+                this.addRowHeightIfNecessary(
+                        cell.reference()
+                                .row()
+                                .setReferenceKind(SpreadsheetReferenceKind.RELATIVE),
+                        rowsHeights,
+                        context
+                );
+            }
+
+            for (final SpreadsheetCellReference cell : deletedCells) {
+                this.addRowHeightIfNecessary(
+                        cell.row()
+                                .setReferenceKind(SpreadsheetReferenceKind.RELATIVE),
+                        rowsHeights,
+                        context
+                );
+            }
+
+            delta = delta.setRowHeights(rowsHeights);
+        }
 
         return delta;
+    }
+
+    private void addColumnWidthIfNecessary(final SpreadsheetColumnReference column,
+                                           final Map<SpreadsheetColumnReference, Double> columnsWidths,
+                                           final SpreadsheetEngineContext context) {
+        if (false == columnsWidths.containsKey(column)) {
+            final double width = this.columnWidth(column, context);
+            if (width > 0) {
+                columnsWidths.put(column, width);
+            }
+        }
+    }
+
+    private void addRowHeightIfNecessary(final SpreadsheetRowReference row,
+                                         final Map<SpreadsheetRowReference, Double> rowsHeights,
+                                         final SpreadsheetEngineContext context) {
+        if (false == rowsHeights.containsKey(row)) {
+            final double height = this.rowHeight(row, context);
+            if (height > 0) {
+                rowsHeights.put(row, height);
+            }
+        }
     }
 
     private <R extends SpreadsheetColumnOrRowReference & Comparable<R>, H extends HasSpreadsheetReference<R>> void addIfNecessary(final R reference,

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -749,26 +749,9 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
                                   final SpreadsheetEngineEvaluation evaluation,
                                   final Set<SpreadsheetDeltaProperties> deltaProperties,
                                   final SpreadsheetEngineContext context,
-                                  final SpreadsheetCell... cells) {
-        this.loadCellAndCheck(
-                engine,
-                reference,
-                evaluation,
-                deltaProperties,
-                context,
-                SpreadsheetDelta.EMPTY.setCells(
-                        Sets.of(cells)
-                )
-        );
-    }
-
-    default void loadCellAndCheck(final SpreadsheetEngine engine,
-                                  final SpreadsheetCellReference reference,
-                                  final SpreadsheetEngineEvaluation evaluation,
-                                  final Set<SpreadsheetDeltaProperties> deltaProperties,
-                                  final SpreadsheetEngineContext context,
                                   final SpreadsheetDelta loaded) {
-        this.checkEquals(loaded,
+        this.checkEquals(
+                loaded,
                 engine.loadCell(
                         reference,
                         evaluation,
@@ -804,35 +787,11 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
     default void saveCellAndCheck(final SpreadsheetEngine engine,
                                   final SpreadsheetCell save,
                                   final SpreadsheetEngineContext context,
-                                  final SpreadsheetCell... updated) {
-        this.saveCellAndCheck(engine,
-                save,
-                context,
-                SpreadsheetDelta.EMPTY.setCells(Sets.of(updated)));
-    }
-
-    default void saveCellAndCheck(final SpreadsheetEngine engine,
-                                  final SpreadsheetCell save,
-                                  final SpreadsheetEngineContext context,
                                   final SpreadsheetDelta delta) {
         checkEquals(
                 delta,
                 engine.saveCell(save, context),
                 () -> "saveCell " + save
-        );
-    }
-
-    default void deleteCellAndCheck(final SpreadsheetEngine engine,
-                                    final SpreadsheetCellReference delete,
-                                    final SpreadsheetEngineContext context,
-                                    final SpreadsheetCell... updated) {
-        this.deleteCellAndCheck(
-                engine,
-                delete,
-                context,
-                SpreadsheetDelta.EMPTY
-                        .setCells(Sets.of(updated))
-                        .setDeletedCells(Sets.of(delete))
         );
     }
 
@@ -998,20 +957,6 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
                 ),
                 () -> "loadCells " + range + " " + evaluation
         );
-    }
-
-    default void fillCellsAndCheck(final SpreadsheetEngine engine,
-                                   final Collection<SpreadsheetCell> cells,
-                                   final SpreadsheetCellRange from,
-                                   final SpreadsheetCellRange to,
-                                   final SpreadsheetEngineContext context,
-                                   final SpreadsheetCell... updated) {
-        this.fillCellsAndCheck(engine,
-                cells,
-                from,
-                to,
-                context,
-                SpreadsheetDelta.EMPTY.setCells(Sets.of(updated)));
     }
 
     default void fillCellsAndCheck(final SpreadsheetEngine engine,

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -68,6 +68,9 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.text.Length;
+import walkingkooka.tree.text.TextStyle;
+import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
@@ -155,6 +158,10 @@ public final class Sample {
                     .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.FLOOR)
                     .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, SpreadsheetId.with(123))
                     .set(SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN, SpreadsheetPattern.parseTextFormatPattern("@@"))
+                    .set(
+                            SpreadsheetMetadataPropertyName.STYLE,
+                            TextStyle.EMPTY.set(TextStylePropertyName.WIDTH, Length.pixel(50.0))
+                                    .set(TextStylePropertyName.HEIGHT, Length.pixel(50.0)))
                     .set(SpreadsheetMetadataPropertyName.TIME_FORMAT_PATTERN, SpreadsheetPattern.parseTimeFormatPattern("hh:mm"))
                     .set(SpreadsheetMetadataPropertyName.TIME_PARSE_PATTERNS, SpreadsheetPattern.parseTimeParsePatterns("hh:mmhh:mm:ss.000"))
                     .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 31)


### PR DESCRIPTION
…MN_WIDTHS & ROW_HEIGHTS

- SpreadsheetEngineTesting deleted overloads that take only expected cells, rework BasicSpreadsheetEngineTest tests to call expected SpreadsheetDelta overload.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2280
- BasicSpreadsheetEngine not populating columnWidths and rowHeights