### PR TITLE
SpreadsheetFormatParsers.textFormat() SequenceParserToken wrapper

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
@@ -393,7 +393,7 @@ public final class SpreadsheetFormatParsers implements PublicStaticHelper {
     }
 
     private final static Parser<SpreadsheetFormatParserContext> TEXT_FORMAT_PARSER;
-    static final EbnfIdentifierName TEXT_FORMAT_IDENTIFIER = EbnfIdentifierName.with("TEXT_FORMAT");
+    static final EbnfIdentifierName TEXT_FORMAT = EbnfIdentifierName.with("TEXT_FORMAT");
 
     private static void text(final Map<EbnfIdentifierName, Parser<SpreadsheetFormatParserContext>> predefined) {
         predefined.put(QUOTED_IDENTIFIER, QUOTED);
@@ -570,7 +570,7 @@ public final class SpreadsheetFormatParsers implements PublicStaticHelper {
             GENERAL_PARSER = parsers.get(GENERAL_IDENTIFIER);
             NUMBER_PARSER = parsers.get(EbnfIdentifierName.with("NUMBER"));
 
-            TEXT_FORMAT_PARSER = parsers.get(TEXT_FORMAT_IDENTIFIER)
+            TEXT_FORMAT_PARSER = parsers.get(TEXT_FORMAT)
                     .orFailIfCursorNotEmpty(ParserReporters.basic());
 
             TIME_FORMAT_PARSER = parsers.get(TIME_FORMAT)

--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
@@ -167,6 +167,8 @@ final class SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer im
         );
     }
 
+    private static final EbnfIdentifierName TEXT_IDENTIFIER = EbnfIdentifierName.with("TEXT");
+
     private static ParserToken transformTextCharacter(final ParserToken token,
                                                       final SpreadsheetFormatParserContext context) {
         final String text = token.text();
@@ -273,7 +275,10 @@ final class SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer im
 
         identifierToTransform.put(SpreadsheetFormatParsers.GENERAL_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformGeneral);
 
-        identifierToTransform.put(SpreadsheetFormatParsers.TEXT_FORMAT_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformText);
+        identifierToTransform.put(TEXT_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformText);
+        identifierToTransform.put(SpreadsheetFormatParsers.TEXT_FORMAT, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::flat);
+        identifierToTransform.put(SpreadsheetFormatParsers.TIME_PARSE, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::flat);
+
         identifierToTransform.put(TEXT_CHARACTER_IDENTIFIER, SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer::transformTextCharacter);
 
         this.identifierToTransform = identifierToTransform;

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
@@ -905,7 +905,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
                         dateParser(),
                         dateTimeFormatter(),
                         dateTimeParser(),
-                        numberOrTextFormatter(
+                        numberFormatter(
                                 "#",
                                 SpreadsheetFormatParsers.number(),
                                 SpreadsheetFormatNumberParserToken.class,
@@ -1225,7 +1225,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     }
 
     private SpreadsheetFormatter numberFormatter() {
-        return numberOrTextFormatter("\\N #.#",
+        return numberFormatter("\\N #.#",
                 SpreadsheetFormatParsers.number(),
                 SpreadsheetFormatNumberParserToken.class,
                 SpreadsheetFormatters::number
@@ -1237,10 +1237,12 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     }
 
     private SpreadsheetFormatter textFormatter() {
-        return numberOrTextFormatter("@\"" + TEXT_SUFFIX + "\"",
+        return formatter(
+                "@\"" + TEXT_SUFFIX + "\"",
                 SpreadsheetFormatParsers.textFormat(),
                 SpreadsheetFormatTextParserToken.class,
-                SpreadsheetFormatters::text);
+                SpreadsheetFormatters::text
+        );
     }
 
     private final static String TEXT_SUFFIX = "text-literal-123";
@@ -1278,10 +1280,10 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     }
 
     // https://github.com/mP1/walkingkooka-spreadsheet/issues/2662
-    private <T extends SpreadsheetFormatParserToken> SpreadsheetFormatter numberOrTextFormatter(final String pattern,
-                                                                                                final Parser<SpreadsheetFormatParserContext> parser,
-                                                                                                final Class<T> token,
-                                                                                                final Function<T, SpreadsheetFormatter> formatterFactory) {
+    private <T extends SpreadsheetFormatParserToken> SpreadsheetFormatter numberFormatter(final String pattern,
+                                                                                          final Parser<SpreadsheetFormatParserContext> parser,
+                                                                                          final Class<T> token,
+                                                                                          final Function<T, SpreadsheetFormatter> formatterFactory) {
         return parser.orFailIfCursorNotEmpty(ParserReporters.basic())
                 .parse(TextCursors.charSequence(pattern), SpreadsheetFormatParserContexts.basic())
                 .map(t -> t.cast(token))

--- a/src/test/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatterTest.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContext;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.SequenceParserToken;
 
 import java.util.Optional;
 
@@ -204,9 +205,12 @@ public final class ColorSpreadsheetFormatterTest extends SpreadsheetFormatter3Te
     private SpreadsheetFormatter textFormatter() {
         return SpreadsheetFormatters.text(
                 this.parsePatternOrFail(
-                        SpreadsheetFormatParsers.textFormat(),
-                        TEXT_PATTERN
-                ).cast(SpreadsheetFormatTextParserToken.class)
+                                SpreadsheetFormatParsers.textFormat(),
+                                TEXT_PATTERN
+                        ).cast(SequenceParserToken.class)
+                        .value()
+                        .get(0)
+                        .cast(SpreadsheetFormatTextParserToken.class)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter3TestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter3TestCase.java
@@ -18,7 +18,6 @@
 package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.Cast;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContext;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContexts;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
@@ -67,13 +66,11 @@ public abstract class SpreadsheetFormatter3TestCase<F extends SpreadsheetFormatt
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     final ParserToken parsePatternOrFail(final Parser<SpreadsheetFormatParserContext> parser,
                                          final String pattern) {
-        return Cast.to(
-                parser.orFailIfCursorNotEmpty(ParserReporters.basic())
-                        .parse(
-                                TextCursors.charSequence(pattern),
-                                SpreadsheetFormatParserContexts.basic())
-                        .get()
-        );
+        return parser.orFailIfCursorNotEmpty(ParserReporters.basic())
+                .parse(
+                        TextCursors.charSequence(pattern),
+                        SpreadsheetFormatParserContexts.basic())
+                .get();
     }
 
     abstract Parser<SpreadsheetFormatParserContext> parser();

--- a/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContext;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParsers;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.SequenceParserToken;
 
 import java.util.Optional;
 
@@ -134,9 +135,9 @@ public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatter3Tes
         return "@";
     }
 
-    @Override
     Parser<SpreadsheetFormatParserContext> parser() {
-        return SpreadsheetFormatParsers.textFormat();
+        return SpreadsheetFormatParsers.textFormat()
+                .transform((v, c) -> v.cast(SequenceParserToken.class).value().get(0));
     }
 
     //toString .......................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
@@ -288,6 +288,15 @@ public abstract class SpreadsheetFormatParserTestCase {
         return SpreadsheetFormatParserToken.star('#', "*#");
     }
 
+    static SpreadsheetFormatTextParserToken text(final SpreadsheetFormatParserToken... tokens) {
+        final List<ParserToken> list = Lists.of(tokens);
+
+        return SpreadsheetFormatParserToken.text(
+                list,
+                ParserToken.text(list)
+        );
+    }
+
     static SpreadsheetFormatParserToken textPlaceholder() {
         return SpreadsheetFormatParserToken.textPlaceholder("@", "@");
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
@@ -4743,17 +4743,23 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testTextFormatTextDigitZeroFails() {
-        this.textFormatParseThrows(digitZero());
+        this.textFormatParseThrows(
+                digitZero()
+        );
     }
 
     @Test
     public void testTextFormatTextDigitSpaceFails() {
-        this.textFormatParseThrows(digitSpace());
+        this.textFormatParseThrows(
+                digitSpace()
+        );
     }
 
     @Test
     public void testTextFormatLetterFails() {
-        this.textFormatParseThrows(textLiteral('A'));
+        this.textFormatParseThrows(
+                textLiteral('A')
+        );
     }
 
     @Test
@@ -4763,22 +4769,36 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testTextFormatGeneraFailsl() {
-        this.textFormatParseThrows(generalSymbol());
+        this.textFormatParseThrows(
+                generalSymbol()
+        );
     }
 
     @Test
     public void testTextFormatEscaped() {
-        this.textFormatParseAndCheck(escape());
+        this.textFormatParseAndCheck(
+                text(
+                        escape()
+                )
+        );
     }
 
     @Test
     public void testTextFormatStar() {
-        this.textFormatParseAndCheck(star());
+        this.textFormatParseAndCheck(
+                text(
+                        star()
+                )
+        );
     }
 
     @Test
     public void testTextFormatStar2() {
-        this.textFormatParseAndCheck(star2());
+        this.textFormatParseAndCheck(
+                text(
+                        star2()
+                )
+        );
     }
 
     @Test
@@ -4803,142 +4823,215 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     @Test
     public void testTextFormatDollar() {
         this.textFormatParseAndCheck(
-                textLiteralDollar()
+                text(
+                        textLiteralDollar()
+                )
         );
     }
 
     @Test
     public void testTextFormatMinusSign() {
         this.textFormatParseAndCheck(
-                textLiteralMinus()
+                text(
+                        textLiteralMinus()
+                )
         );
     }
 
     @Test
     public void testTextFormatPlusSign() {
         this.textFormatParseAndCheck(
-                textLiteralPlus()
+                text(
+                        textLiteralPlus()
+                )
         );
     }
 
     @Test
     public void testTextFormatSlash() {
         this.textFormatParseAndCheck(
-                textLiteralSlash()
+                text(
+                        textLiteralSlash()
+                )
         );
     }
 
     @Test
     public void testTextFormatOpenParens() {
         this.textFormatParseAndCheck(
-                textLiteralOpenParens()
+                text(
+                        textLiteralOpenParens()
+                )
         );
     }
 
     @Test
     public void testTextFormatCloseParens() {
         this.textFormatParseAndCheck(
-                textLiteralCloseParens()
+                text(
+                        textLiteralCloseParens()
+                )
         );
     }
 
     @Test
     public void testTextFormatColon() {
         this.textFormatParseAndCheck(
-                textLiteral(':')
+                text(
+                        textLiteral(':')
+                )
         );
     }
 
     @Test
     public void testTextFormatEqualsSign() {
         this.textFormatParseAndCheck(
-                textLiteral('=')
+                text(
+                        textLiteral('=')
+                )
         );
     }
 
     @Test
     public void testTextFormatGreaterThanEquals() {
         this.textFormatParseAndCheck(
-                textLiteral('>')
+                text(
+                        textLiteral('>')
+                )
         );
     }
 
     @Test
     public void testTextFormatGreaterThanEqualsSign() {
         this.textFormatParseAndCheck(
-                textLiteral(">=")
+                text(
+                        textLiteral(">=")
+                )
         );
     }
 
     @Test
     public void testTextFormatLessThan() {
         this.textFormatParseAndCheck(
-                textLiteral('<')
+                text(
+                        textLiteral('<')
+                )
         );
     }
 
     @Test
     public void testTextFormatLessThanEqualsSign() {
         this.textFormatParseAndCheck(
-                textLiteral("<=")
+                text(
+                        textLiteral("<=")
+                )
         );
     }
 
     @Test
     public void testTextFormatNotEqualsSign() {
         this.textFormatParseAndCheck(
-                textLiteral("!=")
+                text(
+                        textLiteral("!=")
+                )
         );
     }
 
     @Test
     public void testTextFormatSpace() {
-        this.textFormatParseAndCheck(textLiteralSpace());
+        this.textFormatParseAndCheck(
+                text(
+                        textLiteralSpace()
+                )
+        );
     }
 
     @Test
     public void testTextFormatTextPlaceholder() {
-        this.textFormatParseAndCheck(textPlaceholder());
+        this.textFormatParseAndCheck(
+                text(
+                        textPlaceholder()
+                )
+        );
     }
 
     @Test
     public void testTextFormatTextPlaceholder2() {
-        this.textFormatParseAndCheck(textPlaceholder(), textPlaceholder());
+        this.textFormatParseAndCheck(
+                text(
+                        textPlaceholder(),
+                        textPlaceholder()
+                )
+        );
     }
 
     @Test
     public void testTextFormatTextQuoted() {
-        this.textFormatParseAndCheck(quotedText());
+        this.textFormatParseAndCheck(
+                text(
+                        quotedText()
+                )
+        );
     }
 
     @Test
     public void testTextFormatUnderscore() {
-        this.textFormatParseAndCheck(underscore());
+        this.textFormatParseAndCheck(
+                text(
+                        underscore()
+                )
+        );
     }
 
     @Test
     public void testTextFormatUnderscore2() {
-        this.textFormatParseAndCheck(underscore());
+        this.textFormatParseAndCheck(
+                text(
+                        underscore()
+                )
+        );
     }
 
     @Test
     public void testTextFormatUnderscoreUnderscore() {
-        this.textFormatParseAndCheck(underscore(), underscore2());
+        this.textFormatParseAndCheck(
+                text(
+                        underscore(),
+                        underscore2()
+                )
+        );
     }
 
     @Test
     public void testTextFormatAll() {
-        this.textFormatParseAndCheck(textLiteralSpace(), quotedText(), textPlaceholder(), underscore());
+        this.textFormatParseAndCheck(
+                text(
+                        textLiteralSpace(),
+                        quotedText(),
+                        textPlaceholder(),
+                        underscore()
+                )
+        );
     }
 
     @Test
     public void testTextFormatColorQuotedText() {
-        this.textFormatParseAndCheck(color(), quotedText());
+        this.textFormatParseAndCheck(
+                text(
+                        color(),
+                        quotedText()
+                )
+        );
     }
 
     @Test
     public void testTextFormatQuotedTextColor() {
-        this.textFormatParseAndCheck(quotedText(), color());
+        this.textFormatParseAndCheck(
+                text(
+                        quotedText(),
+                        color()
+                )
+        );
     }
 
     @Test
@@ -5043,9 +5136,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionNotEqualsTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionNotEquals(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5053,9 +5150,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionEqualsTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionEquals(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5063,9 +5164,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionGreaterThanTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionGreaterThan(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5073,9 +5178,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionGreaterThanEqualsTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionGreaterThanEquals(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5083,9 +5192,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionLessThanTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionLessThan(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5093,9 +5206,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionLessThanEqualsTextPlaceholderPatternSeparatorTextPlaceholder() {
         this.textFormatParseAndCheck(
                 conditionLessThanEquals(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder()
+                text(
+                        textPlaceholder()
+                )
         );
     }
 
@@ -5112,18 +5229,24 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionColorPatternSeparatorColorPattern() {
         this.textFormatParseAndCheck(
                 conditionEquals(),
-                color(),
-                textPlaceholder(),
+                text(
+                        color(),
+                        textPlaceholder()
+                ),
                 separator(),
-                color(),
-                textPlaceholder()
+                text(
+                        color(),
+                        textPlaceholder()
+                )
         );
     }
 
     @Test
     public void testTextFormatPatternSeparator() {
         this.textFormatParseAndCheck(
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator()
         );
     }
@@ -5142,9 +5265,13 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatConditionPatternSeparatorPatternSeparator() {
         this.textFormatParseAndCheck(
                 conditionEquals(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator(),
-                textPlaceholder(),
+                text(
+                        textPlaceholder()
+                ),
                 separator()
         );
     }
@@ -5152,9 +5279,8 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     // text helpers......................................................................................................
 
     private void textFormatParseAndCheck(final SpreadsheetFormatParserToken... tokens) {
-        this.parseAndCheck3(
+        this.parseAndCheck2(
                 SpreadsheetFormatParsers.textFormat(),
-                SpreadsheetFormatParserToken::text,
                 tokens
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
@@ -201,11 +201,10 @@ public final class SpreadsheetTextFormatPatternTest extends SpreadsheetFormatPat
     }
 
     @Override
-    SpreadsheetFormatTextParserToken parseFormatParserToken(final String text) {
+    ParserToken parseFormatParserToken(final String text) {
         return SpreadsheetFormatParsers.textFormat()
                 .orFailIfCursorNotEmpty(ParserReporters.basic())
                 .parse(TextCursors.charSequence(text), SpreadsheetFormatParserContexts.basic())
-                .map(SpreadsheetFormatTextParserToken.class::cast)
                 .get();
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2650
- SpreadsheetFormatParserToken.textFormat only wrap a single pattern returning a Sequence of SpreadsheetFormatTextPatternParserToken