### PR TITLE
BasicSpreadsheetEngine honours SpreadsheetCell.parsePatterns

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -425,6 +425,62 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     }
 
     @Test
+    public void testLoadCellsParsePatternFails() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext(engine);
+
+        final SpreadsheetCellReference cellReference = this.cellReference(1, 1);
+        context.storeRepository()
+                .cells()
+                .save(
+                        this.cell(
+                                cellReference,
+                                "=1+2"
+                        ).setParsePatterns(
+                                Optional.of(
+                                        SpreadsheetPattern.parseNumberParsePatterns("#")
+                                )
+                        )
+                );
+
+        this.loadCellAndCheckError(
+                engine,
+                cellReference,
+                SpreadsheetEngineEvaluation.FORCE_RECOMPUTE,
+                context,
+                "Invalid character '=' at (1,1) \"=1+2\" expected \"#\""
+        );
+    }
+
+    @Test
+    public void testLoadCellsParsePattern() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext(engine);
+
+        final SpreadsheetCellReference cellReference = this.cellReference(1, 1);
+        context.storeRepository()
+                .cells()
+                .save(
+                        this.cell(
+                                cellReference,
+                                "123"
+                        ).setParsePatterns(
+                                Optional.of(
+                                        SpreadsheetPattern.parseNumberParsePatterns("$#;#")
+                                )
+                        )
+                );
+
+        this.loadCellAndCheckValue(
+                engine,
+                cellReference,
+                SpreadsheetEngineEvaluation.FORCE_RECOMPUTE,
+                context,
+                number(123)
+        );
+    }
+
+    @Test
     public void testLoadCellsComputeIfNecessaryKeepsExpression() {
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
         final SpreadsheetEngineContext context = this.createContext(engine);


### PR DESCRIPTION
- If SpreadsheetCell.parsePatterns is present that is used otherwise the SpreadsheetEngineContext.parseFormula is used.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2504
- SpreadsheetEngine should use SpreadsheetCell.parsePatterns