### PR TITLE
BasicSpreadsheetEngine navigate label selection support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1601,14 +1601,19 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
      * Assumes a selection without navigation, returning an {@link SpreadsheetEngine#NO_VIEWPORT_SELECTION} if
      * the selection is hidden.
      */
-    private Optional<SpreadsheetViewportSelection> navigateWithoutNavigation(final SpreadsheetViewportSelection selection,
+    private Optional<SpreadsheetViewportSelection> navigateWithoutNavigation(final SpreadsheetViewportSelection viewportSelection,
                                                                              final SpreadsheetEngineContext context) {
         final SpreadsheetStoreRepository repository = context.storeRepository();
 
-        return selection.selection()
+        SpreadsheetSelection selection = viewportSelection.selection();
+        if (selection.isLabelName()) {
+            selection = context.resolveCellReference((SpreadsheetLabelName) selection);
+        }
+
+        return selection
                 .isHidden(repository.columns()::isHidden, repository.rows()::isHidden) ?
                 SpreadsheetEngine.NO_VIEWPORT_SELECTION :
-                Optional.of(selection);
+                Optional.of(viewportSelection);
     }
 
     // checkers.........................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -10450,6 +10450,71 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
+    public void testNavigateSelectionLabelMissingNavigation() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        context.storeRepository()
+                .labels()
+                .save(LABEL.mapping(SpreadsheetSelection.parseCell("B2")));
+
+        final SpreadsheetViewportSelection viewportSelection = LABEL
+                .setAnchor(SpreadsheetViewportSelectionAnchor.NONE);
+
+        this.navigateAndCheck(
+                engine,
+                viewportSelection,
+                context,
+                Optional.of(viewportSelection)
+        );
+    }
+
+    @Test
+    public void testNavigate() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        this.navigateAndCheck(
+                engine,
+                SpreadsheetSelection.parseCell("B2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+                        .setNavigation(
+                                Optional.of(
+                                        SpreadsheetViewportSelectionNavigation.RIGHT
+                                )
+                        ),
+                context,
+                SpreadsheetSelection.parseCell("C2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    @Test
+    public void testNavigateLabel() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        final SpreadsheetCellReference selection = SpreadsheetSelection.parseCell("B2");
+
+        context.storeRepository()
+                .labels()
+                .save(LABEL.mapping(selection));
+
+        this.navigateAndCheck(
+                engine,
+                selection.setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+                        .setNavigation(
+                                Optional.of(
+                                        SpreadsheetViewportSelectionNavigation.RIGHT
+                                )
+                        ),
+                context,
+                SpreadsheetSelection.parseCell("C2")
+                        .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+        );
+    }
+
+    @Test
     public void testNavigateHidden() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext();


### PR DESCRIPTION
- Previously loading a cell with a label would fail because BSE.navigate(Label) would with

> java.lang.UnsupportedOperationException
  	at walkingkooka.spreadsheet.reference.SpreadsheetLabelName.isHidden(SpreadsheetLabelName.java:193)
  	at walkingkooka.spreadsheet.engine.BasicSpreadsheetEngine.navigateWithoutNavigation(BasicSpreadsheetEngine.java:1609)