### PR TITLE
cell reference parser invalid character fail message improvements

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParsers.java
@@ -94,7 +94,8 @@ public final class SpreadsheetParsers implements PublicStaticHelper {
             .builder()
             .required(row())
             .build()
-            .transform(SpreadsheetParsers::transformColumnAndRow);
+            .transform(SpreadsheetParsers::transformColumnAndRow)
+            .setToString("cell");
 
     private static ParserToken transformColumnAndRow(final ParserToken token,
                                                      final SpreadsheetParserContext context) {

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -2221,7 +2221,7 @@ final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAn
     public void testParseInvalidBeginFails() {
         this.parseStringFails(
                 "##:A2",
-                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected (SpreadsheetColumnReference, SpreadsheetRowReference)")
+                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected cell")
         );
     }
 
@@ -2229,7 +2229,7 @@ final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAn
     public void testParseInvalidEndFails() {
         this.parseStringFails(
                 "A1:##",
-                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected (SpreadsheetColumnReference, SpreadsheetRowReference)")
+                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected cell")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -882,8 +882,9 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testParseCellReferenceRangeFails() {
-        this.parseStringFails("A1:B2",
-                new IllegalArgumentException("Invalid character ':' at (3,1) \"A1:B2\" expected (SpreadsheetColumnReference, SpreadsheetRowReference)")
+        this.parseStringFails(
+                "A1:B2",
+                new IllegalArgumentException("Invalid character ':' at (3,1) \"A1:B2\" expected cell")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -469,7 +469,7 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
                 () -> SpreadsheetSelection.parseCellOrCellRange("A@@@")
         );
         this.checkEquals(
-                "Invalid character 'A' at (1,1) \"A@@@\" expected (SpreadsheetColumnReference, SpreadsheetRowReference)",
+                "Invalid character 'A' at (1,1) \"A@@@\" expected cell",
                 thrown.getMessage(),
                 "message"
         );


### PR DESCRIPTION
- parse range still gives wrong character position for upper range fails.