### PR TITLE
SpreadsheetFormula.text replaced by present token

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
@@ -221,7 +221,21 @@ public final class SpreadsheetCell implements Comparable<SpreadsheetCell>,
 
         return this.parsePatterns.equals(parsePatterns) ?
                 this :
-                this.replace(this.reference, this.formula.setToken(SpreadsheetFormula.NO_TOKEN), this.style, parsePatterns, this.formatPattern, NO_FORMATTED_CELL);
+                this.setParsePatterns0(parsePatterns);
+    }
+
+    private SpreadsheetCell setParsePatterns0(final Optional<SpreadsheetParsePatterns<?>> parsePatterns) {
+        final SpreadsheetFormula formula = this.formula;
+
+        return this.replace(
+                this.reference,
+                formula.setToken(SpreadsheetFormula.NO_TOKEN)
+                        .setText(formula.text()),
+                this.style,
+                parsePatterns,
+                this.formatPattern,
+                NO_FORMATTED_CELL
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellTest.java
@@ -1081,7 +1081,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                 ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1105,7 +1104,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                 ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1134,7 +1132,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                 ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1171,7 +1168,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                 ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1200,7 +1196,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                 ).setStyle(this.boldAndItalics()),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1235,7 +1230,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                         ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1274,7 +1268,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                         ),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1313,7 +1306,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                         .setFormatPattern(formatPattern()),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +
@@ -1350,7 +1342,6 @@ public final class SpreadsheetCellTest implements ClassTesting2<SpreadsheetCell>
                         .setFormatted(formatted()),
                 "Cell A1\n" +
                         "  Formula\n" +
-                        "    text: \"=1+2\"\n" +
                         "    token:\n" +
                         "      SpreadsheetExpression\n" +
                         "        SpreadsheetEqualsSymbol \"=\" \"=\" (java.lang.String)\n" +


### PR DESCRIPTION
- Internally text nulled when a non empty token is set.
- SpreadsheetFormula if a token is present then text() always returns the token().text().
- SpreadsheetFormula.setToken restores text if previous token was present, this ensures the text is always present.
- SpreadsheetFormula.printTree skips printing text, if token present.
- SpreadsheetCell.setParsePatterns after clearing token, restores text.