### PR TITLE
SpreadsheetCellReferenceOrRange

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
  * of other {@link SpreadsheetSelection}.
  */
 @SuppressWarnings("lgtm[java/inconsistent-equals-and-hashcode]")
-public final class SpreadsheetCellRange extends SpreadsheetExpressionReference
+public final class SpreadsheetCellRange extends SpreadsheetCellReferenceOrRange
         implements Comparable<SpreadsheetCellRange>,
         HasRange<SpreadsheetCellReference>,
         HasRangeBounds<SpreadsheetCellReference>,

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -44,7 +44,7 @@ import java.util.function.Predicate;
  * {@link #compareTo(SpreadsheetCellReference)} ignores the {@link SpreadsheetReferenceKind} of the column and row.
  */
 @SuppressWarnings("lgtm[java/inconsistent-equals-and-hashcode]")
-public final class SpreadsheetCellReference extends SpreadsheetExpressionReference
+public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRange
         implements Comparable<SpreadsheetCellReference>,
         HateosResource<String> {
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRange.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+/**
+ * Common base class for both {@link SpreadsheetCellRange} or {@link SpreadsheetCellReference}.
+ */
+public abstract class SpreadsheetCellReferenceOrRange extends SpreadsheetExpressionReference {
+
+    SpreadsheetCellReferenceOrRange() {
+        super();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class SpreadsheetCellRangeTest extends SpreadsheetExpressionReferenceTestCase<SpreadsheetCellRange>
+public final class SpreadsheetCellRangeTest extends SpreadsheetCellReferenceOrRangeTestCase<SpreadsheetCellRange>
         implements
         ComparableTesting2<SpreadsheetCellRange>,
         IterableTesting<SpreadsheetCellRange, SpreadsheetCellReference>,

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRangeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import walkingkooka.reflect.ClassTesting2;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class SpreadsheetCellReferenceOrRangeTest implements ClassTesting2<SpreadsheetCellReferenceOrRange> {
+
+    @Override
+    public Class<SpreadsheetCellReferenceOrRange> type() {
+        return SpreadsheetCellReferenceOrRange.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRangeTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceOrRangeTestCase.java
@@ -1,0 +1,26 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+public abstract class SpreadsheetCellReferenceOrRangeTestCase<R extends SpreadsheetCellReferenceOrRange> extends SpreadsheetExpressionReferenceTestCase<R> {
+
+    SpreadsheetCellReferenceOrRangeTestCase() {
+        super();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -35,7 +35,7 @@ import walkingkooka.visit.Visiting;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class SpreadsheetCellReferenceTest extends SpreadsheetExpressionReferenceTestCase<SpreadsheetCellReference>
+public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReferenceOrRangeTestCase<SpreadsheetCellReference>
         implements ComparableTesting2<SpreadsheetCellReference>,
         HateosResourceTesting<SpreadsheetCellReference> {
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2348
- Need a shared base class/interface for only cell and cell range.