### PR TITLE
SpreadsheetFormatterContext extends SpreadsheetConverterContext

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/FormatPatternConverterSpreadsheetValueVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/FormatPatternConverterSpreadsheetValueVisitor.java
@@ -34,7 +34,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReferenceRange;
 import walkingkooka.tree.expression.ExpressionNumber;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -54,7 +53,7 @@ final class FormatPatternConverterSpreadsheetValueVisitor extends SpreadsheetVal
 
     static String format(final Object value,
                          final String pattern,
-                         final ExpressionNumberConverterContext context) {
+                         final SpreadsheetConverterContext context) {
         final FormatPatternConverterSpreadsheetValueVisitor visitor = new FormatPatternConverterSpreadsheetValueVisitor(
                 pattern,
                 context
@@ -65,7 +64,7 @@ final class FormatPatternConverterSpreadsheetValueVisitor extends SpreadsheetVal
 
     // VisibleForTesting
     FormatPatternConverterSpreadsheetValueVisitor(final String pattern,
-                                                  final ExpressionNumberConverterContext context) {
+                                                  final SpreadsheetConverterContext context) {
         super();
         this.pattern = pattern;
         this.context = context;
@@ -250,7 +249,7 @@ final class FormatPatternConverterSpreadsheetValueVisitor extends SpreadsheetVal
      */
     private final String pattern;
 
-    private final ExpressionNumberConverterContext context;
+    private final SpreadsheetConverterContext context;
 
     private String formatted;
 

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -17,7 +17,9 @@
 
 package walkingkooka.spreadsheet.convert;
 
+import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.Converter;
+import walkingkooka.convert.Converters;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePatterns;
@@ -26,6 +28,22 @@ import walkingkooka.spreadsheet.format.pattern.SpreadsheetNumberParsePatterns;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeParsePatterns;
 
 public final class SpreadsheetConverters implements PublicStaticHelper {
+
+    /**
+     * A basic {@link Converter} that supports number -> number, date -> datetime, time -> datetime.
+     */
+    public static Converter<SpreadsheetConverterContext> basic() {
+        return CONVERTER;
+    }
+
+    private final static Converter<SpreadsheetConverterContext> CONVERTER = Converters.collection(
+            Lists.of(
+                    Converters.simple(),
+                    Converters.numberNumber(),
+                    Converters.localDateLocalDateTime(),
+                    Converters.localTimeLocalDateTime()
+            )
+    );
 
     /**
      * {@see FormatPatternConverter}

--- a/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
@@ -20,7 +20,9 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.Either;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.color.Color;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.convert.Converter;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.math.MathContext;
@@ -40,34 +42,34 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
                                                  final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
                                                  final int cellCharacterWidth,
                                                  final SpreadsheetFormatter defaultSpreadsheetFormatter,
-                                                 final ExpressionNumberConverterContext converterContext) {
+                                                 final SpreadsheetConverterContext context) {
         Objects.requireNonNull(numberToColor, "numberToColor");
         Objects.requireNonNull(nameToColor, "nameToColor");
         if (cellCharacterWidth <= 0) {
             throw new IllegalArgumentException("Invalid cellCharacterWidth " + cellCharacterWidth + " <= 0");
         }
-        Objects.requireNonNull(converterContext, "converterContext");
+        Objects.requireNonNull(context, "context");
         Objects.requireNonNull(defaultSpreadsheetFormatter, "defaultSpreadsheetFormatter");
 
         return new BasicSpreadsheetFormatterContext(numberToColor,
                 nameToColor,
                 cellCharacterWidth,
                 defaultSpreadsheetFormatter,
-                converterContext);
+                context);
     }
 
     private BasicSpreadsheetFormatterContext(final Function<Integer, Optional<Color>> numberToColor,
                                              final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
                                              final int cellCharacterWidth,
                                              final SpreadsheetFormatter defaultSpreadsheetFormatter,
-                                             final ExpressionNumberConverterContext converterContext) {
+                                             final SpreadsheetConverterContext context) {
         super();
 
         this.numberToColor = numberToColor;
         this.nameToColor = nameToColor;
         this.cellCharacterWidth = cellCharacterWidth;
 
-        this.converterContext = converterContext;
+        this.context = context;
 
         this.defaultSpreadsheetFormatter = defaultSpreadsheetFormatter;
     }
@@ -98,14 +100,20 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
     // Converter........................................................................................................
 
     @Override
-    public boolean canConvert(final Object value, final Class<?> target) {
-        return this.converterContext.canConvert(value, target);
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        return this.context.canConvert(value, type);
     }
 
     @Override
     public <T> Either<T, String> convert(final Object value,
-                                         final Class<T> target) {
-        return this.converterContext.convert(value, target);
+                                         final Class<T> type) {
+        return this.context.convert(value, type);
+    }
+
+    @Override
+    public Converter<SpreadsheetConverterContext> converter() {
+        return this.context.converter();
     }
 
     // defaultFormatText.................................................................................................
@@ -121,97 +129,102 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
 
     @Override
     public List<String> ampms() {
-        return this.converterContext.ampms();
+        return this.context.ampms();
     }
 
     @Override
     public int defaultYear() {
-        return this.converterContext.defaultYear();
+        return this.context.defaultYear();
     }
 
     @Override
     public List<String> monthNames() {
-        return this.converterContext.monthNames();
+        return this.context.monthNames();
     }
 
     @Override
     public List<String> monthNameAbbreviations() {
-        return this.converterContext.monthNameAbbreviations();
+        return this.context.monthNameAbbreviations();
     }
 
     @Override
     public LocalDateTime now() {
-        return this.converterContext.now();
+        return this.context.now();
     }
 
     @Override
     public int twoDigitYear() {
-        return this.converterContext.twoDigitYear();
+        return this.context.twoDigitYear();
     }
 
     @Override
     public List<String> weekDayNames() {
-        return this.converterContext.weekDayNames();
+        return this.context.weekDayNames();
     }
 
     @Override
     public List<String> weekDayNameAbbreviations() {
-        return this.converterContext.weekDayNameAbbreviations();
+        return this.context.weekDayNameAbbreviations();
     }
 
     // DecimalNumberContext.............................................................................................
 
     @Override
     public String currencySymbol() {
-        return this.converterContext.currencySymbol();
+        return this.context.currencySymbol();
     }
 
     @Override
     public char decimalSeparator() {
-        return this.converterContext.decimalSeparator();
+        return this.context.decimalSeparator();
     }
 
     @Override
     public String exponentSymbol() {
-        return this.converterContext.exponentSymbol();
+        return this.context.exponentSymbol();
     }
 
     @Override
     public char groupingSeparator() {
-        return this.converterContext.groupingSeparator();
+        return this.context.groupingSeparator();
     }
 
     @Override
     public char percentageSymbol() {
-        return this.converterContext.percentageSymbol();
+        return this.context.percentageSymbol();
     }
 
     @Override
     public MathContext mathContext() {
-        return this.converterContext.mathContext();
+        return this.context.mathContext();
     }
 
     @Override
     public char negativeSign() {
-        return this.converterContext.negativeSign();
+        return this.context.negativeSign();
     }
 
     @Override
     public char positiveSign() {
-        return this.converterContext.positiveSign();
+        return this.context.positiveSign();
     }
 
     @Override
     public Locale locale() {
-        return this.converterContext.locale();
+        return this.context.locale();
     }
 
     @Override
     public ExpressionNumberKind expressionNumberKind() {
-        return this.converterContext.expressionNumberKind();
+        return this.context.expressionNumberKind();
     }
 
-    private final ExpressionNumberConverterContext converterContext;
+    @Override
+    public SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection) {
+        return this.context.resolveIfLabel(selection);
+    }
+
+    private final SpreadsheetConverterContext context;
 
     // Object...........................................................................................................
 
@@ -221,7 +234,7 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
                 .label("cellCharacterWidth").value(this.cellCharacterWidth)
                 .label("numberToColor").value(this.numberToColor)
                 .label("nameToColor").value(this.nameToColor)
-                .label("converterContext").value(this.converterContext)
+                .label("context").value(this.context)
                 .build();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
@@ -18,11 +18,11 @@
 package walkingkooka.spreadsheet.format;
 
 import walkingkooka.color.Color;
-import walkingkooka.tree.expression.FakeExpressionEvaluationContext;
+import walkingkooka.spreadsheet.convert.FakeSpreadsheetConverterContext;
 
 import java.util.Optional;
 
-public class FakeSpreadsheetFormatterContext extends FakeExpressionEvaluationContext implements SpreadsheetFormatterContext {
+public class FakeSpreadsheetFormatterContext extends FakeSpreadsheetConverterContext implements SpreadsheetFormatterContext {
 
     @Override
     public int cellCharacterWidth() {

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
@@ -20,7 +20,7 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.HasConverter;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -28,7 +28,7 @@ import java.util.Optional;
 /**
  * Formats a value
  */
-public interface SpreadsheetFormatter extends HasConverter<ExpressionNumberConverterContext> {
+public interface SpreadsheetFormatter extends HasConverter<SpreadsheetConverterContext> {
 
     /**
      * Constant holding a failed format.
@@ -54,7 +54,7 @@ public interface SpreadsheetFormatter extends HasConverter<ExpressionNumberConve
     /**
      * {@see SpreadsheetFormatterConverter}
      */
-    default Converter<ExpressionNumberConverterContext> converter() {
+    default Converter<SpreadsheetConverterContext> converter() {
         return SpreadsheetFormatterConverter.with(this);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
@@ -18,16 +18,14 @@
 package walkingkooka.spreadsheet.format;
 
 import walkingkooka.color.Color;
-import walkingkooka.convert.CanConvert;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 
 import java.util.Optional;
 
 /**
  * A {@link }Context} that accompanies a value format, holding local sensitive attributes such as the decimal point character.
  */
-public interface SpreadsheetFormatterContext extends CanConvert,
-        ExpressionNumberConverterContext {
+public interface SpreadsheetFormatterContext extends SpreadsheetConverterContext {
 
     /**
      * The width of the "cell" in characters.

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContexts.java
@@ -19,7 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.color.Color;
 import walkingkooka.reflect.PublicStaticHelper;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -33,12 +33,14 @@ public final class SpreadsheetFormatterContexts implements PublicStaticHelper {
                                                     final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
                                                     final int cellCharacterWidth,
                                                     final SpreadsheetFormatter defaultSpreadsheetFormatter,
-                                                    final ExpressionNumberConverterContext converterContext) {
-        return BasicSpreadsheetFormatterContext.with(numberToColor,
+                                                    final SpreadsheetConverterContext context) {
+        return BasicSpreadsheetFormatterContext.with(
+                numberToColor,
                 nameToColor,
                 cellCharacterWidth,
                 defaultSpreadsheetFormatter,
-                converterContext);
+                context
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverter.java
@@ -19,13 +19,13 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.text.CharSequences;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 
 /**
  * A {@link Converter} which formats a value to {@link String text} using the given {@link SpreadsheetFormatter}.
  */
-final class SpreadsheetFormatterConverter implements Converter<ExpressionNumberConverterContext> {
+final class SpreadsheetFormatterConverter implements Converter<SpreadsheetConverterContext> {
 
     static SpreadsheetFormatterConverter with(final SpreadsheetFormatter formatter) {
         return new SpreadsheetFormatterConverter(formatter);
@@ -39,23 +39,29 @@ final class SpreadsheetFormatterConverter implements Converter<ExpressionNumberC
 
     @Override
     public boolean canConvert(final Object value,
-                              final Class<?> targetType,
-                              final ExpressionNumberConverterContext context) {
-        return String.class == targetType && this.formatter.canFormat(value, SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(context));
+                              final Class<?> type,
+                              final SpreadsheetConverterContext context) {
+        return String.class == type &&
+                this.formatter.canFormat(
+                        value,
+                        SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(context)
+                );
     }
 
     @Override
     public <T> Either<T, String> convert(final Object value,
-                                         final Class<T> targetType,
-                                         final ExpressionNumberConverterContext context) {
-        return this.formatter.format(value, SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(context))
+                                         final Class<T> type,
+                                         final SpreadsheetConverterContext context) {
+        return this.formatter.format(
+                        value,
+                        SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(context))
                 .map(
                         t -> this.successfulConversion(
                                 t.text(),
-                                targetType
+                                type
                         )
                 )
-                .orElse(Either.<T, String>right("Unable to convert " + CharSequences.quoteIfChars(value) + " to " + targetType.getName()));
+                .orElse(Either.<T, String>right("Unable to convert " + CharSequences.quoteIfChars(value) + " to " + type.getName()));
     }
 
     private final SpreadsheetFormatter formatter;

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
@@ -18,11 +18,10 @@
 package walkingkooka.spreadsheet.format;
 
 import walkingkooka.Either;
-import walkingkooka.collect.list.Lists;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converter;
-import walkingkooka.convert.Converters;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.math.MathContext;
@@ -33,11 +32,11 @@ import java.util.Optional;
 
 final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements SpreadsheetFormatterContext {
 
-    static SpreadsheetFormatterConverterSpreadsheetFormatterContext with(final ExpressionNumberConverterContext context) {
+    static SpreadsheetFormatterConverterSpreadsheetFormatterContext with(final SpreadsheetConverterContext context) {
         return new SpreadsheetFormatterConverterSpreadsheetFormatterContext(context);
     }
 
-    private SpreadsheetFormatterConverterSpreadsheetFormatterContext(final ExpressionNumberConverterContext context) {
+    private SpreadsheetFormatterConverterSpreadsheetFormatterContext(final SpreadsheetConverterContext context) {
         super();
 
         this.context = context;
@@ -45,17 +44,21 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
 
     @Override
     public List<String> ampms() {
-        return context.ampms();
+        return this.context.ampms();
     }
 
     @Override
     public String ampm(final int hourOfDay) {
-        return context.ampm(hourOfDay);
+        return this.context.ampm(hourOfDay);
     }
 
     @Override
-    public boolean canConvert(final Object value, final Class<?> target) {
-        return CONVERTER.canConvert(value, target, this.context);
+    public boolean canConvert(final Object value,
+                              final Class<?> type) {
+        return this.context.canConvert(
+                value,
+                type
+        );
     }
 
     @Override
@@ -74,18 +77,18 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
     }
 
     @Override
-    public <T> Either<T, String> convert(final Object value, final Class<T> target) {
-        return CONVERTER.convert(value, target, this.context);
+    public <T> Either<T, String> convert(final Object value,
+                                         final Class<T> type) {
+        return this.context.convert(
+                value,
+                type
+        );
     }
 
-    /**
-     * Supports number -> number, date -> datetime, time -> datetime.
-     */
-    private final static Converter<ExpressionNumberConverterContext> CONVERTER = Converters.collection(Lists.of(
-            Converters.simple(),
-            Converters.numberNumber(),
-            Converters.localDateLocalDateTime(),
-            Converters.localTimeLocalDateTime()));
+    @Override
+    public Converter<SpreadsheetConverterContext> converter() {
+        return this.context.converter();
+    }
 
     @Override
     public Optional<SpreadsheetText> defaultFormatText(final Object value) {
@@ -94,12 +97,12 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
 
     @Override
     public String currencySymbol() {
-        return context.currencySymbol();
+        return this.context.currencySymbol();
     }
 
     @Override
     public char decimalSeparator() {
-        return context.decimalSeparator();
+        return this.context.decimalSeparator();
     }
 
     @Override
@@ -109,47 +112,47 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
 
     @Override
     public String exponentSymbol() {
-        return context.exponentSymbol();
+        return this.context.exponentSymbol();
     }
 
     @Override
     public char groupingSeparator() {
-        return context.groupingSeparator();
+        return this.context.groupingSeparator();
     }
 
     @Override
     public Locale locale() {
-        return context.locale();
+        return this.context.locale();
     }
 
     @Override
     public MathContext mathContext() {
-        return context.mathContext();
+        return this.context.mathContext();
     }
 
     @Override
     public List<String> monthNames() {
-        return context.monthNames();
+        return this.context.monthNames();
     }
 
     @Override
     public String monthName(final int month) {
-        return context.monthName(month);
+        return this.context.monthName(month);
     }
 
     @Override
     public List<String> monthNameAbbreviations() {
-        return context.monthNameAbbreviations();
+        return this.context.monthNameAbbreviations();
     }
 
     @Override
     public String monthNameAbbreviation(final int month) {
-        return context.monthNameAbbreviation(month);
+        return this.context.monthNameAbbreviation(month);
     }
 
     @Override
     public char negativeSign() {
-        return context.negativeSign();
+        return this.context.negativeSign();
     }
 
     @Override
@@ -159,37 +162,42 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
 
     @Override
     public char percentageSymbol() {
-        return context.percentageSymbol();
+        return this.context.percentageSymbol();
     }
 
     @Override
     public char positiveSign() {
-        return context.positiveSign();
+        return this.context.positiveSign();
+    }
+
+    @Override
+    public SpreadsheetSelection resolveIfLabel(final SpreadsheetSelection selection) {
+        return this.context.resolveIfLabel(selection);
     }
 
     @Override
     public int twoDigitYear() {
-        return context.twoDigitYear();
+        return this.context.twoDigitYear();
     }
 
     @Override
     public List<String> weekDayNames() {
-        return context.weekDayNames();
+        return this.context.weekDayNames();
     }
 
     @Override
     public String weekDayName(final int day) {
-        return context.weekDayName(day);
+        return this.context.weekDayName(day);
     }
 
     @Override
     public List<String> weekDayNameAbbreviations() {
-        return context.weekDayNameAbbreviations();
+        return this.context.weekDayNameAbbreviations();
     }
 
     @Override
     public String weekDayNameAbbreviation(final int day) {
-        return context.weekDayNameAbbreviation(day);
+        return this.context.weekDayNameAbbreviation(day);
     }
 
     @Override
@@ -197,7 +205,7 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
         return this.context.expressionNumberKind();
     }
 
-    private final ExpressionNumberConverterContext context;
+    private final SpreadsheetConverterContext context;
 
     @Override
     public String toString() {

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterBooleanStringTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterBooleanStringTest.java
@@ -22,6 +22,7 @@ import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTextFormatPattern;
+import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 
 public final class GeneralSpreadsheetConverterBooleanStringTest extends GeneralSpreadsheetConverterTestCase<GeneralSpreadsheetConverterBooleanString>
         implements ConverterTesting2<GeneralSpreadsheetConverterBooleanString, SpreadsheetConverterContext> {
@@ -71,7 +72,11 @@ public final class GeneralSpreadsheetConverterBooleanStringTest extends GeneralS
 
     @Override
     public SpreadsheetConverterContext createContext() {
-        return SpreadsheetConverterContexts.fake();
+        return SpreadsheetConverterContexts.basic(
+                SpreadsheetConverters.basic(),
+                RESOLVE_IF_LABEL,
+                ExpressionNumberConverterContexts.fake()
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
@@ -1145,7 +1145,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     @Override
     public SpreadsheetConverterContext createContext() {
         return SpreadsheetConverterContexts.basic(
-                Converters.fake(),
+                SpreadsheetConverters.basic(),
                 RESOLVE_IF_LABEL,
                 ExpressionNumberConverterContexts.basic(
                         Converters.fake(),

--- a/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
@@ -25,7 +25,9 @@ import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -44,70 +46,94 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
     private final static Locale LOCALE = Locale.CANADA_FRENCH;
 
+    private final static Function<SpreadsheetSelection, SpreadsheetSelection> RESOLVE_IF_LABEL = (s) -> {
+        throw new UnsupportedOperationException();
+    };
+
     @Test
     public void testWithNullNumberToColorFails() {
-        this.withFails(null,
+        this.withFails(
+                null,
                 this.nameToColor(),
                 CELL_CHARACTER_WIDTH,
                 this.defaultSpreadsheetFormatter(),
-                this.converterContext());
+                this.converterContext()
+        );
     }
 
     @Test
     public void testWithNullNameToColorFails() {
-        this.withFails(this.numberToColor(),
+        this.withFails(
+                this.numberToColor(),
                 null,
                 CELL_CHARACTER_WIDTH,
                 this.defaultSpreadsheetFormatter(),
-                this.converterContext());
+                this.converterContext()
+        );
     }
 
     @Test
     public void testWithInvalidCellCharacterWidthFails() {
-        assertThrows(IllegalArgumentException.class, () -> BasicSpreadsheetFormatterContext.with(this.numberToColor(),
-                this.nameToColor(),
-                -1,
-                this.defaultSpreadsheetFormatter(),
-                this.converterContext()));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BasicSpreadsheetFormatterContext.with(this.numberToColor(),
+                        this.nameToColor(),
+                        -1,
+                        this.defaultSpreadsheetFormatter(),
+                        this.converterContext()
+                )
+        );
     }
 
     @Test
     public void testWithInvalidCellCharacterWidthFails2() {
-        assertThrows(IllegalArgumentException.class, () -> BasicSpreadsheetFormatterContext.with(this.numberToColor(),
-                this.nameToColor(),
-                0,
-                this.defaultSpreadsheetFormatter(),
-                this.converterContext()));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BasicSpreadsheetFormatterContext.with(this.numberToColor(),
+                        this.nameToColor(),
+                        0,
+                        this.defaultSpreadsheetFormatter(),
+                        this.converterContext())
+        );
     }
 
     @Test
     public void testWithNullDefaultSpreadsheetFormatterFails() {
-        this.withFails(this.numberToColor(),
+        this.withFails(
+                this.numberToColor(),
                 this.nameToColor(),
                 CELL_CHARACTER_WIDTH,
                 null,
-                this.converterContext());
+                this.converterContext()
+        );
     }
 
     @Test
     public void testWIthNullConverterContextFails() {
-        this.withFails(this.numberToColor(),
+        this.withFails(
+                this.numberToColor(),
                 this.nameToColor(),
                 CELL_CHARACTER_WIDTH,
                 this.defaultSpreadsheetFormatter(),
-                null);
+                null
+        );
     }
 
     private void withFails(final Function<Integer, Optional<Color>> numberToColor,
                            final Function<SpreadsheetColorName, Optional<Color>> nameToColor,
                            final int width,
                            final SpreadsheetFormatter defaultSpreadsheetFormatter,
-                           final ExpressionNumberConverterContext converterContext) {
-        assertThrows(NullPointerException.class, () -> BasicSpreadsheetFormatterContext.with(numberToColor,
-                nameToColor,
-                width,
-                defaultSpreadsheetFormatter,
-                converterContext));
+                           final SpreadsheetConverterContext converterContext) {
+        assertThrows(
+                NullPointerException.class,
+                () -> BasicSpreadsheetFormatterContext.with(
+                        numberToColor,
+                        nameToColor,
+                        width,
+                        defaultSpreadsheetFormatter,
+                        converterContext
+                )
+        );
     }
 
     @Test
@@ -145,8 +171,10 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createContext(),
-                "cellCharacterWidth=1 numberToColor=1=#123456 nameToColor=bingo=#123456 converterContext=locale=\"fr-CA\" twoDigitYear=50 \"$$\" '!' \"E\" 'G' 'N' 'P' 'L' fr_CA precision=7 roundingMode=HALF_EVEN DOUBLE");
+        this.toStringAndCheck(
+                this.createContext(),
+                "cellCharacterWidth=1 numberToColor=1=#123456 nameToColor=bingo=#123456 context=Truthy BigDecimal|BigInteger|Byte|Short|Integer|Long|Float|Double->Boolean " + RESOLVE_IF_LABEL + " locale=\"fr-CA\" twoDigitYear=50 \"$$\" '!' \"E\" 'G' 'N' 'P' 'L' fr_CA precision=7 roundingMode=HALF_EVEN DOUBLE"
+        );
     }
 
     @Override
@@ -211,13 +239,17 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
         };
     }
 
-    private ExpressionNumberConverterContext converterContext() {
-        return ExpressionNumberConverterContexts.basic(
+    private SpreadsheetConverterContext converterContext() {
+        return SpreadsheetConverterContexts.basic(
                 Converters.truthyNumberBoolean(),
-                ConverterContexts.basic(Converters.fake(),
-                        this.dateTimeContext(),
-                        this.decimalNumberContext()),
-                EXPRESSION_NUMBER_KIND
+                RESOLVE_IF_LABEL,
+                ExpressionNumberConverterContexts.basic(
+                        Converters.fake(),
+                        ConverterContexts.basic(Converters.fake(),
+                                this.dateTimeContext(),
+                                this.decimalNumberContext()),
+                        EXPRESSION_NUMBER_KIND
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContextTest.java
@@ -24,7 +24,9 @@ import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -77,8 +79,11 @@ public final class SpreadsheetFormatterConverterSpreadsheetFormatterContextTest 
 
     @Test
     public void testToString() {
-        final ExpressionNumberConverterContext converterContext = this.converterContext();
-        this.toStringAndCheck(SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(converterContext), converterContext.toString());
+        final SpreadsheetConverterContext converterContext = this.converterContext();
+        this.toStringAndCheck(
+                SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(converterContext),
+                converterContext.toString()
+        );
     }
 
     @Override
@@ -126,10 +131,22 @@ public final class SpreadsheetFormatterConverterSpreadsheetFormatterContextTest 
         return this.decimalNumberContext().positiveSign();
     }
 
-    private ExpressionNumberConverterContext converterContext() {
-        return ExpressionNumberConverterContexts.basic(Converters.fake(),
-                ConverterContexts.basic(Converters.fake(), dateTimeContext(), decimalNumberContext()),
-                ExpressionNumberKind.DEFAULT);
+    private SpreadsheetConverterContext converterContext() {
+        return SpreadsheetConverterContexts.basic(
+                SpreadsheetConverters.basic(),
+                (s) -> {
+                    throw new UnsupportedOperationException();
+                },
+                ExpressionNumberConverterContexts.basic(
+                        Converters.fake(),
+                        ConverterContexts.basic(
+                                Converters.fake(),
+                                dateTimeContext(),
+                                decimalNumberContext()
+                        ),
+                        ExpressionNumberKind.DEFAULT
+                )
+        );
     }
 
     private DateTimeContext dateTimeContext() {

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
@@ -23,12 +23,14 @@ import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatNumberParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContexts;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.ParserReporters;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -36,7 +38,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
 
-public final class SpreadsheetFormatterConverterTest implements ConverterTesting2<SpreadsheetFormatterConverter, ExpressionNumberConverterContext> {
+public final class SpreadsheetFormatterConverterTest implements ConverterTesting2<SpreadsheetFormatterConverter, SpreadsheetConverterContext> {
 
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DEFAULT;
 
@@ -112,11 +114,22 @@ public final class SpreadsheetFormatterConverterTest implements ConverterTesting
     }
 
     @Override
-    public ExpressionNumberConverterContext createContext() {
-        return ExpressionNumberConverterContexts.basic(Converters.fake(),
-                ConverterContexts.basic(Converters.fake(),
-                        DateTimeContexts.fake(), DecimalNumberContexts.american(MathContext.UNLIMITED)),
-                EXPRESSION_NUMBER_KIND);
+    public SpreadsheetConverterContext createContext() {
+        return SpreadsheetConverterContexts.basic(
+                SpreadsheetConverters.basic(),
+                (s) -> {
+                    throw new UnsupportedOperationException();
+                },
+                ExpressionNumberConverterContexts.basic(
+                        Converters.fake(),
+                        ConverterContexts.basic(
+                                Converters.fake(),
+                                DateTimeContexts.fake(),
+                                DecimalNumberContexts.american(MathContext.UNLIMITED)
+                        ),
+                        EXPRESSION_NUMBER_KIND
+                )
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1194,15 +1194,17 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     private void convertAndCheck2(final Object value,
                                   final Object expected) {
         final SpreadsheetMetadata metadata = this.createSpreadsheetMetadataWithConverter();
+        final Converter<SpreadsheetConverterContext> converter = metadata.converter();
 
         this.convertAndCheck3(
                 value,
                 expected,
                 metadata.converter(),
                 SpreadsheetConverterContexts.basic(
-                        Converters.fake(),
+                        converter,
                         RESOLVE_IF_LABEL,
-                        ExpressionNumberConverterContexts.basic(Converters.fake(),
+                        ExpressionNumberConverterContexts.basic(
+                                Converters.fake(),
                                 ConverterContexts.basic(
                                         Converters.fake(),
                                         DateTimeContexts.locale(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPatternTest.java
@@ -24,11 +24,12 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverter;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateFormatPattern;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -70,34 +71,43 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPatternTe
                 }),
                 1,
                 SpreadsheetFormatters.fake(),
-                ExpressionNumberConverterContexts.basic(new FakeConverter<>() {
+                SpreadsheetConverterContexts.basic(
+                        new FakeConverter<>() {
 
-                                                            @Override
-                                                            public <T> Either<T, String> convert(final Object value,
-                                                                                                 final Class<T> type,
-                                                                                                 final ExpressionNumberConverterContext context) {
-                                                                return this.successfulConversion(
-                                                                        type.cast(
-                                                                                LocalDateTime.of(
-                                                                                        (LocalDate) value,
-                                                                                        LocalTime.MIDNIGHT
-                                                                                )
-                                                                        ),
-                                                                        type
-                                                                );
-                                                            }
-                                                        },
-                        ConverterContexts.basic(
+                            @Override
+                            public <T> Either<T, String> convert(final Object value,
+                                                                 final Class<T> type,
+                                                                 final SpreadsheetConverterContext context) {
+                                return this.successfulConversion(
+                                        type.cast(
+                                                LocalDateTime.of(
+                                                        (LocalDate) value,
+                                                        LocalTime.MIDNIGHT
+                                                )
+                                        ),
+                                        type
+                                );
+                            }
+                        },
+                        RESOLVE_IF_LABEL,
+                        SpreadsheetConverterContexts.basic(
                                 Converters.fake(),
-                                DateTimeContexts.locale(
-                                        Locale.ENGLISH,
-                                        1900,
-                                        20,
-                                        LocalDateTime::now
-                                ),
-                                DecimalNumberContexts.american(MathContext.DECIMAL32)
-                        ),
-                        ExpressionNumberKind.DEFAULT
+                                RESOLVE_IF_LABEL,
+                                ExpressionNumberConverterContexts.basic(
+                                        Converters.fake(),
+                                        ConverterContexts.basic(
+                                                Converters.fake(),
+                                                DateTimeContexts.locale(
+                                                        Locale.ENGLISH,
+                                                        1900,
+                                                        20,
+                                                        LocalDateTime::now
+                                                ),
+                                                DecimalNumberContexts.american(MathContext.DECIMAL32)
+                                        ),
+                                        ExpressionNumberKind.DEFAULT
+                                )
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPatternTest.java
@@ -24,12 +24,13 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverter;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePatterns;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeFormatPattern;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -73,30 +74,35 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPatte
                 }),
                 1,
                 SpreadsheetFormatters.fake(),
-                ExpressionNumberConverterContexts.basic(
+                SpreadsheetConverterContexts.basic(
                         new FakeConverter<>() {
 
                             @Override
                             public <T> Either<T, String> convert(final Object value,
                                                                  final Class<T> type,
-                                                                 final ExpressionNumberConverterContext context) {
+                                                                 final SpreadsheetConverterContext context) {
                                 return this.successfulConversion(
                                         type.cast(value),
                                         type
                                 );
                             }
                         },
-                        ConverterContexts.basic(
+                        RESOLVE_IF_LABEL,
+                        ExpressionNumberConverterContexts.basic(
                                 Converters.fake(),
-                                DateTimeContexts.locale(
-                                        Locale.ENGLISH,
-                                        1900,
-                                        20,
-                                        LocalDateTime::now
+                                ConverterContexts.basic(
+                                        Converters.fake(),
+                                        DateTimeContexts.locale(
+                                                Locale.ENGLISH,
+                                                1900,
+                                                20,
+                                                LocalDateTime::now
+                                        ),
+                                        DecimalNumberContexts.american(MathContext.DECIMAL32)
                                 ),
-                                DecimalNumberContexts.american(MathContext.DECIMAL32)
-                        ),
-                        ExpressionNumberKind.DEFAULT)
+                                ExpressionNumberKind.DEFAULT
+                        )
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPatternTest.java
@@ -24,11 +24,12 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverter;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetNumberFormatPattern;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -75,30 +76,35 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern
                 }),
                 1,
                 SpreadsheetFormatters.fake(),
-                ExpressionNumberConverterContexts.basic(
+                SpreadsheetConverterContexts.basic(
                         new FakeConverter<>() {
 
                             @Override
                             public <T> Either<T, String> convert(final Object value,
                                                                  final Class<T> type,
-                                                                 final ExpressionNumberConverterContext context) {
+                                                                 final SpreadsheetConverterContext context) {
                                 return this.successfulConversion(
                                         type.cast(value),
                                         type
                                 );
                             }
                         },
-                        ConverterContexts.basic(
+                        RESOLVE_IF_LABEL,
+                        ExpressionNumberConverterContexts.basic(
                                 Converters.fake(),
-                                DateTimeContexts.locale(
-                                        Locale.ENGLISH,
-                                        1900,
-                                        20,
-                                        LocalDateTime::now
+                                ConverterContexts.basic(
+                                        Converters.fake(),
+                                        DateTimeContexts.locale(
+                                                Locale.ENGLISH,
+                                                1900,
+                                                20,
+                                                LocalDateTime::now
+                                        ),
+                                        DecimalNumberContexts.american(MathContext.DECIMAL32)
                                 ),
-                                DecimalNumberContexts.american(MathContext.DECIMAL32)
-                        ),
-                        ExpressionNumberKind.DEFAULT)
+                                ExpressionNumberKind.DEFAULT
+                        )
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPatternTest.java
@@ -24,12 +24,13 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverter;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeParsePatterns;
-import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -76,13 +77,13 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPatternTe
                 }),
                 1,
                 SpreadsheetFormatters.fake(),
-                ExpressionNumberConverterContexts.basic(
+                SpreadsheetConverterContexts.basic(
                         new FakeConverter<>() {
 
                             @Override
                             public <T> Either<T, String> convert(final Object value,
                                                                  final Class<T> type,
-                                                                 final ExpressionNumberConverterContext context) {
+                                                                 final SpreadsheetConverterContext context) {
                                 final LocalTime time = (LocalTime) value;
                                 return this.successfulConversion(
                                         type.cast(
@@ -92,15 +93,19 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPatternTe
                                 );
                             }
                         },
-                        ConverterContexts.basic(Converters.fake(),
-                                DateTimeContexts.locale(
-                                        Locale.ENGLISH,
-                                        1900,
-                                        20,
-                                        LocalDateTime::now
-                                ),
-                                DecimalNumberContexts.american(MathContext.DECIMAL32)),
-                        ExpressionNumberKind.DEFAULT
+                        RESOLVE_IF_LABEL,
+                        ExpressionNumberConverterContexts.basic(
+                                Converters.fake(),
+                                ConverterContexts.basic(Converters.fake(),
+                                        DateTimeContexts.locale(
+                                                Locale.ENGLISH,
+                                                1900,
+                                                20,
+                                                LocalDateTime::now
+                                        ),
+                                        DecimalNumberContexts.american(MathContext.DECIMAL32)),
+                                ExpressionNumberKind.DEFAULT
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.meta;
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
@@ -30,11 +31,16 @@ import walkingkooka.tree.text.TextStylePropertyName;
 import java.math.MathContext;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SpreadsheetMetadataPropertyNameTestCase<N extends SpreadsheetMetadataPropertyName<V>, V> extends SpreadsheetMetadataTestCase2<N>
         implements ToStringTesting<N> {
+
+    final static Function<SpreadsheetSelection, SpreadsheetSelection> RESOLVE_IF_LABEL = (s) -> {
+        throw new UnsupportedOperationException();
+    };
 
     SpreadsheetMetadataPropertyNameTestCase() {
         super();


### PR DESCRIPTION
- SpreadsheetConverters.basic() a new Converter that handles most spreadsheet type conversions. Good for testing.
- SpreadsheetFormatter now implements HasConverter<SpreadsheetConverterContext> was HasConverter<ExpressionNumberConverterContext>