### PR TITLE
SpreadsheetPattern.text remove unnecessary format wrapping

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
@@ -577,7 +577,7 @@ abstract public class SpreadsheetPattern<V> implements Value<V>, TreePrintable {
         );
     }
 
-    private final static Parser<SpreadsheetFormatParserContext> TEXT_FORMAT_PARSER = formatParser(SpreadsheetFormatParsers.text().cast());
+    private final static Parser<SpreadsheetFormatParserContext> TEXT_FORMAT_PARSER = SpreadsheetFormatParsers.text();
 
     /**
      * Transforms the tokens into a {@link SpreadsheetTextFormatPattern}


### PR DESCRIPTION
- text parser already handles multiple patterns no need to call format which repeats parser etc.