### PR TITLE
SpreadsheetCellFormat.formatter removed.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
@@ -437,7 +437,7 @@ public final class SpreadsheetCell implements Comparable<SpreadsheetCell>,
         SpreadsheetCell.NO_FORMATTED_CELL.hashCode();
         SpreadsheetFormula.EMPTY.hashCode();
         TextNode.NO_ATTRIBUTES.isEmpty();
-        SpreadsheetCellFormat.NO_FORMATTER.isPresent();
+        SpreadsheetCellFormat.with("");
 
         JsonNodeContext.register(
                 JsonNodeContext.computeTypeName(SpreadsheetCell.class),

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellFormat.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellFormat.java
@@ -21,14 +21,12 @@ import walkingkooka.Cast;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.ToStringBuilderOption;
 import walkingkooka.UsesToStringBuilder;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Holds the pattern and compiled formatter for a cell.
@@ -36,36 +34,24 @@ import java.util.Optional;
 public final class SpreadsheetCellFormat implements UsesToStringBuilder {
 
     /**
-     * A constant holding no formatter.
-     */
-    public final static Optional<SpreadsheetFormatter> NO_FORMATTER = Optional.empty();
-
-    /**
      * Creates a {@link SpreadsheetCellFormat}
      */
     public static SpreadsheetCellFormat with(final String pattern) {
         checkPattern(pattern);
 
-        return new SpreadsheetCellFormat(pattern, NO_FORMATTER);
+        return new SpreadsheetCellFormat(pattern);
     }
 
     private static void checkPattern(final String pattern) {
         Objects.requireNonNull(pattern, "pattern");
     }
 
-    static SpreadsheetCellFormat with(final String pattern,
-                                      final Optional<SpreadsheetFormatter> formatter) {
-        return new SpreadsheetCellFormat(pattern, formatter);
-    }
-
     /**
      * Private ctor use factory.
      */
-    private SpreadsheetCellFormat(final String pattern,
-                                  final Optional<SpreadsheetFormatter> formatter) {
+    private SpreadsheetCellFormat(final String pattern) {
         super();
         this.pattern = pattern;
-        this.formatter = formatter;
     }
 
     public String pattern() {
@@ -77,39 +63,10 @@ public final class SpreadsheetCellFormat implements UsesToStringBuilder {
 
         return this.pattern.equals(pattern) ?
                 this :
-                this.replace(pattern, NO_FORMATTER);
+                new SpreadsheetCellFormat(pattern);
     }
 
     private final String pattern;
-
-    // formatter...........................................................................
-
-    public Optional<SpreadsheetFormatter> formatter() {
-        return this.formatter;
-    }
-
-    public SpreadsheetCellFormat setFormatter(final Optional<SpreadsheetFormatter> formatter) {
-        Objects.requireNonNull(formatter, "formatter");
-
-        return this.formatter.equals(formatter) ?
-                this :
-                this.replace(this.pattern, formatter);
-    }
-
-    /**
-     * The cached or compiled form of the {@link #pattern}
-     */
-    private final Optional<SpreadsheetFormatter> formatter;
-
-    // replace.............................................................................
-
-    /**
-     * Factory that creates a new {@link SpreadsheetCellFormat}
-     */
-    private SpreadsheetCellFormat replace(final String pattern,
-                                          final Optional<SpreadsheetFormatter> formatter) {
-        return new SpreadsheetCellFormat(pattern, formatter);
-    }
 
     // JsonNodeContext .................................................................................................
 
@@ -138,7 +95,7 @@ public final class SpreadsheetCellFormat implements UsesToStringBuilder {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.pattern, this.formatter);
+        return Objects.hash(this.pattern);
     }
 
     @Override
@@ -149,8 +106,7 @@ public final class SpreadsheetCellFormat implements UsesToStringBuilder {
     }
 
     private boolean equals0(final SpreadsheetCellFormat other) {
-        return this.pattern.equals(other.pattern) &&
-                this.formatter.equals(other.formatter);
+        return this.pattern.equals(other.pattern);
     }
 
     @Override
@@ -163,6 +119,5 @@ public final class SpreadsheetCellFormat implements UsesToStringBuilder {
         builder.separator(" ");
         builder.enable(ToStringBuilderOption.QUOTE);
         builder.value(this.pattern);
-        builder.value(this.formatter);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1077,11 +1077,10 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                 .formatter();
         final Optional<SpreadsheetCellFormat> maybeFormat = cell.format();
         if (maybeFormat.isPresent()) {
-            final SpreadsheetCellFormat format = this.parsePatternIfNecessary(maybeFormat.get(), context);
-            result = cell.setFormat(Optional.of(format));
-
-            formatter = format.formatter()
-                    .orElseThrow(() -> new SpreadsheetEngineException("Invalid cell format " + format));
+            formatter = context.parsePattern(
+                    maybeFormat.get()
+                            .pattern()
+            );
         }
 
         final SpreadsheetFormula formula = cell.formula();
@@ -1101,25 +1100,6 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                         this.formatAndApplyStyleValueAbsent(result);
 
         return this.locateAndApplyConditionalFormattingRule(beforeConditionalRules, context);
-    }
-
-    /**
-     * Returns a {@link SpreadsheetCellFormat} parsing the pattern if necessary.
-     */
-    private SpreadsheetCellFormat parsePatternIfNecessary(final SpreadsheetCellFormat format,
-                                                          final SpreadsheetEngineContext context) {
-        final Optional<SpreadsheetFormatter> formatter = format.formatter();
-        return formatter.isPresent() ?
-                format :
-                this.parsePattern(format, context);
-    }
-
-    /**
-     * Returns an updated {@link SpreadsheetCellFormat} after parsing the pattern into a {@link SpreadsheetFormatter}.
-     */
-    private SpreadsheetCellFormat parsePattern(final SpreadsheetCellFormat format,
-                                               final SpreadsheetEngineContext context) {
-        return format.setFormatter(Optional.of(context.parsePattern(format.pattern())));
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellFormatTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellFormatTest.java
@@ -22,14 +22,10 @@ import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -41,24 +37,26 @@ public final class SpreadsheetCellFormatTest implements ClassTesting2<Spreadshee
         ToStringTesting<SpreadsheetCellFormat> {
 
     private final static String PATTERN = "abc123";
-    private final static Optional<SpreadsheetFormatter> FORMATTER = Optional.of(SpreadsheetFormatters.fake());
 
     @Test
     public void testWithNullPatternFails() {
-        assertThrows(NullPointerException.class, () -> SpreadsheetCellFormat.with(null));
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetCellFormat.with(null)
+        );
     }
 
     @Test
     public void testWithEmptyPattern() {
         final String pattern = "";
         final SpreadsheetCellFormat format = SpreadsheetCellFormat.with(pattern);
-        this.check(format, pattern, SpreadsheetCellFormat.NO_FORMATTER);
+        this.check(format, pattern);
     }
 
     @Test
     public void testWith() {
         final SpreadsheetCellFormat format = SpreadsheetCellFormat.with(PATTERN);
-        this.check(format, PATTERN, SpreadsheetCellFormat.NO_FORMATTER);
+        this.check(format, PATTERN);
     }
 
     // setPattern...........................................................
@@ -75,50 +73,16 @@ public final class SpreadsheetCellFormatTest implements ClassTesting2<Spreadshee
     }
 
     @Test
-    public void testSetPatternDifferentClearsFormatter() {
+    public void testSetPatternDifferent() {
         final String differentPattern = "different";
         final SpreadsheetCellFormat format = this.createObject();
         final SpreadsheetCellFormat different = format.setPattern(differentPattern);
         assertNotSame(format, different);
-        this.check(different, differentPattern, SpreadsheetCellFormat.NO_FORMATTER);
-    }
-
-    // setFormatter...........................................................
-
-    @SuppressWarnings("OptionalAssignedToNull")
-    @Test
-    public void testSetFormatterNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createObject().setFormatter(null));
-    }
-
-    @Test
-    public void testSetFormatterSame() {
-        final SpreadsheetCellFormat format = this.createObject();
-        assertSame(format, format.setFormatter(FORMATTER));
-    }
-
-    @Test
-    public void testSetFormatterDifferent() {
-        this.setFormatterDifferentAndCheck(Optional.of(SpreadsheetFormatters.general()));
-    }
-
-    @Test
-    public void testSetFormatterDifferentWithout() {
-        this.setFormatterDifferentAndCheck(SpreadsheetCellFormat.NO_FORMATTER);
-    }
-
-    private void setFormatterDifferentAndCheck(final Optional<SpreadsheetFormatter> differentFormatter) {
-        final SpreadsheetCellFormat format = this.createObject();
-        final SpreadsheetCellFormat different = format.setFormatter(differentFormatter);
-        assertNotSame(format, different);
-        this.check(different, PATTERN, differentFormatter);
     }
 
     private void check(final SpreadsheetCellFormat format,
-                       final String pattern,
-                       final Optional<SpreadsheetFormatter> formatter) {
+                       final String pattern) {
         this.checkEquals(pattern, format.pattern(), "pattern");
-        this.checkEquals(formatter, format.formatter(), "formatter");
     }
 
     // equals..................................................................................
@@ -129,18 +93,10 @@ public final class SpreadsheetCellFormatTest implements ClassTesting2<Spreadshee
     }
 
     @Test
-    public void testEqualsDifferentText() {
-        this.checkNotEquals(SpreadsheetCellFormat.with("different").setFormatter(FORMATTER));
-    }
-
-    @Test
-    public void testEqualsDifferentFormatter() {
-        this.checkNotEquals(SpreadsheetCellFormat.with(PATTERN).setFormatter(Optional.of(SpreadsheetFormatters.general())));
-    }
-
-    @Test
-    public void testEqualstDifferentNoFormatter() {
-        this.checkNotEquals(this.withoutFormatter());
+    public void testEqualsDifferentPattern() {
+        this.checkNotEquals(
+                SpreadsheetCellFormat.with("different")
+        );
     }
 
     // JsonNodeMarshallingTesting.......................................................................................
@@ -166,8 +122,10 @@ public final class SpreadsheetCellFormatTest implements ClassTesting2<Spreadshee
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createObject(),
-                CharSequences.quote(PATTERN) + " " + FORMATTER.get());
+        this.toStringAndCheck(
+                this.createObject(),
+                CharSequences.quote(PATTERN).toString()
+        );
     }
 
     @Test
@@ -178,7 +136,7 @@ public final class SpreadsheetCellFormatTest implements ClassTesting2<Spreadshee
 
     @Override
     public SpreadsheetCellFormat createObject() {
-        return SpreadsheetCellFormat.with(PATTERN, FORMATTER);
+        return SpreadsheetCellFormat.with(PATTERN);
     }
 
     private SpreadsheetCellFormat withoutFormatter() {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -370,15 +370,6 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 FORMATTED_PATTERN_SUFFIX);
     }
 
-    @Test
-    public void testLoadCellsWithFormatPatternAndFormatter() {
-        final String pattern = "Custom";
-        final String suffix = "CustomSuffix";
-        this.cellStoreSaveAndLoadCellAndCheck(Optional.of(SpreadsheetCellFormat.with(pattern)
-                        .setFormatter(Optional.of(this.formatter(pattern, SpreadsheetText.WITHOUT_COLOR, suffix)))),
-                suffix);
-    }
-
     private void cellStoreSaveAndLoadCellAndCheck(final Optional<SpreadsheetCellFormat> format,
                                                   final String patternSuffix) {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();


### PR DESCRIPTION
- BasicSpreadsheetEngine always calls context.parsePattern with SpreadsheetCellFormat.pattern.
- SpreadsheetCell is never cached within BasicSpreadsheetEngine so cached formatter is pointless.