### PR TITLE
ChainSpreadsheetFormatter.toString() pattern separator between format…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatter.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.format;
 
 import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 
 import java.util.List;
 import java.util.Objects;
@@ -103,6 +104,8 @@ final class ChainSpreadsheetFormatter implements SpreadsheetFormatter {
 
     @Override
     public String toString() {
-        return this.formatters.toString();
+        return this.formatters.stream()
+                .map(SpreadsheetFormatter::toString)
+                .collect(Collectors.joining(SpreadsheetPattern.SEPARATOR));
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatterTest.java
@@ -106,7 +106,10 @@ public final class ChainSpreadsheetFormatterTest extends SpreadsheetFormatterTes
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createFormatter(), Lists.of(VALUE1, VALUE2).toString());
+        this.toStringAndCheck(
+                this.createFormatter(),
+                VALUE1 + ";" + VALUE2
+        );
     }
 
     // helpers..........................................................................................................


### PR DESCRIPTION
…ters

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2658
- SpreadsheetFormatters.chain.toString should return pattern,separator,pattern rather than list of patterns.toString()