### PR TITLE
SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor separato…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor.java
@@ -352,11 +352,9 @@ final class SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor extends
         );
     }
 
-//    final BiFunction<ParserToken, ParserContext, ParserToken> second(final )
-
     @Override
     protected void visit(final SpreadsheetFormatSeparatorSymbolParserToken token) {
-        this.literal(token);
+        // consume but ignore separator.
     }
 
     @Override
@@ -424,7 +422,6 @@ final class SpreadsheetParsePatterns2SpreadsheetFormatParserTokenVisitor extends
                 SpreadsheetParserToken::year
         );
     }
-
 
     // helpers.........................................................................................................
 


### PR DESCRIPTION
…r ignored fix

- Previously a pattern separator ";" was turned into a String parser with ";".