### PR TITLE
Error handling cell formatted text fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
@@ -149,11 +149,11 @@ abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
      */
     private void fixExpressionReferences(final SpreadsheetCell cell,
                                          final SpreadsheetEngineContext context) {
-        final SpreadsheetCell fixed = cell.setFormula(
-                this.engine.parseFormulaIfNecessary(
-                        cell,
-                        this::fixCellReferencesWithinExpression,
-                        context));
+        final SpreadsheetCell fixed = this.engine.parseFormulaIfNecessary(
+                cell,
+                this::fixCellReferencesWithinExpression,
+                context
+        );
         if (!cell.equals(fixed)) {
             this.saveCell(fixed);
         }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFillCells.java
@@ -129,13 +129,14 @@ final class BasicSpreadsheetEngineFillCells {
         final SpreadsheetEngineContext context = this.context;
 
         // possibly fix references, and then parse the formula and evaluate etc.
-        final SpreadsheetCell save = updatedReference.setFormula(engine.parseFormulaIfNecessary(
+        final SpreadsheetCell save = engine.parseFormulaIfNecessary(
                 updatedReference,
                 token -> BasicSpreadsheetEngineFillCellsSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.expressionFixReferences(
                         token,
                         xOffset,
-                        yOffset),
-                context)
+                        yOffset
+                ),
+                context
         );
         this.engine.maybeParseAndEvaluateAndFormat(save,
                 SpreadsheetEngineEvaluation.CLEAR_VALUE_ERROR_SKIP_EVALUATE,

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -318,7 +318,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 SpreadsheetEngineEvaluation.COMPUTE_IF_NECESSARY,
                 context,
                 error,
-                errorMessage, // formatted text
+                error.kind().text(), // formatted text
                 errorMessage
         );
     }
@@ -699,7 +699,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
         this.checkFormattedText(
                 second,
-                "End of text at (6,1) \"=1+2+\" expected BINARY_SUB_EXPRESSION"
+                "#ERROR"
         );
     }
 
@@ -11501,10 +11501,6 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
     private SpreadsheetCell formattedCellWithError(final SpreadsheetCell cell,
                                                    final SpreadsheetErrorKind errorKind,
                                                    final String errorMessage) {
-        final Optional<TextNode> formattedCell = Optional.of(this.style()
-                .replace(TextNode.text(errorMessage))
-                .root());
-
         return cell.setFormula(
                         this.parseFormula(cell.formula())
                                 .setValue(
@@ -11515,7 +11511,11 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                         )
                                 )
                 )
-                .setFormatted(formattedCell);
+                .setFormatted(
+                        Optional.of(
+                                TextNode.text(errorKind.text())
+                        )
+                );
     }
 
     /**


### PR DESCRIPTION
- Updated BasicSpreadsheetEngine to handle value with SpreadsheetError.kind.text().

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2515
- formatting a SpreadsheetError should not include message

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2516
- converting a SpreadsheetError into a String should ignore SpreadsheetError.message and only use kind.toString()