### PR TITLE
Time pattern ampm full support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisitor.java
@@ -113,7 +113,25 @@ final class DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisito
 
     @Override
     protected void visit(final SpreadsheetFormatAmPmParserToken token) {
-        text.append(context.ampm(value.getHour()));
+        final String tokenText = token.text();
+        final String ampm = this.context.ampm(this.value.getHour());
+
+        final String text;
+
+        switch (tokenText.length()) {
+            case 1:
+                text = ampm.substring(0, 1);
+                break;
+            default:
+                text = ampm;
+                break;
+        }
+
+        this.text.append(
+                Character.isLowerCase(tokenText.charAt(0)) ?
+                        text.toLowerCase() :
+                        text.toUpperCase()
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeFormatPatternTest.java
@@ -492,36 +492,54 @@ public final class SpreadsheetDateTimeFormatPatternTest extends SpreadsheetForma
     }
 
     @Test
-    public void testFormatterHMmmAp() {
+    public void testFormatterHMmmap12() {
         this.formatAndCheck4(
                 "hmmma/p",
                 LocalTime.of(12, 58, 59),
-                "1258QAM"
+                "1258qam"
         );
     }
 
     @Test
-    public void testFormatterHMmmAp2() {
+    public void testFormatterHMmmap23() {
         this.formatAndCheck4(
                 "hmmma/p",
                 LocalTime.of(23, 58, 59),
-                "1158RPM"
+                "1158rpm"
         );
     }
 
     @Test
-    public void testFormatterHMmmAmpm() {
+    public void testFormatterHMmmAmpm12Lower() {
         this.formatAndCheck4(
                 "hmmmam/pm",
+                LocalTime.of(12, 58, 59),
+                "1258qam"
+        );
+    }
+
+    @Test
+    public void testFormatterHMmmAmpm23Lower() {
+        this.formatAndCheck4(
+                "hmmmam/pm",
+                LocalTime.of(23, 58, 59),
+                "1158rpm"
+        );
+    }
+
+    @Test
+    public void testFormatterHMmmAmpm12Upper() {
+        this.formatAndCheck4(
+                "hmmmAM/PM",
                 LocalTime.of(12, 58, 59),
                 "1258QAM"
         );
     }
 
     @Test
-    public void testFormatterHMmmAmpm2() {
+    public void testFormatterHMmmAmpm23Upper() {
         this.formatAndCheck4(
-                "hmmmam/pm",
+                "hmmmAM/PM",
                 LocalTime.of(23, 58, 59),
                 "1158RPM"
         );
@@ -627,45 +645,72 @@ public final class SpreadsheetDateTimeFormatPatternTest extends SpreadsheetForma
     }
 
     @Test
-    public void testFormatterFormatASlashP() {
+    public void testFormatterFormatASlashPLower() {
         this.formatAndCheck4(
                 "a/p",
+                LocalTime.of(12, 58, 59, 123456789),
+                "qam"
+        );
+    }
+
+    @Test
+    public void testFormatterFormatASlashPLowerPM() {
+        this.formatAndCheck4(
+                "a/p",
+                LocalTime.of(23, 58, 59, 123456789),
+                "rpm"
+        );
+    }
+
+    @Test
+    public void testFormatterFormatAmpmLower() {
+        this.formatAndCheck4(
+                "am/pm",
+                LocalTime.of(12, 58, 59, 123456789),
+                "qam"
+        );
+    }
+
+    @Test
+    public void testFormatterFormatAmpmUpper() {
+        this.formatAndCheck4(
+                "AM/PM",
                 LocalTime.of(12, 58, 59, 123456789),
                 "QAM"
         );
     }
 
     @Test
-    public void testFormatterFormatA2() {
+    public void testFormatterFormatAmpm2Lower() {
         this.formatAndCheck4(
-                "a/p",
+                "am/pm",
+                LocalTime.of(23, 58, 59, 123456789),
+                "rpm"
+        );
+    }
+
+    @Test
+    public void testFormatterFormatAmpm2Upper() {
+        this.formatAndCheck4(
+                "AM/PM",
                 LocalTime.of(23, 58, 59, 123456789),
                 "RPM"
         );
     }
 
     @Test
-    public void testFormatterFormatAmpm() {
-        this.formatAndCheck4(
-                "am/pm",
-                LocalTime.of(12, 58, 59, 123456789),
-                "QAM"
-        );
-    }
-
-    @Test
-    public void testFormatterFormatAmpm2() {
-        this.formatAndCheck4(
-                "am/pm",
-                LocalTime.of(23, 58, 59, 123456789),
-                "RPM"
-        );
-    }
-
-    @Test
-    public void testFormatterFormatHhmmAm() {
+    public void testFormatterFormatHhmmAmLower() {
         this.formatAndCheck4(
                 "hhmma/p",
+                LocalTime.of(12, 58, 59, 123456789),
+                "1258qam"
+        );
+    }
+
+    @Test
+    public void testFormatterFormatHhmmAmUpper() {
+        this.formatAndCheck4(
+                "hhmmA/P",
                 LocalTime.of(12, 58, 59, 123456789),
                 "1258QAM"
         );

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
@@ -107,7 +107,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
         this.localePatternFormatAndCheck(
                 SpreadsheetPattern.dateTimeFormatPatternLocale(EN_AU),
                 LocalDateTime.of(2000, 12, 31, 12, 58),
-                "Sunday, 31 December 2000 at 12:58:00 pm"
+                "Sunday, 31 December 2000 at 12:58:00 PM"
         );
     }
 
@@ -116,7 +116,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
         this.localePatternFormatAndCheck(
                 SpreadsheetPattern.timeFormatPatternLocale(EN_AU),
                 LocalTime.of(12, 58, 59),
-                "12:58:59 pm"
+                "12:58:59 PM"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeFormatPatternTest.java
@@ -249,7 +249,7 @@ public final class SpreadsheetTimeFormatPatternTest extends SpreadsheetFormatPat
         this.formatAndCheck2(
                 "hmmma/p",
                 LocalTime.of(12, 58, 59),
-                "1258QAM"
+                "1258qam"
         );
     }
 
@@ -258,7 +258,16 @@ public final class SpreadsheetTimeFormatPatternTest extends SpreadsheetFormatPat
         this.formatAndCheck2(
                 "hmmma/p",
                 LocalTime.of(23, 58, 59),
-                "1158RPM"
+                "1158rpm"
+        );
+    }
+
+    @Test
+    public void testFormatterHMmmABigP() {
+        this.formatAndCheck2(
+                "hmmma/P",
+                LocalTime.of(12, 58, 59),
+                "1258qam"
         );
     }
 
@@ -267,7 +276,7 @@ public final class SpreadsheetTimeFormatPatternTest extends SpreadsheetFormatPat
         this.formatAndCheck2(
                 "hmmmam/pm",
                 LocalTime.of(12, 58, 59),
-                "1258QAM"
+                "1258qam"
         );
     }
 
@@ -276,7 +285,7 @@ public final class SpreadsheetTimeFormatPatternTest extends SpreadsheetFormatPat
         this.formatAndCheck2(
                 "hmmmam/pm",
                 LocalTime.of(23, 58, 59),
-                "1158RPM"
+                "1158rpm"
         );
     }
 


### PR DESCRIPTION
- Case of output ampm matches case of pattern.
- single 'a' or 'p' results in only first letter of am/pm appearing in formatted text.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1316
- time pattern "a/p" capitalisation