### PR TITLE
SpreadsheetEngine.deleteCells(SpreadsheetSelection)

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -218,15 +218,19 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
      * DELETE the cell, and updates all affected (referenced cells) returning all updated cells.
      */
     @Override
-    public SpreadsheetDelta deleteCell(final SpreadsheetCellReference reference,
-                                       final SpreadsheetEngineContext context) {
-        checkReference(reference);
+    public SpreadsheetDelta deleteCells(final SpreadsheetSelection selection,
+                                        final SpreadsheetEngineContext context) {
+        Objects.requireNonNull(selection, "selection");
         checkContext(context);
 
         try (final BasicSpreadsheetEngineChanges changes = BasicSpreadsheetEngineChangesMode.IMMEDIATE.createChanges(this, context)) {
-            context.storeRepository()
-                    .cells()
-                    .delete(reference);
+            final SpreadsheetStoreRepository repository = context.storeRepository();
+            final Optional<SpreadsheetCellRange> cells = selection.toCellRange(
+                    repository.labels()::cellRange
+            );
+            if(cells.isPresent()) {
+                repository.cells().deleteCells(cells.get());
+            }
             return this.prepareDelta(changes, context);
         }
     }
@@ -1717,7 +1721,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         Objects.requireNonNull(mapping, "mapping");
     }
 
-    private static void checkReference(final SpreadsheetCellReference reference) {
+    private static void checkReference(final SpreadsheetExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
@@ -21,6 +21,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 
 import java.util.Collection;
 import java.util.List;
@@ -48,7 +49,7 @@ final class BasicSpreadsheetEngineFillCells {
                          final SpreadsheetCellRange from,
                          final SpreadsheetCellRange to) {
         if (cells.isEmpty()) {
-            this.clear(to);
+            this.deleteCell(to);
         } else {
             final List<SpreadsheetCell> out = cells.stream()
                     .filter(c -> false == from.test(c.reference()))
@@ -59,13 +60,6 @@ final class BasicSpreadsheetEngineFillCells {
 
             this.fill(cells, from, to);
         }
-    }
-
-    /**
-     * Clears aka deletes all the cells in the given {@link SpreadsheetCellRange}
-     */
-    private void clear(final SpreadsheetCellRange to) {
-        to.cellStream().forEach(this::deleteCell);
     }
 
     /**
@@ -115,8 +109,11 @@ final class BasicSpreadsheetEngineFillCells {
         }
     }
 
-    private void deleteCell(final SpreadsheetCellReference reference) {
-        this.engine.deleteCell(reference, this.context);
+    private void deleteCell(final SpreadsheetExpressionReference reference) {
+        this.engine.deleteCells(
+                reference,
+                this.context
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
@@ -59,8 +59,8 @@ public class FakeSpreadsheetEngine implements SpreadsheetEngine, Fake {
     }
 
     @Override
-    public SpreadsheetDelta deleteCell(final SpreadsheetCellReference cell,
-                                       final SpreadsheetEngineContext context) {
+    public SpreadsheetDelta deleteCells(final SpreadsheetSelection cells,
+                                        final SpreadsheetEngineContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -67,10 +67,10 @@ public interface SpreadsheetEngine {
                                final SpreadsheetEngineContext context);
 
     /**
-     * Deletes the cell, removing references and updates and returns all affected (referenced cells).
+     * Deletes the cellS, removing references and updates and returns all affected (referenced cells).
      */
-    SpreadsheetDelta deleteCell(final SpreadsheetCellReference cell,
-                                final SpreadsheetEngineContext context);
+    SpreadsheetDelta deleteCells(final SpreadsheetSelection cells,
+                                 final SpreadsheetEngineContext context);
 
     /**
      * Loads the given {@link SpreadsheetColumn}

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -152,15 +152,26 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
     }
 
     @Test
-    default void testDeleteCellNullCellFails() {
-        assertThrows(NullPointerException.class, () -> this.createSpreadsheetEngine().deleteCell(null,
-                this.createContext()));
+    default void testDeleteCellsNullCellFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createSpreadsheetEngine()
+                        .deleteCells(
+                                null,
+                                this.createContext()
+                        )
+        );
     }
 
     @Test
-    default void testDeleteCellNullContextFails() {
-        assertThrows(NullPointerException.class, () -> this.createSpreadsheetEngine().deleteCell(CELL_REFERENCE,
-                null));
+    default void testDeleteCellsNullContextFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createSpreadsheetEngine().deleteCells(
+                        CELL_REFERENCE,
+                        null
+                )
+        );
     }
 
     @Test
@@ -807,12 +818,12 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
     }
 
     default void deleteCellAndCheck(final SpreadsheetEngine engine,
-                                    final SpreadsheetCellReference delete,
+                                    final SpreadsheetSelection delete,
                                     final SpreadsheetEngineContext context,
                                     final SpreadsheetDelta delta) {
         checkEquals(
                 delta,
-                engine.deleteCell(delete, context),
+                engine.deleteCells(delete, context),
                 () -> "deleteCell " + delete
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngine.java
@@ -115,10 +115,10 @@ final class SpreadsheetMetadataStampingSpreadsheetEngine implements SpreadsheetE
     }
 
     @Override
-    public SpreadsheetDelta deleteCell(final SpreadsheetCellReference cell,
-                                       final SpreadsheetEngineContext context) {
+    public SpreadsheetDelta deleteCells(final SpreadsheetSelection cells,
+                                        final SpreadsheetEngineContext context) {
         return this.stamp(
-                () -> this.engine.deleteCell(cell, context),
+                () -> this.engine.deleteCells(cells, context),
                 context
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -2227,7 +2227,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     // deleteCell....................................................................................................
 
     @Test
-    public void testDeleteCell() {
+    public void testDeleteCellsMatchingCellReference() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext(engine);
 
@@ -2251,7 +2251,90 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
-    public void testDeleteCellWithCellReferences() {
+    public void testDeleteCellsMatchingCellRange() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext(engine);
+
+        final SpreadsheetCellReference a1 = SpreadsheetSelection.parseCell("A1");
+        engine.saveCell(
+                this.cell(
+                        a1, "=111"
+                ),
+                context
+        );
+
+        final SpreadsheetCellReference a2 = SpreadsheetSelection.parseCell("A2");
+        engine.saveCell(
+                this.cell(
+                        a2,
+                        "=222"
+                ),
+                context
+        );
+
+        this.deleteCellAndCheck(
+                engine,
+                SpreadsheetSelection.parseCellRange("A1:A2"),
+                context,
+                SpreadsheetDelta.EMPTY
+                        .setDeletedCells(
+                                Sets.of(a1, a2)
+                        ).setColumnWidths(
+                                columnWidths("A")
+                        ).setRowHeights(
+                                rowHeights("1,2")
+                        )
+        );
+    }
+
+    @Test
+    public void testDeleteCellsMatchingColumn() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext(engine);
+
+        final SpreadsheetCellReference a1 = SpreadsheetSelection.parseCell("A1");
+        engine.saveCell(
+                this.cell(
+                        a1, "=111"
+                ),
+                context
+        );
+
+        final SpreadsheetCellReference a2 = SpreadsheetSelection.parseCell("A2");
+        engine.saveCell(
+                this.cell(
+                        a2,
+                        "=222"
+                ),
+                context
+        );
+
+        final SpreadsheetCellReference c3 = SpreadsheetSelection.parseCell("C3");
+        engine.saveCell(
+                this.cell(
+                        c3,
+                        "=333"
+                ),
+                context
+        );
+
+        this.deleteCellAndCheck(
+                engine,
+                SpreadsheetSelection.parseColumn("A"),
+                context,
+                SpreadsheetDelta.EMPTY
+                        .setDeletedCells(
+                                Sets.of(a1, a2)
+                        ).setColumnWidths(
+                                columnWidths("A")
+                        ).setRowHeights(
+                                rowHeights("1,2")
+                        )
+        );
+    }
+
+    @Test
+    public void testDeleteCellsWhereCellHasCellReferences() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext(engine);
 
@@ -2285,7 +2368,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
-    public void testDeleteCellWithCellReferrers() {
+    public void testDeleteCellsWhereCellHasCellReferrers() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext(engine);
         final SpreadsheetCellReference b2Reference = SpreadsheetSelection.parseCell("$B$2");
@@ -2331,7 +2414,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
-    public void testDeleteCellWithColumn() {
+    public void testDeleteCellsIncludesColumn() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext(engine);
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -149,7 +149,7 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
         final SpreadsheetMetadataStampingSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext();
 
-        engine.deleteCell(SpreadsheetSelection.parseCell("A1"), context);
+        engine.deleteCells(SpreadsheetSelection.parseCell("A1"), context);
 
         this.checkMetadataNotUpdated(context);
     }
@@ -165,7 +165,7 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
 
         context.storeRepository().metadatas().save(BEFORE);
 
-        engine.deleteCell(cell.reference(), context);
+        engine.deleteCells(cell.reference(), context);
 
         this.checkMetadataUpdated(context);
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2446
- SpreadsheetEngine.deleteCells(SpreadsheetSelection) replaces deleteCell(SpreadsheetCellReference)