### PR TITLE
SpreadsheetDelta labels with range removed fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
@@ -686,9 +686,9 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
                 labels,
                 m -> {
                     final SpreadsheetExpressionReference r = m.reference();
-                    return r.isCellReference() &&
-                            window.stream()
-                                    .anyMatch(w -> w.test((SpreadsheetCellReference) m.reference()));
+
+                    return window.stream()
+                            .anyMatch(r::testCellRange);
                 }
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaNonWindowedTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaNonWindowedTest.java
@@ -163,7 +163,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n"
+                        "    LabelC3: C3:D4\n"
         );
     }
 
@@ -223,7 +223,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n"
+                        "    LabelC3: C3:D4\n"
         );
     }
 
@@ -257,7 +257,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  deletedCells:\n" +
                         "    C1,C2\n"
         );
@@ -399,7 +399,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  deletedCells:\n" +
                         "    C1,C2\n" +
                         "  deletedColumns:\n" +
@@ -782,7 +782,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         SpreadsheetDelta.NO_COLUMN_WIDTHS,
                         SpreadsheetDelta.NO_ROW_HEIGHTS
                 ),
-                "selection: A1:B2 BOTTOM_RIGHT cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3");
+                "selection: A1:B2 BOTTOM_RIGHT cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3:D4");
     }
 
     @Test
@@ -800,7 +800,7 @@ public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestC
                         SpreadsheetDelta.NO_COLUMN_WIDTHS,
                         SpreadsheetDelta.NO_ROW_HEIGHTS
                 ),
-                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3 deletedCells: C1, C2");
+                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3:D4 deletedCells: C1, C2");
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
@@ -29,6 +29,7 @@ import walkingkooka.spreadsheet.SpreadsheetRow;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -70,6 +71,60 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
         this.checkEquals(
                 Sets.empty(),
                 SpreadsheetDelta.NO_WINDOW
+        );
+    }
+
+    // setLabel.........................................................................................................
+
+    @Test
+    public void testSetLabelsWithLabelRangeInsideWindow() {
+        final Set<SpreadsheetLabelMapping> mappings = this.labelMappingsLabel123ToC3E5();
+
+        final SpreadsheetDelta delta = SpreadsheetDelta.EMPTY
+                .setWindow(SpreadsheetSelection.parseWindow("B2:F6"))
+                .setLabels(mappings);
+
+        this.checkEquals(
+                mappings,
+                delta.labels(),
+                "labels"
+        );
+    }
+
+    @Test
+    public void testSetLabelsWithLabelRangePartiallyOutsideWindow() {
+        final Set<SpreadsheetLabelMapping> mappings = this.labelMappingsLabel123ToC3E5();
+
+        final SpreadsheetDelta delta = SpreadsheetDelta.EMPTY
+                .setWindow(SpreadsheetSelection.parseWindow("B2:D4"))
+                .setLabels(mappings);
+
+        this.checkEquals(
+                mappings,
+                delta.labels(),
+                "labels"
+        );
+    }
+
+    @Test
+    public void testSetLabelsWithLabelRangeWholeyOutsideWindow() {
+        final Set<SpreadsheetLabelMapping> mappings = this.labelMappingsLabel123ToC3E5();
+
+        final SpreadsheetDelta delta = SpreadsheetDelta.EMPTY
+                .setWindow(SpreadsheetSelection.parseWindow("A1:B2"))
+                .setLabels(mappings);
+
+        this.checkEquals(
+                SpreadsheetDelta.NO_LABELS,
+                delta.labels(),
+                "labels"
+        );
+    }
+
+    private Set<SpreadsheetLabelMapping> labelMappingsLabel123ToC3E5() {
+        return Sets.of(
+                SpreadsheetSelection.labelName("Label123")
+                        .mapping(SpreadsheetSelection.parseCellRange("C3:E5"))
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
@@ -733,7 +733,26 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         this.checkColumns(before);
         this.checkRows(before);
     }
-    
+
+    @Test
+    public final void testSetDifferentWindowWithLabels() {
+        final D before = this.createSpreadsheetDelta();
+
+        final Set<SpreadsheetCellRange> window = SpreadsheetSelection.parseWindow("A1:Z9999");
+        this.checkNotEquals(window, this.window());
+
+        final SpreadsheetDelta after = before.setWindow(window);
+
+        this.checkCells(after);
+        this.checkColumns(after);
+        this.checkRows(after);
+        this.checkWindow(after, window);
+
+        this.checkCells(before);
+        this.checkColumns(before);
+        this.checkRows(before);
+    }
+
     // unmarshall.......................................................................................................
 
     @Test
@@ -1041,7 +1060,7 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
                 this.label1a().mapping(this.a1().reference()),
                 this.label1b().mapping(this.a1().reference()),
                 this.label2().mapping(this.b2().reference()),
-                this.label3().mapping(this.c3().reference())
+                this.label3().mapping(SpreadsheetSelection.parseCellRange("C3:D4"))
         );
     }
 
@@ -1394,12 +1413,7 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
     final JsonNode labelsJson() {
         return this.marshallContext()
                 .marshallCollection(
-                        Sets.of(
-                                this.label1a().mapping(this.a1().reference()),
-                                this.label1b().mapping(this.a1().reference()),
-                                this.label2().mapping(this.b2().reference()),
-                                this.label3().mapping(this.c3().reference())
-                        )
+                        this.labels()
                 );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaWindowedTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaWindowedTest.java
@@ -408,7 +408,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  window:\n" +
                         "    A1:E5\n"
         );
@@ -474,7 +474,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  window:\n" +
                         "    A1:E5\n"
         );
@@ -511,7 +511,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  deletedCells:\n" +
                         "    C1,C2\n" +
                         "  window:\n" +
@@ -668,7 +668,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         "    LabelA1A: A1\n" +
                         "    LabelA1B: A1\n" +
                         "    LabelB2: B2\n" +
-                        "    LabelC3: C3\n" +
+                        "    LabelC3: C3:D4\n" +
                         "  deletedCells:\n" +
                         "    C1,C2\n" +
                         "  deletedColumns:\n" +
@@ -957,7 +957,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         SpreadsheetDelta.NO_ROW_HEIGHTS,
                         this.window()
                 ),
-                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3 window: A1:E5");
+                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3:D4 window: A1:E5");
     }
 
     @Test
@@ -976,7 +976,7 @@ public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase
                         SpreadsheetDelta.NO_ROW_HEIGHTS,
                         this.window()
                 ),
-                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3 deletedCells: C1, C2 window: A1:E5");
+                "cells: A1=1, B2=2, C3=3 labels: LabelA1A=A1, LabelA1B=A1, LabelB2=B2, LabelC3=C3:D4 deletedCells: C1, C2 window: A1:E5");
     }
 
     @Test


### PR DESCRIPTION
- Not sure why filtering of labels with window would *only* keep labels to references. (check removed)

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2316
- SpreadsheetDelta.setWindow incorrectly removes label mapped to range, when range is within window