### PR TITLE
BasicSpreadsheetEngine.saveCells better batch saveCells.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -169,14 +169,18 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
     private SpreadsheetDelta saveCellsNotEmpty(final Set<SpreadsheetCell> cells,
                                                final SpreadsheetEngineContext context) {
         // save all cells.
-        for (final SpreadsheetCell cell : cells) {
-            this.saveCell(cell, context);
-        }
-
         try (final BasicSpreadsheetEngineChanges changes = BasicSpreadsheetEngineChangesMode.BATCH.createChanges(this, context)) {
             for (final SpreadsheetCell cell : cells) {
-                this.loadCell0(cell.reference(), SpreadsheetEngineEvaluation.COMPUTE_IF_NECESSARY, changes, context);
+                final SpreadsheetCell saved = this.maybeParseAndEvaluateAndFormat(
+                        cell,
+                        SpreadsheetEngineEvaluation.FORCE_RECOMPUTE,
+                        context
+                );
+
+                changes.onCellSavedBatch(saved);
             }
+            changes.refreshUpdated();
+
             return this.prepareDelta(
                     changes,
                     context

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
@@ -271,7 +271,12 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
     // BATCH MODE....................................................................................................
 
     void onCellSavedBatch(final SpreadsheetCell cell) {
-        this.batchCell(cell.reference());
+        final SpreadsheetCellReference reference = cell.reference();
+        this.unsavedCells.add(reference);
+
+        this.removePreviousExpressionReferences(reference);
+        this.addNewExpressionReferences(reference, cell.formula());
+        this.batchReferrers(reference);
     }
 
     void onCellDeletedBatch(final SpreadsheetCellReference cell) {


### PR DESCRIPTION
- Previous saveCells basically saved cell and then loaded them all back.
- BasicSpreadsheetEngineChanges.onCellSavedBatch() has been fixed to also save references etc.