### PR TITLE
SpreadsheetConverter SpreadsheetCellReferenceOrRange support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverter.java
@@ -169,7 +169,7 @@ final class GeneralSpreadsheetConverter implements Converter<SpreadsheetConverte
                 null, // date
                 null, // date-time
                 null, // number
-                GeneralSpreadsheetConverterSelectionStringConverter.INSTANCE, // selection
+                GeneralSpreadsheetConverterSelectionConverter.INSTANCE, // selection
                 Converters.objectString(), // string
                 null // time
         );
@@ -320,7 +320,7 @@ final class GeneralSpreadsheetConverter implements Converter<SpreadsheetConverte
                 isSupportedType(targetType) &&
                         false == (value instanceof LocalTime && targetType == LocalDate.class) &&
                         false == (value instanceof LocalDate && targetType == LocalTime.class) ||
-                GeneralSpreadsheetConverterSelectionStringConverter.INSTANCE.canConvert(value, targetType, context) ||
+                GeneralSpreadsheetConverterSelectionConverter.INSTANCE.canConvert(value, targetType, context) ||
                 GeneralSpreadsheetConverterStringSpreadsheetSelectionConverter.INSTANCE.canConvert(value, targetType, context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueTypeVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSpreadsheetValueTypeVisitor.java
@@ -71,6 +71,11 @@ final class GeneralSpreadsheetConverterSpreadsheetValueTypeVisitor<C extends Con
     }
 
     @Override
+    protected void visitCellReferenceOrRange() {
+        this.converter = this.mapping.selection;
+    }
+
+    @Override
     protected void visitCharacter() {
         this.converter = this.mapping.string;
     }

--- a/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverter.java
@@ -22,6 +22,7 @@ import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReferenceRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -47,6 +48,7 @@ final class GeneralSpreadsheetConverterStringSpreadsheetSelectionConverter imple
                               final SpreadsheetConverterContext context) {
         return (value instanceof Character || value instanceof String) &&
                 (type == SpreadsheetCellReference.class ||
+                        type == SpreadsheetCellReferenceOrRange.class ||
                         type == SpreadsheetCellRange.class ||
                         type == SpreadsheetColumnReference.class ||
                         type == SpreadsheetColumnReferenceRange.class ||

--- a/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverterSpreadsheetValueTypeVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverterSpreadsheetValueTypeVisitor.java
@@ -49,6 +49,11 @@ final class GeneralSpreadsheetConverterStringSpreadsheetSelectionConverterSpread
     }
 
     @Override
+    protected void visitCellReferenceOrRange() {
+        this.selection = SpreadsheetSelection.parseCellOrCellRange(this.string);
+    }
+
+    @Override
     protected void visitColumnReference() {
         this.selection = SpreadsheetSelection.parseColumn(this.string);
     }

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSelectionConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterSelectionConverterTest.java
@@ -22,8 +22,8 @@ import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
-public final class GeneralSpreadsheetConverterSelectionStringConverterTest extends GeneralSpreadsheetConverterTestCase<GeneralSpreadsheetConverterSelectionStringConverter>
-        implements ConverterTesting2<GeneralSpreadsheetConverterSelectionStringConverter, SpreadsheetConverterContext> {
+public final class GeneralSpreadsheetConverterSelectionConverterTest extends GeneralSpreadsheetConverterTestCase<GeneralSpreadsheetConverterSelectionConverter>
+        implements ConverterTesting2<GeneralSpreadsheetConverterSelectionConverter, SpreadsheetConverterContext> {
 
     @Test
     public void testCellToSpreadsheetSelection() {
@@ -68,14 +68,14 @@ public final class GeneralSpreadsheetConverterSelectionStringConverterTest exten
     @Test
     public void testCellRangeToExpressionReference() {
         this.convertAndCheck(
-                SpreadsheetSelection.parseCellRange("B2:C3" ),
+                SpreadsheetSelection.parseCellRange("B2:C3"),
                 SpreadsheetExpressionReference.class
         );
     }
 
     @Override
-    public GeneralSpreadsheetConverterSelectionStringConverter createConverter() {
-        return GeneralSpreadsheetConverterSelectionStringConverter.INSTANCE;
+    public GeneralSpreadsheetConverterSelectionConverter createConverter() {
+        return GeneralSpreadsheetConverterSelectionConverter.INSTANCE;
     }
 
     @Override
@@ -84,7 +84,7 @@ public final class GeneralSpreadsheetConverterSelectionStringConverterTest exten
     }
 
     @Override
-    public Class<GeneralSpreadsheetConverterSelectionStringConverter> type() {
-        return GeneralSpreadsheetConverterSelectionStringConverter.class;
+    public Class<GeneralSpreadsheetConverterSelectionConverter> type() {
+        return GeneralSpreadsheetConverterSelectionConverter.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterStringSpreadsheetSelectionConverterTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.convert.ConverterTesting2;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.function.Function;
@@ -39,6 +40,33 @@ public final class GeneralSpreadsheetConverterStringSpreadsheetSelectionConverte
         this.convertAndCheck2(
                 "B2:C3",
                 SpreadsheetSelection::parseCellRange
+        );
+    }
+
+    @Test
+    public void testStringToSpreadsheetCellOrCellRangeWithCell() {
+        this.convertAndCheck(
+                "A1",
+                SpreadsheetCellReferenceOrRange.class,
+                SpreadsheetSelection.parseCell("A1")
+        );
+    }
+
+    @Test
+    public void testStringToSpreadsheetCellOrCellRangeWithCellRange() {
+        this.convertAndCheck(
+                "B2:C3",
+                SpreadsheetCellReferenceOrRange.class,
+                SpreadsheetSelection.parseCellRange("B2:C3")
+        );
+    }
+
+    @Test
+    public void testStringToSpreadsheetCellOrCellRangeWithCellRangeSingle() {
+        this.convertAndCheck(
+                "D4:D4",
+                SpreadsheetCellReferenceOrRange.class,
+                SpreadsheetSelection.parseCellRange("D4")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.convert;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.TypeNameTesting;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.function.Function;
@@ -28,7 +29,10 @@ public abstract class GeneralSpreadsheetConverterTestCase<T> implements ClassTes
         TypeNameTesting<T> {
 
     final static Function<SpreadsheetSelection, SpreadsheetSelection> RESOLVE_IF_LABEL = (s) -> {
-        throw new UnsupportedOperationException();
+        if (s instanceof SpreadsheetLabelName) {
+            throw new IllegalArgumentException("Did not expected label: " + s);
+        }
+        return s;
     };
 
     GeneralSpreadsheetConverterTestCase() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2367
- SpreadsheetConverter should support SpreadsheetCellReferenceOrRange including label resolving

- Renamed GeneralSpreadsheetConverterStringSpreadsheetSelectionConverter to GeneralSpreadsheetConverterSpreadsheetSelectionConverter