### PR TITLE
SpreadsheetSelection.toCellRange() was toCellRangeOrFail

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetSelectionToSpreadsheetSelectionConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetSelectionToSpreadsheetSelectionConverter.java
@@ -117,7 +117,7 @@ final class SpreadsheetSelectionToSpreadsheetSelectionConverter implements Conve
     }
 
     private static SpreadsheetCellRange cellToCellRange(final SpreadsheetCellReference cell) {
-        return cell.toCellRangeOrFail();
+        return cell.toCellRange();
     }
 
     private static SpreadsheetCellReference cellRangeToCell(final SpreadsheetCellRange range) {

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
@@ -1057,7 +1057,7 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
                     break;
                 case FORMAT_PATTERN_PROPERTY_STRING:
                     cells = patchFormatPattern(
-                            selection.toCellRangeOrFail(),
+                            selection.toCellRange(),
                             cells,
                             JsonNode.object()
                                     .set(FORMAT_PATTERN_PROPERTY, propertyAndValue),
@@ -1066,7 +1066,7 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
                     break;
                 case PARSE_PATTERN_PROPERTY_STRING:
                     cells = patchParsePattern(
-                            selection.toCellRangeOrFail(),
+                            selection.toCellRange(),
                             cells,
                             JsonNode.object()
                                     .set(PARSE_PATTERN_PROPERTY, propertyAndValue),
@@ -1078,7 +1078,7 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
                     break;
                 case STYLE_PROPERTY_STRING:
                     cells = patchStyle(
-                            selection.toCellRangeOrFail(),
+                            selection.toCellRange(),
                             cells,
                             propertyAndValue,
                             context

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -931,7 +931,7 @@ public abstract class SpreadsheetSelection implements HasUrlFragment,
                 .replace("Range", " Range");
     }
 
-    public final SpreadsheetCellRange toCellRangeOrFail() {
+    public final SpreadsheetCellRange toCellRange() {
         return this.toCellRange(LABEL_TO_CELL_RANGE_UOE)
                 .get(); // always works because Labels will throw UOE.
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeSpreadsheetSelectionVisitor.java
@@ -52,7 +52,7 @@ final class SpreadsheetSelectionToCellRangeSpreadsheetSelectionVisitor extends S
 
     @Override
     protected void visit(final SpreadsheetCellReference reference) {
-        this.cellRange = reference.cellRange(reference); // toCellRangeOrFail will result in StackOverflowError
+        this.cellRange = reference.cellRange(reference); // toCellRange will result in StackOverflowError
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/store/SpreadsheetLabelStore.java
@@ -67,7 +67,7 @@ public interface SpreadsheetLabelStore extends SpreadsheetStore<SpreadsheetLabel
      */
     default Optional<SpreadsheetCellRange> cellRange(final SpreadsheetExpressionReference reference) {
         return this.cellReferenceOrRange(reference)
-                .map(SpreadsheetCellReferenceOrRange::toCellRangeOrFail);
+                .map(SpreadsheetCellReferenceOrRange::toCellRange);
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -1181,7 +1181,7 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetCellReferenceOrRa
         final SpreadsheetCellRange range = SpreadsheetSelection.parseCellRange("C3:Z99");
 
         assertSame(
-                range.toCellRangeOrFail(),
+                range.toCellRange(),
                 range
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -579,7 +579,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     // testCellRange....................................................................................................
 
     @Test
-    public void testCellRangeNullFails() {
+    public void testToCellRangeNullFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> this.cell(1, 1)
@@ -588,7 +588,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testCellRangeOne() {
+    public void testToCellRangeOne() {
         final SpreadsheetCellReference lower = this.cell(1, 1);
         final SpreadsheetCellRange range = lower.cellRange(lower);
 
@@ -599,13 +599,13 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testCellRangeLeftTopRightBottom() {
+    public void testToCellRangeLeftTopRightBottom() {
         final int left = 1;
         final int top = 2;
         final int right = 3;
         final int bottom = 4;
 
-        this.toCellRangeOrFailAndCheck(
+        this.toCellRangeAndCheck(
                 this.cell(left, top),
                 this.cell(right, bottom),
                 left, top,
@@ -614,13 +614,13 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testCellRangeLeftBottomRightTop() {
+    public void testToCellRangeLeftBottomRightTop() {
         final int left = 1;
         final int top = 2;
         final int right = 3;
         final int bottom = 4;
 
-        this.toCellRangeOrFailAndCheck(
+        this.toCellRangeAndCheck(
                 this.cell(left, bottom),
                 this.cell(right, top),
                 left, top,
@@ -629,13 +629,13 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testCellRangeRightTopLeftBottom() {
+    public void testToCellRangeRightTopLeftBottom() {
         final int left = 1;
         final int top = 2;
         final int right = 3;
         final int bottom = 4;
 
-        this.toCellRangeOrFailAndCheck(
+        this.toCellRangeAndCheck(
                 this.cell(right, top),
                 this.cell(left, bottom),
                 left, top,
@@ -643,12 +643,12 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         );
     }
 
-    private void toCellRangeOrFailAndCheck(final SpreadsheetCellReference cell,
-                                           final SpreadsheetCellReference other,
-                                           final int left,
-                                           final int top,
-                                           final int right,
-                                           final int bottom) {
+    private void toCellRangeAndCheck(final SpreadsheetCellReference cell,
+                                     final SpreadsheetCellReference other,
+                                     final int left,
+                                     final int top,
+                                     final int right,
+                                     final int bottom) {
         final Range<SpreadsheetCellReference> expected = Range.greaterThanEquals(
                 this.cell(left, top)
         ).and(
@@ -675,29 +675,29 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     // toCellRange......................................................................................................
 
     @Test
-    public void testToCellRangeOrFailAbsolute() {
-        this.toCellRangeOrFailAndCheck(
+    public void testToCellRangeAbsolute() {
+        this.toCellRangeAndCheck(
                 SpreadsheetSelection.parseCell("$B$2"),
                 SpreadsheetSelection.parseCellRange("$B$2")
         );
     }
 
     @Test
-    public void testToCellRangeOrFailRelative() {
+    public void testToCellRangeRelative() {
         final String text = "C3";
 
-        this.toCellRangeOrFailAndCheck(
+        this.toCellRangeAndCheck(
                 SpreadsheetSelection.parseCell(text),
                 SpreadsheetSelection.parseCellRange(text)
         );
     }
 
-    private void toCellRangeOrFailAndCheck(final SpreadsheetCellReference reference,
-                                           final SpreadsheetCellRange range) {
+    private void toCellRangeAndCheck(final SpreadsheetCellReference reference,
+                                     final SpreadsheetCellRange range) {
         this.checkEquals(
                 range,
-                reference.toCellRangeOrFail(),
-                () -> reference + " toCellRangeOrFail()"
+                reference.toCellRange(),
+                () -> reference + " toCellRange()"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
@@ -299,10 +299,10 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetExpressionReferen
     }
 
     @Test
-    public void testToCellRangeOrFailFails() {
+    public void testToCellRangeFails() {
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> SpreadsheetLabelName.with("Label123").toCellRangeOrFail()
+                () -> SpreadsheetLabelName.with("Label123").toCellRange()
         );
     }
 
@@ -403,10 +403,10 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetExpressionReferen
                 (l) -> {
                     this.checkEquals(name, l);
                     return Optional.of(
-                            cell.toCellRangeOrFail()
+                            cell.toCellRange()
                     );
                 },
-                cell.toCellRangeOrFail()
+                cell.toCellRange()
         );
     }
 


### PR DESCRIPTION
- Also fixed naming of tests in SpreadsheetCellReferenceTest.