### PR TITLE
SpreadsheetLabelStore.cellReferenceOrRange replaces cellReference

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStore.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.reference.store;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -51,16 +52,19 @@ public interface SpreadsheetLabelStore extends SpreadsheetStore<SpreadsheetLabel
     /**
      * Attempts to resolve the given label to a {@link SpreadsheetCellReference}.
      */
-    default Optional<SpreadsheetCellReference> cellReference(final SpreadsheetExpressionReference reference) {
-        return SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor.reference(reference, this);
+    default Optional<SpreadsheetCellReferenceOrRange> cellReferenceOrRange(final SpreadsheetExpressionReference reference) {
+        return SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor.cellReferenceOrRange(
+                reference,
+                this
+        );
     }
 
     /**
      * Attempts to resolve any labels to a {@link SpreadsheetCellReference} throwing an {@link IllegalArgumentException}
      * if any label resolution fails.
      */
-    default SpreadsheetCellReference cellReferenceOrFail(final SpreadsheetExpressionReference reference) {
-        return this.cellReference(reference)
+    default SpreadsheetCellReferenceOrRange cellReferenceOrRangeOrFail(final SpreadsheetExpressionReference reference) {
+        return this.cellReferenceOrRange(reference)
                 .orElseThrow(() -> this.notFound(reference));
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.reference.store;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -28,33 +29,30 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Accepts a {@link SpreadsheetLabelName} and returns a {@link SpreadsheetCellReference} or {@link Optional#empty()},
+ * Accepts a {@link SpreadsheetLabelName} and returns a {@link SpreadsheetCellReferenceOrRange} or {@link Optional#empty()},
  * using a {@link SpreadsheetLabelStore} to resolve labels.
  */
-final class SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor extends SpreadsheetSelectionVisitor {
+final class SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor extends SpreadsheetSelectionVisitor {
 
-    private final SpreadsheetLabelStore store;
-    private SpreadsheetCellReference reference = null;
-
-    static Optional<SpreadsheetCellReference> reference(final SpreadsheetExpressionReference reference,
-                                                        final SpreadsheetLabelStore store) {
+    static Optional<SpreadsheetCellReferenceOrRange> cellReferenceOrRange(final SpreadsheetExpressionReference reference,
+                                                                          final SpreadsheetLabelStore store) {
         Objects.requireNonNull(reference, "reference");
         Objects.requireNonNull(store, "store");
 
-        final SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor visitor = new SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor(store);
+        final SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor visitor = new SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor(store);
         visitor.accept(reference);
         return Optional.ofNullable(
-                visitor.reference
+                visitor.cellReferenceOrRange
         );
     }
 
-    SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor(final SpreadsheetLabelStore store) {
+    SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor(final SpreadsheetLabelStore store) {
         super();
         this.store = store;
     }
 
     protected void visit(final SpreadsheetCellReference reference) {
-        this.reference = reference;
+        this.cellReferenceOrRange = reference;
     }
 
     protected void visit(final SpreadsheetLabelName label) {
@@ -65,10 +63,14 @@ final class SpreadsheetLabelStoreCellReferenceSpreadsheetSelectionVisitor extend
     }
 
     protected void visit(final SpreadsheetCellRange range) {
-        this.reference = range.begin();
+        this.cellReferenceOrRange = range;
     }
 
     public String toString() {
-        return String.valueOf(this.reference);
+        return String.valueOf(this.cellReferenceOrRange);
     }
+
+    private final SpreadsheetLabelStore store;
+
+    private SpreadsheetCellReferenceOrRange cellReferenceOrRange = null;
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStoreTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStoreTesting.java
@@ -185,7 +185,7 @@ public interface SpreadsheetLabelStoreTesting<S extends SpreadsheetLabelStore> e
     }
 
     @Test
-    default void testCellReferenceOrFail() {
+    default void testCellReferenceOrRangeOrFail() {
         final S store = this.createStore();
         boolean tested = false;
 
@@ -194,7 +194,7 @@ public interface SpreadsheetLabelStoreTesting<S extends SpreadsheetLabelStore> e
             if (!store.load(label).isPresent()) {
                 assertThrows(
                         LoadStoreException.class,
-                        () -> store.cellReferenceOrFail(label),
+                        () -> store.cellReferenceOrRangeOrFail(label),
                         () -> "Unknown Label: " + label + " should have failed"
                 );
                 tested = true;

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -10923,7 +10923,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 if (selection.isLabelName()) {
                     return this.storeRepository()
                             .labels()
-                            .cellReferenceOrFail((SpreadsheetExpressionReference) selection);
+                            .cellReferenceOrRangeOrFail((SpreadsheetExpressionReference) selection);
                 }
                 return selection;
             }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2330
- SpreadsheetLabelStore.cellReferenceOrFail should also support returning either cell or cell-range