### PR TITLE
ConditionalSpreadsheetFormatter.canFormat calls Condition Predicate

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatter.java
@@ -53,7 +53,9 @@ final class ConditionSpreadsheetFormatter extends SpreadsheetFormatter3<Spreadsh
     @Override
     public boolean canFormat(final Object value,
                              final SpreadsheetFormatterContext context) throws SpreadsheetFormatException {
-        return this.formatter.canFormat(value, context);
+        return context.convert(value, BigDecimal.class)
+                .mapLeft(l -> this.predicate.test(l) && this.formatter.canFormat(value, context))
+                .orElseLeft(false);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
@@ -81,7 +81,7 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
                 LocalTime.of(12, 58, 59),
                 123L,
                 (short) 123,
-                "abc123",
+                "9999",
                 this);
 
         final F formatter = this.createFormatter();

--- a/src/test/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatterTest.java
@@ -200,7 +200,7 @@ public final class ConditionSpreadsheetFormatterTest extends SpreadsheetFormatte
 
     @Override
     public String value() {
-        return "Text123";
+        return "999";
     }
 
     @Override
@@ -234,12 +234,25 @@ public final class ConditionSpreadsheetFormatterTest extends SpreadsheetFormatte
             @Override
             public <T> Either<T, String> convert(final Object value,
                                                  final Class<T> target) {
-                return this.converter.convert(value,
+                if (value instanceof String && BigDecimal.class == target) {
+                    return this.successfulConversion(
+                            new BigDecimal((String) value),
+                            target
+                    );
+                }
+
+                return this.converter.convert(
+                        value,
                         target,
-                        ExpressionNumberConverterContexts.basic(Converters.fake(),
-                                ConverterContexts.basic(Converters.fake(),
-                                        DateTimeContexts.fake(), this),
-                                ExpressionNumberKind.DEFAULT)
+                        ExpressionNumberConverterContexts.basic(
+                                Converters.fake(),
+                                ConverterContexts.basic(
+                                        Converters.fake(),
+                                        DateTimeContexts.fake(),
+                                        this
+                                ),
+                                ExpressionNumberKind.DEFAULT
+                        )
                 );
             }
 


### PR DESCRIPTION
- Previously the Predicate aka Condition was only called in format.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2660
- ConditionSpreadsheetFormatter.canFormat should use Predicate