### PR TITLE
SpreadsheetFormatParsers.text character literals

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
@@ -164,6 +164,17 @@ final class SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer im
         );
     }
 
+    private static ParserToken transformTextCharacter(final ParserToken token,
+                                                      final SpreadsheetFormatParserContext context) {
+        final String text = token.text();
+        return SpreadsheetFormatParserToken.textLiteral(
+                text,
+                text
+        );
+    }
+
+    private static final EbnfIdentifierName TEXT_CHARACTER_IDENTIFIER = EbnfIdentifierName.with("TEXT_CHARACTER");
+
     private static ParserToken transformTime(final ParserToken token,
                                              final SpreadsheetFormatParserContext context) {
         return flat(
@@ -251,6 +262,7 @@ final class SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer im
         identifierToTransform.put(SpreadsheetFormatParsers.GENERAL_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformGeneral);
 
         identifierToTransform.put(SpreadsheetFormatParsers.TEXT_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformText);
+        identifierToTransform.put(TEXT_CHARACTER_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformTextCharacter);
 
         this.identifierToTransform = identifierToTransform;
     }

--- a/src/main/resources/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
+++ b/src/main/resources/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
@@ -135,6 +135,6 @@ TEXT_WITH_STAR                = [{ TEXT_COMPONENT }],
 
 TEXT_WITHOUT_STAR             = [{ TEXT_COMPONENT }];
 
-TEXT_COMPONENT                = COLOR | DATETIME_TEXT_LITERAL | ESCAPE | QUOTED | TEXT_PLACEHOLDER | UNDERSCORE;
+TEXT_COMPONENT                = COLOR | TEXT_CHARACTER | ESCAPE | QUOTED | TEXT_PLACEHOLDER | UNDERSCORE;
 
-
+TEXT_CHARACTER                = { ' ' | '<' | '>' | '=' | '!' | '$' | '-' | '+' | '(' | ')' | '%' | '#' | '&' | '/' | ',' | ':' };

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
@@ -287,7 +287,14 @@ public abstract class SpreadsheetFormatParserTestCase {
     }
 
     static SpreadsheetFormatParserToken textLiteral(final char c) {
-        return SpreadsheetFormatParserToken.textLiteral("" + c, "" + c);
+        return textLiteral("" + c);
+    }
+
+    static SpreadsheetFormatParserToken textLiteral(final String text) {
+        return SpreadsheetFormatParserToken.textLiteral(
+                text,
+                text
+        );
     }
 
     static SpreadsheetFormatParserToken thousands() {

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
@@ -2665,11 +2665,6 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     // text........................................................................................................
 
     @Test
-    public void testTextTextDigitFails() {
-        this.textParseThrows(digit());
-    }
-
-    @Test
     public void testTextTextDigitZeroFails() {
         this.textParseThrows(digitZero());
     }
@@ -2729,42 +2724,98 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     // text literals
 
     @Test
-    public void testTextTextLiteralDollar() {
-        this.textParseAndCheck(textLiteralDollar());
+    public void testTextDollar() {
+        this.textParseAndCheck(
+                textLiteralDollar()
+        );
     }
 
     @Test
-    public void testTextTextLiteralMinusSign() {
-        this.textParseAndCheck(textLiteralMinus());
+    public void testTextMinusSign() {
+        this.textParseAndCheck(
+                textLiteralMinus()
+        );
     }
 
     @Test
-    public void testTextTextLiteralPlusSign() {
-        this.textParseAndCheck(textLiteralPlus());
+    public void testTextPlusSign() {
+        this.textParseAndCheck(
+                textLiteralPlus()
+        );
     }
 
     @Test
-    public void testTextTextLiteralSlash() {
-        this.textParseAndCheck(textLiteralSlash());
+    public void testTextSlash() {
+        this.textParseAndCheck(
+                textLiteralSlash()
+        );
     }
 
     @Test
-    public void testTextTextLiteralOpenParens() {
-        this.textParseAndCheck(textLiteralOpenParens());
+    public void testTextOpenParens() {
+        this.textParseAndCheck(
+                textLiteralOpenParens()
+        );
     }
 
     @Test
-    public void testTextTextLiteralCloseParens() {
-        this.textParseAndCheck(textLiteralCloseParens());
+    public void testTextCloseParens() {
+        this.textParseAndCheck(
+                textLiteralCloseParens()
+        );
     }
 
     @Test
-    public void testTextTextLiteralColon() {
-        this.textParseAndCheck(textLiteralColon());
+    public void testTextColon() {
+        this.textParseAndCheck(
+                textLiteral(':')
+        );
     }
 
     @Test
-    public void testTextTextLiteralSpace() {
+    public void testTextEqualsSign() {
+        this.textParseAndCheck(
+                textLiteral('=')
+        );
+    }
+
+    @Test
+    public void testTextGreaterThanEquals() {
+        this.textParseAndCheck(
+                textLiteral('>')
+        );
+    }
+
+    @Test
+    public void testTextGreaterThanEqualsSign() {
+        this.textParseAndCheck(
+                textLiteral(">=")
+        );
+    }
+
+    @Test
+    public void testTextLessThan() {
+        this.textParseAndCheck(
+                textLiteral('<')
+        );
+    }
+
+    @Test
+    public void testTextLessThanEqualsSign() {
+        this.textParseAndCheck(
+                textLiteral("<=")
+        );
+    }
+
+    @Test
+    public void testTextNotEqualsSign() {
+        this.textParseAndCheck(
+                textLiteral("!=")
+        );
+    }
+
+    @Test
+    public void testTextSpace() {
         this.textParseAndCheck(textLiteralSpace());
     }
 
@@ -2796,36 +2847,6 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     @Test
     public void testTextUnderscoreUnderscore() {
         this.textParseAndCheck(underscore(), underscore2());
-    }
-
-    @Test
-    public void testTextEqualsFails() {
-        this.textParseThrows(equalsSymbol());
-    }
-
-    @Test
-    public void testTextGreaterThanFails() {
-        this.textParseThrows(greaterThan());
-    }
-
-    @Test
-    public void testTextGreaterThanEqualsFails() {
-        this.textParseThrows(greaterThanEquals());
-    }
-
-    @Test
-    public void testTextLessThanFails() {
-        this.textParseThrows(lessThan());
-    }
-
-    @Test
-    public void testTextLessThanEqualsFails() {
-        this.textParseThrows(lessThanEquals());
-    }
-
-    @Test
-    public void testTextNotEqualsFails() {
-        this.textParseThrows(notEquals());
     }
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2635
- SpreadsheetPattern.text() needs to be updated to support single character literals like '<'