### PR TITLE
SpreadsheetErrorException was SpreadsheetErrorConversionException

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorException.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorException.java
@@ -17,25 +17,22 @@
 
 package walkingkooka.spreadsheet;
 
-import walkingkooka.convert.ConversionException;
-
 import java.util.Objects;
 
 /**
- * This exception is thrown by SpreadsheetConverter when it is requested
- * to convert a {@link SpreadsheetError} to some other type.
+ * An {@link RuntimeException} that holds a {@link SpreadsheetError}
  * <br>
  * This behaviour guarantees that any formula or expression with an error will fail with the first {@link SpreadsheetError}.
  */
-public final class SpreadsheetErrorConversionException extends ConversionException implements HasSpreadsheetError {
+public final class SpreadsheetErrorException extends RuntimeException implements HasSpreadsheetError {
 
     private static final long serialVersionUID = 1L;
 
-    protected SpreadsheetErrorConversionException() {
+    protected SpreadsheetErrorException() {
         super();
     }
 
-    public SpreadsheetErrorConversionException(final SpreadsheetError error) {
+    public SpreadsheetErrorException(final SpreadsheetError error) {
         super();
         this.error = Objects.requireNonNull(error, "error");
     }

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetErrorThrowingConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetErrorThrowingConverter.java
@@ -21,10 +21,10 @@ import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.spreadsheet.SpreadsheetError;
-import walkingkooka.spreadsheet.SpreadsheetErrorConversionException;
+import walkingkooka.spreadsheet.SpreadsheetErrorException;
 
 /**
- * A {@link Converter} that throws {@link SpreadsheetErrorConversionException} with any given {@link SpreadsheetError}.
+ * A {@link Converter} that throws {@link SpreadsheetErrorException} with any given {@link SpreadsheetError}.
  * This is necessary so that functions which try and convert a {@link SpreadsheetError} fail early and eventually
  * return this {@link SpreadsheetError}.
  */
@@ -52,7 +52,7 @@ final class SpreadsheetErrorThrowingConverter extends SpreadsheetErrorConverter<
     <T> Either<T, String> convertSpreadsheetError(final SpreadsheetError error,
                                                   final Class<T> type,
                                                   final ConverterContext context) {
-        throw new SpreadsheetErrorConversionException(error);
+        throw new SpreadsheetErrorException(error);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorExceptionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorExceptionTest.java
@@ -23,7 +23,7 @@ import walkingkooka.reflect.JavaVisibility;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class SpreadsheetErrorConversionExceptionTest implements ClassTesting<SpreadsheetErrorConversionException> {
+public final class SpreadsheetErrorExceptionTest implements ClassTesting<SpreadsheetErrorException> {
 
     private final static SpreadsheetError ERROR = SpreadsheetErrorKind.DIV0.setMessage("Hello");
 
@@ -31,13 +31,13 @@ public final class SpreadsheetErrorConversionExceptionTest implements ClassTesti
     public void testNewNullSpreadsheetErrorFails() {
         assertThrows(
                 NullPointerException.class,
-                () -> new SpreadsheetErrorConversionException(null)
+                () -> new SpreadsheetErrorException(null)
         );
     }
 
     @Test
     public void testNew() {
-        final SpreadsheetErrorConversionException exception = new SpreadsheetErrorConversionException(ERROR);
+        final SpreadsheetErrorException exception = new SpreadsheetErrorException(ERROR);
         this.checkEquals(
                 ERROR,
                 exception.spreadsheetError(),
@@ -46,8 +46,8 @@ public final class SpreadsheetErrorConversionExceptionTest implements ClassTesti
     }
 
     @Override
-    public Class<SpreadsheetErrorConversionException> type() {
-        return SpreadsheetErrorConversionException.class;
+    public Class<SpreadsheetErrorException> type() {
+        return SpreadsheetErrorException.class;
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
@@ -53,7 +53,7 @@ public final class SpreadsheetErrorKindTest implements ClassTesting<SpreadsheetE
 
         this.checkEquals(
                 error,
-                SpreadsheetErrorKind.translate(new SpreadsheetErrorConversionException(error))
+                SpreadsheetErrorKind.translate(new SpreadsheetErrorException(error))
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
@@ -25,7 +25,7 @@ import walkingkooka.convert.ConverterTesting2;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.math.DecimalNumberContexts;
-import walkingkooka.spreadsheet.SpreadsheetErrorConversionException;
+import walkingkooka.spreadsheet.SpreadsheetErrorException;
 import walkingkooka.spreadsheet.SpreadsheetErrorKind;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
@@ -554,7 +554,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     @Test
     public void testSpreadsheetErrorToNumber() {
         assertThrows(
-                SpreadsheetErrorConversionException.class,
+                SpreadsheetErrorException.class,
                 () -> this.createConverter()
                         .convert(
                                 SpreadsheetErrorKind.ERROR.setMessage("Ignored"),
@@ -567,7 +567,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     @Test
     public void testSpreadsheetErrorToString() {
         assertThrows(
-                SpreadsheetErrorConversionException.class,
+                SpreadsheetErrorException.class,
                 () -> this.convert(
                         SpreadsheetErrorKind.DIV0.setMessage("Message is ignored"),
                         String.class

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetErrorThrowingConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetErrorThrowingConverterTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.ConverterTesting2;
-import walkingkooka.spreadsheet.SpreadsheetErrorConversionException;
+import walkingkooka.spreadsheet.SpreadsheetErrorException;
 import walkingkooka.spreadsheet.SpreadsheetErrorKind;
 import walkingkooka.tree.expression.ExpressionNumber;
 
@@ -41,7 +41,7 @@ public final class SpreadsheetErrorThrowingConverterTest implements ConverterTes
     @Test
     public void testThrows() {
         assertThrows(
-                SpreadsheetErrorConversionException.class,
+                SpreadsheetErrorException.class,
                 () -> SpreadsheetErrorThrowingConverter.INSTANCE.convert(
                         SpreadsheetErrorKind.ERROR.setMessage("Ignored"),
                         ExpressionNumber.class,


### PR DESCRIPTION
- Now extends RuntimeException was ConversionException.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2547
- Maybe make SpreadsheetError extend RuntimeException so it can be thrown