### PR TITLE
cell AND column AND row Ranges parser upper bound fail fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -71,7 +71,8 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
         }
     }
 
-    private static final Parser<SpreadsheetParserContext> PARSER = SpreadsheetParsers.columnAndRow()
+    // Used by SpreadsheetSelection
+    static final Parser<SpreadsheetParserContext> PARSER = SpreadsheetParsers.columnAndRow()
             .orFailIfCursorNotEmpty(ParserReporters.basic())
             .orReport(ParserReporters.basic());
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -2205,7 +2205,7 @@ final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAn
     public void testParseMissingBeginFails() {
         this.parseStringFails(
                 ":A2",
-                new IllegalArgumentException("Empty lower range in \":A2\"")
+                new IllegalArgumentException("Invalid character ':' at 0 in \":A2\"")
         );
     }
 
@@ -2221,7 +2221,7 @@ final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAn
     public void testParseInvalidBeginFails() {
         this.parseStringFails(
                 "##:A2",
-                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected cell")
+                new IllegalArgumentException("Invalid character '#' at 0 in \"##:A2\"")
         );
     }
 
@@ -2229,7 +2229,7 @@ final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAn
     public void testParseInvalidEndFails() {
         this.parseStringFails(
                 "A1:##",
-                new IllegalArgumentException("Invalid character '#' at (1,1) \"##\" expected cell")
+                new IllegalArgumentException("Invalid character '#' at 3 in \"A1:##\"")
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2474
- cell range parser fail messages for upper bound character positions are not absolute, but only relative to upper bound start