### PR TITLE
SpreadsheetParsers pattern separators now ignored during number parse…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternSpreadsheetFormatParserTokenVisitor.java
@@ -131,7 +131,7 @@ abstract class SpreadsheetParsePatternSpreadsheetFormatParserTokenVisitor<T exte
 
     @Override
     protected final void visit(final SpreadsheetFormatSeparatorSymbolParserToken token) {
-        this.text(token.text());
+        // separators do not contribute any required or optional text in anything being parsed.
     }
 
     @Override


### PR DESCRIPTION
… component transform.

- First step towards text literals being required in text being parsed into values.