### PR TITLE
SpreadsheetErrorParserToken

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/FakeSpreadsheetParserTokenVisitor.java
@@ -328,6 +328,11 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
     }
 
     @Override
+    protected void visit(final SpreadsheetErrorParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final SpreadsheetExponentSymbolParserToken token) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetErrorParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetErrorParserToken.java
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.spreadsheet.parser;
+
+import walkingkooka.spreadsheet.SpreadsheetError;
+
+/**
+ * A token that holds a {@link SpreadsheetError}.
+ */
+public final class SpreadsheetErrorParserToken extends SpreadsheetNonSymbolParserToken<SpreadsheetError> {
+
+    static SpreadsheetErrorParserToken with(final SpreadsheetError value,
+                                            final String text) {
+        checkValueAndText(value, text);
+
+        return new SpreadsheetErrorParserToken(value, text);
+    }
+
+    private SpreadsheetErrorParserToken(final SpreadsheetError value,
+                                        final String text) {
+        super(value, text);
+    }
+
+    // SpreadsheetParserTokenVisitor....................................................................................
+
+    @Override
+    void accept(final SpreadsheetParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof SpreadsheetErrorParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserToken.java
@@ -18,6 +18,7 @@ package walkingkooka.spreadsheet.parser;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.SpreadsheetError;
 import walkingkooka.spreadsheet.expression.SpreadsheetFunctionName;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -184,6 +185,14 @@ public abstract class SpreadsheetParserToken implements ParserToken {
      */
     public static SpreadsheetEqualsSymbolParserToken equalsSymbol(final String value, final String text) {
         return SpreadsheetEqualsSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see SpreadsheetErrorParserToken}
+     */
+    public static SpreadsheetErrorParserToken error(final SpreadsheetError value,
+                                                    final String text) {
+        return SpreadsheetErrorParserToken.with(value, text);
     }
 
     /**
@@ -705,6 +714,13 @@ public abstract class SpreadsheetParserToken implements ParserToken {
     }
 
     /**
+     * Only {@link SpreadsheetEqualsSymbolParserToken} returns true
+     */
+    public final boolean isError() {
+        return this instanceof SpreadsheetErrorParserToken;
+    }
+
+    /**
      * Only {@link SpreadsheetExponentSymbolParserToken} returns true
      */
     public final boolean isExponentSymbol() {
@@ -1160,6 +1176,11 @@ public abstract class SpreadsheetParserToken implements ParserToken {
         );
 
         registerLeafParserToken(
+                SpreadsheetErrorParserToken.class,
+                SpreadsheetParserToken::unmarshallError
+        );
+
+        registerLeafParserToken(
                 SpreadsheetFunctionNameParserToken.class,
                 SpreadsheetParserToken::unmarshallFunctionName
         );
@@ -1282,6 +1303,16 @@ public abstract class SpreadsheetParserToken implements ParserToken {
                 String.class,
                 context,
                 SpreadsheetParserToken::digits
+        );
+    }
+
+    static SpreadsheetErrorParserToken unmarshallError(final JsonNode node,
+                                                       final JsonNodeUnmarshallContext context) {
+        return unmarshallLeafParserToken(
+                node,
+                SpreadsheetError.class,
+                context,
+                SpreadsheetParserToken::error
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitor.java
@@ -317,6 +317,10 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
         // nop
     }
 
+    protected void visit(final SpreadsheetErrorParserToken token) {
+        // nop
+    }
+
     protected void visit(final SpreadsheetExponentSymbolParserToken token) {
         // nop
     }

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserTokenVisitorToExpression.java
@@ -354,6 +354,11 @@ final class SpreadsheetParserTokenVisitorToExpression extends SpreadsheetParserT
     // ignore all SymbolParserTokens, dont bother to collect them.
 
     @Override
+    protected void visit(final SpreadsheetErrorParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final SpreadsheetLabelNameParserToken token) {
         this.addReference(token.value(), token);
     }

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetErrorParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetErrorParserTokenTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.spreadsheet.parser;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.SpreadsheetError;
+import walkingkooka.spreadsheet.SpreadsheetErrorKind;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+import walkingkooka.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetErrorParserTokenTest extends SpreadsheetNonSymbolParserTokenTestCase<SpreadsheetErrorParserToken, SpreadsheetError> {
+
+    @Test
+    public void testWithEmptyTextFails() {
+        assertThrows(IllegalArgumentException.class, () -> this.createToken(""));
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final SpreadsheetErrorParserToken token = this.createToken();
+
+        new FakeSpreadsheetParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final SpreadsheetParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final SpreadsheetParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final SpreadsheetErrorParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        this.checkEquals("13542", b.toString());
+    }
+
+    @Test
+    public void testToExpression() {
+        this.toExpressionAndFail();
+    }
+
+    @Override
+    public String text() {
+        return "sum";
+    }
+
+    @Override
+    SpreadsheetError value() {
+        return SpreadsheetErrorKind.REF.toError();
+    }
+
+    @Override
+    SpreadsheetErrorParserToken createToken(final SpreadsheetError value, final String text) {
+        return SpreadsheetErrorParserToken.with(value, text);
+    }
+
+    @Override
+    public SpreadsheetErrorParserToken createDifferentToken() {
+        final SpreadsheetError error = SpreadsheetErrorKind.DIV0.toError();
+
+        return SpreadsheetErrorParserToken.with(
+                error,
+                error.kind().text()
+        );
+    }
+
+    @Override
+    public Class<SpreadsheetErrorParserToken> type() {
+        return SpreadsheetErrorParserToken.class;
+    }
+
+    @Override
+    public SpreadsheetErrorParserToken unmarshall(final JsonNode from,
+                                                  final JsonNodeUnmarshallContext context) {
+        return SpreadsheetParserToken.unmarshallError(from, context);
+    }
+}


### PR DESCRIPTION
- TODO parser & integration into SpreadsheetParsers.expression().
- to expression SpreadsheetParserTokenVisitorToExpression, will probably need a error(number, message, value) function.
- TODO BasicSpreadsheetEngine delete update