### PR TITLE
TextSpreadsheetFormatter color formatting support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatter.java
@@ -49,11 +49,16 @@ final class TextSpreadsheetFormatter extends SpreadsheetFormatter3<SpreadsheetFo
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context) {
+    Optional<SpreadsheetText> format0(final Object value,
+                                      final SpreadsheetFormatterContext context) {
         return this.canFormat(value, context) ?
-                Optional.of(TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.format(this.token,
-                        context.convertOrFail(value, String.class),
-                        context)) :
+                Optional.of(
+                        TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.format(
+                                this.token,
+                                context.convertOrFail(value, String.class),
+                                context
+                        )
+                ) :
                 Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
@@ -17,6 +17,9 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.color.Color;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatColorNameParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatColorNumberParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatEscapeParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserTokenVisitor;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatQuotedTextParserToken;
@@ -25,6 +28,8 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextLiteralParser
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextPlaceholderParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatUnderscoreParserToken;
+
+import java.util.Optional;
 
 /**
  * A {@link SpreadsheetFormatParserTokenVisitor} is used exclusively by {@link SpreadsheetFormatter#format(Object, SpreadsheetFormatterContext)}
@@ -38,7 +43,10 @@ final class TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor extends 
     static SpreadsheetText format(final SpreadsheetFormatTextParserToken token, final String value, final SpreadsheetFormatterContext context) {
         final TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor visitor = new TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor(value, context);
         visitor.accept(token);
-        return SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, visitor.text.toString());
+        return SpreadsheetText.with(
+                visitor.color,
+                visitor.text.toString()
+        );
     }
 
     /**
@@ -48,6 +56,20 @@ final class TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor extends 
         super();
         this.context = context;
         this.value = value;
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatColorNameParserToken token) {
+        this.color = this.context.colorName(
+                token.colorName()
+        );
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatColorNumberParserToken token) {
+        this.color = this.context.colorNumber(
+                token.value()
+        );
     }
 
     @Override
@@ -101,6 +123,8 @@ final class TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor extends 
      * Aggregates the formatted output text.
      */
     private final StringBuilder text = new StringBuilder();
+
+    private Optional<Color> color = SpreadsheetText.WITHOUT_COLOR;
 
     @Override
     public String toString() {

--- a/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
@@ -19,14 +19,19 @@ package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
+import walkingkooka.color.Color;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContext;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.text.cursor.parser.Parser;
 
+import java.util.Optional;
+
 public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3TestCase<TextSpreadsheetFormatter, SpreadsheetFormatTextParserToken> {
 
     private final static String TEXT = "Abc123";
+
+    private final static Color RED = Color.parse("#FF0000");
 
     @Test
     public void testPlaceholder() {
@@ -74,6 +79,36 @@ public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3Tes
                 TEXT + "B");
     }
 
+    @Test
+    public void testColorNameAndTextPlaceholder() {
+        this.parseFormatAndCheck(
+                "[RED]@",
+                TEXT,
+                new TestSpreadsheetFormatterContext() {
+
+                },
+                SpreadsheetText.with(
+                        Optional.of(RED),
+                        TEXT
+                )
+        );
+    }
+
+    @Test
+    public void testColorNumberAndTextPlaceholder() {
+        this.parseFormatAndCheck(
+                "[color44]@",
+                TEXT,
+                new TestSpreadsheetFormatterContext() {
+
+                },
+                SpreadsheetText.with(
+                        Optional.of(RED),
+                        TEXT
+                )
+        );
+    }
+
     private void parseFormatAndCheck(final String pattern,
                                      final String value,
                                      final String text) {
@@ -84,13 +119,13 @@ public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3Tes
                                      final String value,
                                      final SpreadsheetFormatterContext context,
                                      final String text) {
-        this.parseFormatAndCheck0(pattern, value, context, SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, text));
+        this.parseFormatAndCheck(pattern, value, context, SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, text));
     }
 
-    private void parseFormatAndCheck0(final String pattern,
-                                      final String value,
-                                      final SpreadsheetFormatterContext context,
-                                      final SpreadsheetText text) {
+    private void parseFormatAndCheck(final String pattern,
+                                     final String value,
+                                     final SpreadsheetFormatterContext context,
+                                     final SpreadsheetText text) {
         this.formatAndCheck(this.createFormatter(pattern), value, context, text);
     }
 
@@ -126,7 +161,7 @@ public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3Tes
         return new TestSpreadsheetFormatterContext();
     }
 
-    static class TestSpreadsheetFormatterContext extends FakeSpreadsheetFormatterContext {
+    class TestSpreadsheetFormatterContext extends FakeSpreadsheetFormatterContext {
 
         TestSpreadsheetFormatterContext() {
             super();
@@ -149,6 +184,30 @@ public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3Tes
                             value,
                             target
                     );
+        }
+
+        @Override
+        public Optional<Color> colorName(final SpreadsheetColorName name) {
+            checkEquals(
+                    SpreadsheetColorName.with("red"),
+                    name,
+                    "colorName"
+            );
+            return Optional.of(
+                    RED
+            );
+        }
+
+        @Override
+        public Optional<Color> colorNumber(final int number) {
+            checkEquals(
+                    44,
+                    number,
+                    "colorNumber"
+            );
+            return Optional.of(
+                    RED
+            );
         }
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2616
- TextSpreadsheetFormatter parses and saves Color within pattern but ignores when formatting.