### PR TITLE
SpreadsheetExpressionEvaluationContext.resolveIfLabel

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -188,6 +188,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                             metadata,
                             this.functions,
                             this.function,
+                            this::resolveIfLabel,
                             this.now
                     )
             );

--- a/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
@@ -31,6 +31,7 @@ import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
@@ -61,6 +62,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                                                             final SpreadsheetMetadata spreadsheetMetadata,
                                                             final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                                             final Function<ExpressionReference, Optional<Object>> references,
+                                                            final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel,
                                                             final Supplier<LocalDateTime> now) {
         Objects.requireNonNull(cell, "cell");
         Objects.requireNonNull(cellStore, "cellStore");
@@ -68,6 +70,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
         Objects.requireNonNull(spreadsheetMetadata, "spreadsheetMetadata");
         Objects.requireNonNull(functions, "functions");
         Objects.requireNonNull(references, "references");
+        Objects.requireNonNull(resolveIfLabel, "resolveIfLabel");
         Objects.requireNonNull(now, "now");
 
         return new BasicSpreadsheetExpressionEvaluationContext(
@@ -77,6 +80,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                 spreadsheetMetadata,
                 functions,
                 references,
+                resolveIfLabel,
                 now
         );
     }
@@ -87,6 +91,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                                                         final SpreadsheetMetadata spreadsheetMetadata,
                                                         final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                                         final Function<ExpressionReference, Optional<Object>> references,
+                                                        final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel,
                                                         final Supplier<LocalDateTime> now) {
         super();
         this.cell = cell;
@@ -95,6 +100,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
         this.spreadsheetMetadata = spreadsheetMetadata;
         this.functions = functions;
         this.references = references;
+        this.resolveIfLabel = resolveIfLabel;
         this.now = now;
     }
 
@@ -153,6 +159,13 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                 .get()
                 .cast(SpreadsheetParserToken.class);
     }
+
+    @Override
+    public SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection) {
+        return this.resolveIfLabel.apply(selection);
+    }
+
+    private final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel;
 
     @Override
     public SpreadsheetMetadata spreadsheetMetadata() {

--- a/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
@@ -173,6 +174,11 @@ final class ConverterSpreadsheetExpressionEvaluationContext implements Spreadshe
     @Override
     public SpreadsheetParserToken parseExpression(final TextCursor expression) {
         return this.context.parseExpression(expression);
+    }
+
+    @Override
+    public SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection) {
+        return this.context.resolveIfLabel(selection);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
@@ -23,6 +23,7 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
 
@@ -46,6 +47,11 @@ public class FakeSpreadsheetExpressionEvaluationContext extends FakeExpressionEv
 
     @Override
     public SpreadsheetParserToken parseExpression(final TextCursor expression) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.SpreadsheetErrorKind;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
@@ -77,6 +78,12 @@ public interface SpreadsheetExpressionEvaluationContext extends ExpressionEvalua
      * Loads the cell for the given {@link SpreadsheetCellReference}, note that the formula is not evaluated.
      */
     Optional<SpreadsheetCell> loadCell(final SpreadsheetCellReference cell);
+
+    /**
+     * If the {@link SpreadsheetSelection} is a {@link walkingkooka.spreadsheet.reference.SpreadsheetLabelName}
+     * resolve to a {@link SpreadsheetCellReference} or {@link walkingkooka.spreadsheet.reference.SpreadsheetCellRange}.
+     */
+    SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection);
 
     /**
      * Returns the {@link SpreadsheetMetadata} for the enclosing spreadsheet.

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.tree.expression.ExpressionEvaluationContextTesting;
 
@@ -66,6 +67,26 @@ public interface SpreadsheetExpressionEvaluationContextTesting<C extends Spreads
                 expected,
                 context.loadCell(cellReference),
                 () -> "loadCell " + cellReference
+        );
+    }
+
+    // resolveIfLabel...................................................................................................
+
+    @Test
+    default void testResolveIfLabelNullSelectionFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext().resolveIfLabel(null)
+        );
+    }
+
+    default void resolveIfLabel(final C context,
+                                final SpreadsheetSelection selection,
+                                final SpreadsheetSelection expected) {
+        this.checkEquals(
+                expected,
+                context.resolveIfLabel(selection),
+                () -> "resolveIfLabel " + selection
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContexts.java
@@ -48,6 +48,7 @@ public final class SpreadsheetExpressionEvaluationContexts implements PublicStat
                                                                final SpreadsheetMetadata spreadsheetMetadata,
                                                                final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                                                                final Function<ExpressionReference, Optional<Object>> references,
+                                                               final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel,
                                                                final Supplier<LocalDateTime> now) {
         return BasicSpreadsheetExpressionEvaluationContext.with(
                 cell,
@@ -56,6 +57,7 @@ public final class SpreadsheetExpressionEvaluationContexts implements PublicStat
                 spreadsheetMetadata,
                 functions,
                 references,
+                resolveIfLabel,
                 now
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
@@ -70,6 +70,11 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
         throw new UnknownExpressionFunctionException(n);
     };
 
+    private final static Function<SpreadsheetSelection, SpreadsheetSelection> RESOLVE_IF_LABEL = (s) -> {
+        Objects.requireNonNull(s, "selection");
+        throw new UnsupportedOperationException();
+    };
+
     private final static Function<ExpressionReference, Optional<Object>> REFERENCES = (r) -> {
         throw new UnsupportedOperationException();
     };
@@ -87,6 +92,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 METADATA,
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }
@@ -100,6 +106,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 METADATA,
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }
@@ -113,6 +120,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 METADATA,
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }
@@ -126,6 +134,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 null,
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }
@@ -139,6 +148,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 METADATA,
                 null,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }
@@ -151,6 +161,21 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SERVER_URL,
                 METADATA,
                 FUNCTIONS,
+                null,
+                RESOLVE_IF_LABEL,
+                NOW
+        );
+    }
+
+    @Test
+    public void testWithNullResolveIfLabelFails() {
+        this.withFails(
+                CELL,
+                CELL_STORE,
+                SERVER_URL,
+                METADATA,
+                FUNCTIONS,
+                REFERENCES,
                 null,
                 NOW
         );
@@ -165,6 +190,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 METADATA,
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 null
         );
     }
@@ -175,6 +201,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                            final SpreadsheetMetadata spreadsheetMetadata,
                            final Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> functions,
                            final Function<ExpressionReference, Optional<Object>> references,
+                           final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel,
                            final Supplier<LocalDateTime> now) {
         assertThrows(
                 NullPointerException.class,
@@ -185,6 +212,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                         spreadsheetMetadata,
                         functions,
                         references,
+                        resolveIfLabel,
                         now
                 )
         );
@@ -424,6 +452,7 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                         .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20),
                 FUNCTIONS,
                 REFERENCES,
+                RESOLVE_IF_LABEL,
                 NOW
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
@@ -172,6 +172,11 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
         throw new UnsupportedOperationException();
     };
 
+    private final static Function<SpreadsheetSelection, SpreadsheetSelection> RESOLVE_IF_LABEL = (s) -> {
+        Objects.requireNonNull(s, "selection");
+        throw new UnsupportedOperationException();
+    };
+
     // tests............................................................................................................
 
     @Test
@@ -442,6 +447,7 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
                         METADATA,
                         FUNCTIONS,
                         REFERENCES,
+                        RESOLVE_IF_LABEL,
                         LocalDateTime::now
                 )
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2347
- SpreadsheetExpressionEvaluationContext.resolveIfLabel(final SpreadsheetSelection selection);

- This will make it easier to resolve labels to cells/cell-ranges which is needed by spreadsheet functions.