### PR TITLE
SpreadsheetSelection testCell fixed test names

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -247,7 +247,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     // testCell.........................................................................................................
 
     @Test
-    public void testTestDifferentColumnFalse() {
+    public void testTestCellDifferentColumnFalse() {
         final SpreadsheetCellReference selection = this.createSelection();
         this.testCellAndCheck(
                 selection,
@@ -257,7 +257,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testTestDifferentRowFalse() {
+    public void testTestCellDifferentRowFalse() {
         final SpreadsheetCellReference selection = this.createSelection();
         this.testCellAndCheck(
                 selection,
@@ -267,7 +267,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testTestDifferentColumnKindTrue() {
+    public void testTestCellDifferentColumnKindTrue() {
         final SpreadsheetCellReference selection = this.createSelection();
         this.testCellAndCheck(
                 selection,
@@ -277,7 +277,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testTestDifferentRowKindTrue() {
+    public void testTestCellDifferentRowKindTrue() {
         final SpreadsheetCellReference selection = this.createSelection();
         final SpreadsheetRowReference row = selection.row();
         final SpreadsheetReferenceKind kind = row.referenceKind();

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceRangeTest.java
@@ -201,7 +201,7 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     // testCelll........................................................................................................
 
     @Test
-    public void testTestBefore() {
+    public void testTestCellBefore() {
         this.testCellAndCheck(
                 this.createSelection(),
                 SpreadsheetSelection.parseCell("A1"),
@@ -210,7 +210,7 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     }
 
     @Test
-    public void testTestLeft() {
+    public void testTestCellLeft() {
         this.testCellAndCheck(
                 this.createSelection(),
                 SpreadsheetSelection.parseCell("B1"),
@@ -219,7 +219,7 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     }
 
     @Test
-    public void testTestRight() {
+    public void testTestCellRight() {
         this.testCellAndCheck(
                 this.createSelection(),
                 SpreadsheetSelection.parseCell("D2"),
@@ -228,7 +228,7 @@ public final class SpreadsheetColumnReferenceRangeTest extends SpreadsheetColumn
     }
 
     @Test
-    public void testTestAfter() {
+    public void testTestCellAfter() {
         this.testCellAndCheck(
                 this.createSelection(),
                 SpreadsheetSelection.parseCell("E1"),

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -93,7 +93,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     }
 
     @Test
-    public void testTestDifferentColumnKindTrue() {
+    public void testTestCellDifferentColumnKindTrue() {
         final SpreadsheetColumnReference selection = this.createSelection();
         this.testCellAndCheck(
                 selection,

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceRangeTest.java
@@ -226,7 +226,7 @@ public final class SpreadsheetRowReferenceRangeTest extends SpreadsheetColumnOrR
     }
 
     @Test
-    public void testTestBelow() {
+    public void testTestCellBelow() {
         this.testCellAndCheck(
                 this.createSelection(),
                 SpreadsheetSelection.parseCell("E5"),

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -118,7 +118,7 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     // testCell.........................................................................................................
 
     @Test
-    public void testTestDifferentRowFalse() {
+    public void testTestCellDifferentRowFalse() {
         final SpreadsheetRowReference selection = this.createSelection();
 
         this.testCellAndCheck(
@@ -130,7 +130,7 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     }
 
     @Test
-    public void testTestDifferentRowKindTrue() {
+    public void testTestCellDifferentRowKindTrue() {
         final SpreadsheetRowReference selection = this.createSelection();
 
         this.testCellAndCheck(


### PR DESCRIPTION
- testTestXXX becomes testTestCellXXX.
- Should make SpreadsheetSelection.testCell tests distinct from any SpreadsheetSelection implements Predicate tests.