### PR TITLE
BasicSpreadsheetEngine.loadCell missing always loads labels

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -46,6 +46,7 @@ public interface SpreadsheetEngine {
      * <li>If the cell is not found it will not be present in the resulting {@link SpreadsheetDelta}.</li>
      * <li>If parsing or evaluating the cell fails it will be present with an error.</li>
      * <li>Any additional cells that require recomputing because of the requested cell will also be returned.</li>
+     * <li>If the cell was not found and labels are requested {@link SpreadsheetDeltaProperties#LABELS} any labels will be returned.</li>
      * </ul>
      */
     SpreadsheetDelta loadCell(final SpreadsheetCellReference cell,

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -281,13 +281,16 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
         this.checkEquals(Optional.empty(), context.storeRepository().cells().load(LABEL_CELL));
 
-        context.storeRepository()
+        final SpreadsheetLabelMapping labelMapping = context.storeRepository()
                 .labels()
                 .save(LABEL.mapping(LABEL_CELL));
 
         this.checkEquals(
                 SpreadsheetDelta.EMPTY
-                        .setCells(SpreadsheetDelta.NO_CELLS),
+                        .setCells(SpreadsheetDelta.NO_CELLS)
+                        .setLabels(
+                                Sets.of(labelMapping)
+                        ),
                 engine.loadCell(
                         LABEL_CELL,
                         SpreadsheetEngineEvaluation.COMPUTE_IF_NECESSARY,


### PR DESCRIPTION
- Updated SpreadsheetEngine.loadCell to mention this new requirement.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2332
- BasicSpreadsheetEngine.loadCell should always return labels even when selected cell is not found