### PR TITLE
SpreadsheetValueTypeVisitor supports visiting SpreadsheetCellReferenc…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetValueTypeVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetValueTypeVisitor.java
@@ -57,6 +57,9 @@ public abstract class SpreadsheetValueTypeVisitor extends Visitor<Class<?>> {
                 case "walkingkooka.spreadsheet.reference.SpreadsheetCellReference":
                     this.visitCellReference();
                     break;
+                case "walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange":
+                    this.visitCellReferenceOrRange();
+                    break;
                 case "java.lang.Character":
                     this.visitCharacter();
                     break;
@@ -153,6 +156,10 @@ public abstract class SpreadsheetValueTypeVisitor extends Visitor<Class<?>> {
     }
 
     protected void visitCellReference() {
+
+    }
+
+    protected void visitCellReferenceOrRange() {
 
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetValueTypeVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetValueTypeVisitorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -266,6 +267,40 @@ public class SpreadsheetValueTypeVisitorTest implements SpreadsheetValueTypeVisi
     public void testAcceptCellReference2() {
         new SpreadsheetValueTypeVisitor() {
         }.accept(SpreadsheetCellReference.class);
+    }
+
+    @Test
+    public void testAcceptCellReferenceOrRange() {
+        final StringBuilder b = new StringBuilder();
+        final Class<SpreadsheetCellReferenceOrRange> type = SpreadsheetCellReferenceOrRange.class;
+
+        new FakeSpreadsheetValueTypeVisitor() {
+            @Override
+            protected Visiting startVisit(final Class<?> t) {
+                assertSame(type, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final Class<?> t) {
+                assertSame(type, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visitCellReferenceOrRange() {
+                b.append("3");
+            }
+        }.accept(type);
+
+        this.checkEquals("132", b.toString());
+    }
+
+    @Test
+    public void testAcceptCellReferenceOrRange2() {
+        new SpreadsheetValueTypeVisitor() {
+        }.accept(SpreadsheetCellReferenceOrRange.class);
     }
 
     @Test


### PR DESCRIPTION
…eOrRange

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2366
- SpreadsheetValueTypeVisitor should support SpreadsheetCellReferenceOrRange