### PR TITLE
Missing cell-reference have zero value

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -50,8 +50,8 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     /**
      * {@see SpreadsheetErrorConverter}
      */
-    public static <C extends ConverterContext> Converter<C> error() {
-        return Cast.to(SpreadsheetErrorConverter.INSTANCE);
+    public static Converter<SpreadsheetConverterContext> error() {
+        return SpreadsheetErrorConverter.INSTANCE;
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1033,7 +1033,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                         cell,
                                         context
                                 )
-                        )
+                        ).replaceErrorWithValueIfPossible(context)
                 );
             }
 
@@ -1070,7 +1070,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                         cell.formula()
                                 .setValue(
                                         Optional.of(
-                                                error
+                                                error.replaceWithValueIfPossible(context)
                                         )
                                 )
                 ),
@@ -1130,7 +1130,8 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                     .formatter();
         }
 
-        final SpreadsheetFormula formula = cell.formula();
+        final SpreadsheetFormula formula = cell
+                .formula();
         final Object value = formula.value()
                 .orElse("");
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
@@ -22,16 +22,10 @@ import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.spreadsheet.engine.FakeSpreadsheetEngineContext;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContexts;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.printer.TreePrintableTesting;
-import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -155,59 +149,6 @@ public final class SpreadsheetErrorTest implements ClassTesting2<SpreadsheetErro
                 is,
                 error.isMissingCell(),
                 () -> error + ".isMissingCell()"
-        );
-    }
-
-    // replaceWithValueIfPossible......................................................................................
-
-    @Test
-    public void testReplaceWithValueIfPossibleWithNullContextFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> SpreadsheetErrorKind.ERROR.setMessage("!!")
-                        .replaceWithValueIfPossible(null)
-        );
-    }
-
-    @Test
-    public void testReplaceWithValueIfPossibleWithMissingCellBecomesZero() {
-        final ExpressionNumberKind kind = ExpressionNumberKind.BIG_DECIMAL;
-
-        this.replaceWithValueIfPossibleAndCheck(
-                SpreadsheetError.notFound(SpreadsheetSelection.parseCell("A1")),
-                new FakeSpreadsheetEngineContext() {
-                    @Override
-                    public SpreadsheetMetadata metadata() {
-                        return SpreadsheetMetadata.EMPTY.defaults()
-                                .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, kind);
-                    }
-                },
-                kind.zero()
-        );
-    }
-
-    @Test
-    public void testReplaceWithValueIfPossibleWithNotMissingCell() {
-        this.replaceWithValueIfPossibleAndCheck(
-                SpreadsheetErrorKind.DIV0.setMessage("!!")
-        );
-    }
-
-    private void replaceWithValueIfPossibleAndCheck(final SpreadsheetError error) {
-        this.replaceWithValueIfPossibleAndCheck(
-                error,
-                SpreadsheetEngineContexts.fake(),
-                error
-        );
-    }
-
-    private void replaceWithValueIfPossibleAndCheck(final SpreadsheetError error,
-                                                    final SpreadsheetEngineContext context,
-                                                    final Object expected) {
-        this.checkEquals(
-                expected,
-                error.replaceWithValueIfPossible(context),
-                () -> error + " replaceWithValueIfPossible"
         );
     }
 


### PR DESCRIPTION
- formulas = missing cell have zero value, eg=Z99=0 and =1+Z99=1 where Z99 is a missing/empty cell.
- SpreadsheetErrorConverter updated to support converting Error -> Number.
- SpreadsheetErrorConverter implements Converter<SpreadsheetConverterContext>

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2527
- Handling missing reference corrections