### PR TITLE
SpreadsheetMetadataPropertyName.isParseValueSupported & parseValue()

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -56,6 +56,7 @@ import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -447,7 +448,7 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
      */
     abstract void accept(final T value, final SpreadsheetMetadataVisitor visitor);
 
-    // HaUrlFragment....................................................................................................
+    // HasUrlFragment...................................................................................................
 
     @Override
     public final UrlFragment urlFragment() {
@@ -455,6 +456,26 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     }
 
     private final UrlFragment urlFragment;
+
+    /**
+     * Not all values may be represented by a {@link UrlFragment} which indicates that a property may have its value
+     * updated.
+     */
+    public abstract boolean isParseValueSupported();
+
+    public final T parseValue(final String value) {
+        Objects.requireNonNull(value, value);
+
+        return this.checkValue(
+                this.parseValue0(value)
+        );
+    }
+
+    abstract T parseValue0(final String value);
+
+    final T failParseValueUnsupported() {
+        throw new UnsupportedOperationException("UrlFragment not supported for " + CharSequences.quoteAndEscape(this.value()));
+    }
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.text.CharSequences;
+
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Optional;
@@ -65,5 +67,21 @@ abstract class SpreadsheetMetadataPropertyNameCharacter extends SpreadsheetMetad
     @Override
     final String compareToName() {
         return this.value();
+    }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final Character parseValue0(final String value) {
+        if (value.isEmpty() || value.length() > 1) {
+            throw new IllegalArgumentException("Invalid value " + CharSequences.quoteAndEscape(value) + " expected a single character");
+        }
+
+        return value.charAt(0);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameColor.java
@@ -54,4 +54,16 @@ abstract class SpreadsheetMetadataPropertyNameColor extends SpreadsheetMetadataP
     final Class<Color> type() {
         return Color.class;
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final Color parseValue0(final String value) {
+        return Color.parse(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
@@ -67,4 +67,16 @@ final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMet
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public Long parseValue0(final String value) {
+        return Long.parseLong(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDouble.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDouble.java
@@ -48,4 +48,16 @@ abstract class SpreadsheetMetadataPropertyNameDouble extends SpreadsheetMetadata
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final Double parseValue0(final String value) {
+        return Double.parseDouble(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
@@ -56,4 +56,16 @@ abstract class SpreadsheetMetadataPropertyNameEmailAddress extends SpreadsheetMe
     final String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public final EmailAddress parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
@@ -69,4 +69,16 @@ final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends Spreadsh
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public ExpressionNumberKind parseValue0(final String value) {
+        return ExpressionNumberKind.valueOf(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
@@ -79,4 +79,16 @@ final class SpreadsheetMetadataPropertyNameFrozenColumns extends SpreadsheetMeta
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetColumnReferenceRange parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
@@ -80,4 +80,16 @@ final class SpreadsheetMetadataPropertyNameFrozenRows extends SpreadsheetMetadat
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetRowReferenceRange parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
@@ -52,4 +52,16 @@ abstract class SpreadsheetMetadataPropertyNameInteger extends SpreadsheetMetadat
     final String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final Integer parseValue0(final String value) {
+        return Integer.parseInt(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
@@ -55,4 +55,16 @@ abstract class SpreadsheetMetadataPropertyNameLocalDateTime extends SpreadsheetM
     final String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final LocalDateTime parseValue0(final String value) {
+        return LocalDateTime.parse(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
@@ -67,4 +67,16 @@ final class SpreadsheetMetadataPropertyNameLocale extends SpreadsheetMetadataPro
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public Locale parseValue0(final String value) {
+        return Locale.forLanguageTag(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
@@ -68,4 +68,16 @@ final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetad
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public RoundingMode parseValue0(final String value) {
+        return RoundingMode.valueOf(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSelection.java
@@ -77,4 +77,16 @@ final class SpreadsheetMetadataPropertyNameSelection extends SpreadsheetMetadata
                 final SpreadsheetMetadataVisitor visitor) {
         visitor.visitSelection(value);
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetViewportSelection parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateFormatPattern extends 
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetDateFormatPattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseDateFormatPattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateParsePattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateParsePattern extends S
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetDateParsePattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseDateParsePattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern.java
@@ -71,4 +71,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeFormatPattern exte
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetDateTimeFormatPattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseDateTimeFormatPattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetDateTimeParsePattern exten
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetDateTimeParsePattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseDateTimeParsePattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
@@ -70,4 +70,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMeta
     String compareToName() {
         return ""; // ensure id always appears first.
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetId parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
@@ -70,4 +70,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMe
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetName parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetNumberFormatPattern extend
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetNumberFormatPattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseNumberFormatPattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetNumberParsePattern extends
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetNumberParsePattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseNumberParsePattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTextFormatPattern;
 
 import java.util.Locale;
@@ -68,5 +69,17 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTextFormatPattern extends 
     @Override
     String compareToName() {
         return this.value();
+    }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetTextFormatPattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseTextFormatPattern(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern.java
@@ -72,4 +72,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeFormatPattern extends 
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetTimeFormatPattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseTimeFormatPattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePattern.java
@@ -71,4 +71,16 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetTimeParsePattern extends S
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public SpreadsheetTimeParsePattern parseValue0(final String value) {
+        return SpreadsheetPattern.parseTimeParsePattern(value);
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
@@ -61,4 +61,16 @@ abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadata
     final String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public final boolean isParseValueSupported() {
+        return true;
+    }
+
+    @Override
+    public final String parseValue0(final String value) {
+        return value;
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
@@ -71,4 +71,16 @@ final class SpreadsheetMetadataPropertyNameStyle extends SpreadsheetMetadataProp
     String compareToName() {
         return this.value();
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public TextStyle parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportCell.java
@@ -77,4 +77,16 @@ final class SpreadsheetMetadataPropertyNameViewportCell extends SpreadsheetMetad
                 final SpreadsheetMetadataVisitor visitor) {
         visitor.visitViewportCell(value);
     }
+
+    // parseValue.......................................................................................................
+
+    @Override
+    public boolean isParseValueSupported() {
+        return false;
+    }
+
+    @Override
+    public SpreadsheetCellReference parseValue0(final String value) {
+        return this.failParseValueUnsupported();
+    }
 }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTest.java
@@ -22,8 +22,11 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.color.Color;
 import walkingkooka.naming.NameTesting;
+import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.FieldAttributes;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.text.CaseSensitivity;
 
 import java.lang.reflect.Field;
@@ -170,6 +173,99 @@ public final class SpreadsheetMetadataPropertyNameTest extends SpreadsheetMetada
         this.compareToArraySortAndCheck(
                 color3, color2, creator, spreadsheetId, color10,
                 spreadsheetId, color2, color3, color10, creator
+        );
+    }
+
+    // parseValue.......................................................................................................
+
+    @Test
+    public void testParseValueColor() {
+        final Color color = Color.parse("#123456");
+
+        this.checkEquals(
+                color,
+                SpreadsheetMetadataPropertyName.numberedColor(1)
+                        .parseValue(color.toString())
+        );
+    }
+
+    @Test
+    public void testParseValueCreatorFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.CREATOR,
+                EmailAddress.parse("creator@example.com")
+        );
+    }
+
+    @Test
+    public void testParseValueFrozenColumnFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.FROZEN_COLUMNS,
+                "A:B"
+        );
+    }
+
+    @Test
+    public void testParseValueModifiedByFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.MODIFIED_BY,
+                EmailAddress.parse("modified-by@example.com")
+        );
+    }
+
+    @Test
+    public void testParseValueFrozenRowFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.FROZEN_ROWS,
+                "1:2"
+        );
+    }
+
+    @Test
+    public void testParseValueSpreadsheetIdFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
+                SpreadsheetId.parse("123abc")
+        );
+    }
+
+    @Test
+    public void testParseValueSpreadsheetNameFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_NAME,
+                SpreadsheetName.with("SpreadsheetName123")
+        );
+    }
+
+    @Test
+    public void testParseValueStyleFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.STYLE,
+                "style"
+        );
+    }
+
+    @Test
+    public void testParseValueViewportCellFails() {
+        this.parseValueFails(
+                SpreadsheetMetadataPropertyName.VIEWPORT_CELL,
+                "!"
+        );
+    }
+
+    private <T> void parseValueFails(final SpreadsheetMetadataPropertyName<T> propertyName,
+                                     final T propertyValue) {
+        this.parseValueFails(
+                propertyName,
+                propertyValue.toString()
+        );
+    }
+
+    private void parseValueFails(final SpreadsheetMetadataPropertyName<?> propertyName,
+                                 final String propertyValue) {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> propertyName.parseValue(propertyValue)
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
+import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -145,6 +146,36 @@ public abstract class SpreadsheetMetadataPropertyNameTestCase<N extends Spreadsh
         this.checkEquals(Optional.ofNullable(value),
                 propertyName.extractLocaleValue(locale),
                 propertyName + " extractLocaleValue " + locale);
+    }
+
+    // parseValue.......................................................................................................
+
+    @Test
+    public final void testParseValue() {
+        final SpreadsheetMetadataPropertyName<V> propertyName = this.createName();
+
+        final String text;
+
+        final V value = this.propertyValue();
+        if (value instanceof HasUrlFragment) {
+            final HasUrlFragment has = (HasUrlFragment) value;
+            text = has.urlFragment().value();
+        } else {
+            text = String.valueOf(value);
+        }
+
+        if (propertyName.isParseValueSupported()) {
+            this.checkEquals(
+                    value,
+                    propertyName.parseValue(text),
+                    () -> "parseValue " + CharSequences.quoteAndEscape(text)
+            );
+        } else {
+            assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> propertyName.parseValue("")
+            );
+        }
     }
 
     // NameTesting......................................................................................................


### PR DESCRIPTION
- parseValue is only supported by some metadata properties.