### PR TITLE
SpreadsheetFormatParsers whitespace parsed into whitespace tokens *FIX*

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisitor.java
@@ -32,6 +32,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserTokenVisito
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatQuotedTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatSecondParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextLiteralParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatWhitespaceParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatYearParserToken;
 
 import java.time.LocalDateTime;
@@ -364,6 +365,11 @@ final class DateTimeSpreadsheetFormatterFormatSpreadsheetFormatParserTokenVisito
 
     @Override
     protected void visit(final SpreadsheetFormatTextLiteralParserToken token) {
+        this.append(token.value());
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatWhitespaceParserToken token) {
         this.append(token.value());
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
@@ -33,6 +33,8 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatPercentParserToke
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatQuotedTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextLiteralParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatThousandsParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatWhitespaceParserToken;
+import walkingkooka.text.CharSequences;
 import walkingkooka.visit.Visiting;
 
 import java.util.List;
@@ -147,6 +149,18 @@ final class NumberSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor extend
     @Override
     protected void visit(final SpreadsheetFormatThousandsParserToken token) {
         this.digitMode.thousands(this);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatWhitespaceParserToken token) {
+        this.add(
+                NumberSpreadsheetFormatterComponent.textLiteral(
+                        CharSequences.repeating(
+                                ' ',
+                                token.value().length()
+                        ).toString()
+                )
+        );
     }
 
     // misc ..................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor.java
@@ -28,6 +28,8 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextLiteralParser
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextPlaceholderParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatUnderscoreParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatWhitespaceParserToken;
+import walkingkooka.text.CharSequences;
 
 import java.util.Optional;
 
@@ -110,11 +112,21 @@ final class TextSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor extends 
         this.append(token.value());
     }
 
+    @Override
+    protected void visit(final SpreadsheetFormatWhitespaceParserToken token) {
+        this.append(
+                CharSequences.repeating(
+                        ' ',
+                        token.value().length()
+                )
+        );
+    }
+
     private void append(final char c) {
         this.text.append(c);
     }
 
-    private void append(final String text) {
+    private void append(final CharSequence text) {
         this.text.append(text);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsers.java
@@ -615,14 +615,25 @@ public final class SpreadsheetFormatParsers implements PublicStaticHelper {
                 .cast();
     }
 
+    /**
+     * Includes logic making a special case of space characters transforming them into a {@link SpreadsheetFormatParserToken#whitespace(String, String)}.
+     */
     private static SpreadsheetFormatParserToken literalTransform(final ParserToken token,
                                                                  final ParserContext context) {
-        return SpreadsheetFormatParserToken.textLiteral(
-                token.cast(CharacterParserToken.class)
-                        .value()
-                        .toString(),
-                token.text()
-        );
+        final CharacterParserToken characterParserToken = token.cast(CharacterParserToken.class);
+        final char c = characterParserToken.value();
+        final String value = String.valueOf(c);
+        final String text = characterParserToken.text();
+
+        return ' ' == c ?
+                SpreadsheetFormatParserToken.whitespace(
+                        value,
+                        text
+                ) :
+                SpreadsheetFormatParserToken.textLiteral(
+                        value,
+                        text
+                );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer.java
@@ -169,10 +169,16 @@ final class SpreadsheetFormatParsersEbnfParserCombinatorSyntaxTreeTransformer im
     private static ParserToken transformTextCharacter(final ParserToken token,
                                                       final SpreadsheetFormatParserContext context) {
         final String text = token.text();
-        return SpreadsheetFormatParserToken.textLiteral(
-                text,
-                text
-        );
+
+        return text.equals(" ") ?
+                SpreadsheetFormatParserToken.whitespace(
+                        text,
+                        text
+                ) :
+                SpreadsheetFormatParserToken.textLiteral(
+                        text,
+                        text
+                );
     }
 
     private static final EbnfIdentifierName TEXT_CHARACTER_IDENTIFIER = EbnfIdentifierName.with("TEXT_CHARACTER");

--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersGrammar.txt
@@ -250,6 +250,6 @@ TEXT_COLOR_WITH_STAR           = [{ TEXT_COLOR_COMPONENT }],
 
 TEXT_COLOR_WITHOUT_STAR        = [{ TEXT_COLOR_COMPONENT }];
 
-TEXT_COLOR_COMPONENT           = COLOR | TEXT_CHARACTER | ESCAPE | QUOTED | TEXT_PLACEHOLDER | UNDERSCORE;
+TEXT_COLOR_COMPONENT           = COLOR | WHITESPACE | TEXT_CHARACTER | ESCAPE | QUOTED | TEXT_PLACEHOLDER | UNDERSCORE;
 
-TEXT_CHARACTER                 = { ' ' | '<' | '>' | '=' | '!' | '$' | '-' | '+' | '(' | ')' | '%' | '#' | '&' | '/' | ',' | ':' };
+TEXT_CHARACTER                 = { '<' | '>' | '=' | '!' | '$' | '-' | '+' | '(' | ')' | '%' | '#' | '&' | '/' | ',' | ':' };

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponent.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponent.java
@@ -103,8 +103,8 @@ abstract class SpreadsheetNumberParsePatternComponent {
      * {@see SpreadsheetNumberParsePatternComponentWhitespace}
      */
     @SuppressWarnings("SameReturnValue")
-    static SpreadsheetNumberParsePatternComponent whitespace() {
-        return SpreadsheetNumberParsePatternComponentCurrency.INSTANCE;
+    static SpreadsheetNumberParsePatternComponent whitespace(final int length) {
+        return SpreadsheetNumberParsePatternComponentWhitespace.with(length);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespace.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespace.java
@@ -17,20 +17,24 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
 
 /**
- * A {@link SpreadsheetNumberParsePatternComponent} that matches any whitespace character.
+ * A {@link SpreadsheetNumberParsePatternComponent} that matches a given number of whitespace characters.
  */
 final class SpreadsheetNumberParsePatternComponentWhitespace extends SpreadsheetNumberParsePatternComponentNonDigit {
 
     /**
      * Singleton
      */
-    final static SpreadsheetNumberParsePatternComponentWhitespace INSTANCE = new SpreadsheetNumberParsePatternComponentWhitespace();
+    static SpreadsheetNumberParsePatternComponentWhitespace with(final int length) {
+        return new SpreadsheetNumberParsePatternComponentWhitespace(length);
+    }
 
-    private SpreadsheetNumberParsePatternComponentWhitespace() {
+    private SpreadsheetNumberParsePatternComponentWhitespace(final int length) {
         super();
+        this.length = length;
     }
 
     @Override
@@ -47,6 +51,11 @@ final class SpreadsheetNumberParsePatternComponentWhitespace extends Spreadsheet
 
     @Override
     public String toString() {
-        return " ";
+        return CharSequences.repeating(
+                ' ',
+                this.length
+        ).toString();
     }
+
+    private final int length;
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternSpreadsheetFormatParserTokenVisitor.java
@@ -38,6 +38,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatSecondParserToken
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatThousandsParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTimeParserToken;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatWhitespaceParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatYearParserToken;
 import walkingkooka.visit.Visiting;
 
@@ -202,6 +203,15 @@ final class SpreadsheetNumberParsePatternSpreadsheetFormatParserTokenVisitor ext
     @Override
     protected void visit(final SpreadsheetFormatThousandsParserToken token) {
         this.addComponent(SpreadsheetNumberParsePatternComponent.thousands());
+    }
+
+    @Override
+    protected void visit(final SpreadsheetFormatWhitespaceParserToken token) {
+        this.addComponent(
+                SpreadsheetNumberParsePatternComponent.whitespace(
+                        token.textLength()
+                )
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTestCase.java
@@ -44,7 +44,7 @@ public abstract class SpreadsheetFormatParserTestCase {
     }
 
     static SpreadsheetFormatParserToken color() {
-        final List<ParserToken> tokens = Lists.of(bracketOpenSymbol(), colorLiteral(), whitespace(), colorNumberFive(), bracketCloseSymbol());
+        final List<ParserToken> tokens = Lists.of(bracketOpenSymbol(), colorLiteral(), whitespace3(), colorNumberFive(), bracketCloseSymbol());
         return SpreadsheetFormatParserToken.color(tokens, ParserToken.text(tokens));
     }
 
@@ -65,7 +65,7 @@ public abstract class SpreadsheetFormatParserTestCase {
     }
 
     static SpreadsheetFormatParserToken conditionEquals() {
-        final List<ParserToken> list = Lists.of(bracketOpenSymbol(), whitespace(), equalsSymbol(), conditionNumber(), bracketCloseSymbol());
+        final List<ParserToken> list = Lists.of(bracketOpenSymbol(), whitespace3(), equalsSymbol(), conditionNumber(), bracketCloseSymbol());
         return SpreadsheetFormatParserToken.equalsParserToken(list, ParserToken.text(list));
     }
 
@@ -378,10 +378,6 @@ public abstract class SpreadsheetFormatParserTestCase {
         return textLiteral('/');
     }
 
-    static SpreadsheetFormatParserToken textLiteralSpace() {
-        return textLiteral(' ');
-    }
-
     static SpreadsheetFormatParserToken textLiteral(final char c) {
         return textLiteral("" + c);
     }
@@ -415,7 +411,17 @@ public abstract class SpreadsheetFormatParserTestCase {
     }
 
     static SpreadsheetFormatParserToken whitespace() {
-        return SpreadsheetFormatParserToken.whitespace("   ", "   ");
+        return SpreadsheetFormatParserToken.whitespace(
+                " ",
+                " "
+        );
+    }
+
+    static SpreadsheetFormatParserToken whitespace3() {
+        return SpreadsheetFormatParserToken.whitespace(
+                "   ",
+                "   "
+        );
     }
 
     static SpreadsheetFormatParserToken year() {

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenVisitorTest.java
@@ -998,7 +998,7 @@ public final class SpreadsheetFormatParserTokenVisitorTest extends SpreadsheetFo
 
     @Test
     public void testText() {
-        final SpreadsheetFormatParserToken whitespace = whitespace();
+        final SpreadsheetFormatParserToken whitespace = whitespace3();
         final SpreadsheetFormatParserToken placeholder = textPlaceholder();
 
         final SpreadsheetFormatParserToken token = SpreadsheetFormatParserToken.text(Lists.of(
@@ -2043,7 +2043,7 @@ public final class SpreadsheetFormatParserTokenVisitorTest extends SpreadsheetFo
 
     @Test
     public void testWhitespace() {
-        final SpreadsheetFormatParserToken token = whitespace();
+        final SpreadsheetFormatParserToken token = whitespace3();
         final StringBuilder b = new StringBuilder();
         final List<ParserToken> visited = Lists.array();
 
@@ -2065,7 +2065,7 @@ public final class SpreadsheetFormatParserTokenVisitorTest extends SpreadsheetFo
     @Test
     public void testWhitespace2() {
         new SpreadsheetFormatParserTokenVisitor() {
-        }.accept(whitespace());
+        }.accept(whitespace3());
     }
 
     abstract static class TestSpreadsheetFormatParserTokenVisitor extends FakeSpreadsheetFormatParserTokenVisitor {

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersTest.java
@@ -140,7 +140,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.colorParseAndCheck(
                 bracketOpenSymbol(),
                 red(),
-                whitespace(),
+                whitespace3(),
                 bracketCloseSymbol()
         );
     }
@@ -160,7 +160,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.colorParseAndCheck(
                 bracketOpenSymbol(),
                 colorLiteral(),
-                whitespace(),
+                whitespace3(),
                 colorNumberFive(),
                 bracketCloseSymbol()
         );
@@ -171,9 +171,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.colorParseAndCheck(
                 bracketOpenSymbol(),
                 colorLiteral(),
-                whitespace(),
+                whitespace3(),
                 colorNumberFive(),
-                whitespace(),
+                whitespace3(),
                 bracketCloseSymbol()
         );
     }
@@ -276,7 +276,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testConditionSpaceFails() {
-        this.conditionParseThrows(textLiteralSpace());
+        this.conditionParseThrows(whitespace());
     }
 
     @Test
@@ -455,7 +455,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateFormatWhitespaceGeneral() {
         this.dateFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -466,7 +466,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateFormatParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -475,9 +475,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateFormatWhitespaceGeneralWhitespace() {
         this.dateFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -497,7 +497,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateFormatParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -631,7 +631,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateFormatSpace() {
         this.dateFormatParseAndCheck(
                 date(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -1202,7 +1202,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateFormatSpaceDayMonthYear() {
         this.dateFormatParseAndCheck(
                 date(
-                        textLiteralSpace(),
+                        whitespace(),
                         day(),
                         month(),
                         year()
@@ -1215,7 +1215,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateFormatParseAndCheck(
                 date(
                         day(),
-                        textLiteralSpace(),
+                        whitespace(),
                         month(),
                         year()
                 )
@@ -1228,7 +1228,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                 date(
                         day(),
                         month(),
-                        textLiteralSpace(),
+                        whitespace(),
                         year()
                 )
         );
@@ -1241,7 +1241,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         day(),
                         month(),
                         year(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -1777,7 +1777,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateParseWhitespaceGeneral() {
         this.dateParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -1788,7 +1788,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateParseParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -1797,9 +1797,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateParseWhitespaceGeneralWhitespace() {
         this.dateParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -1819,7 +1819,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateParseParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -1953,7 +1953,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateParseSpace() {
         this.dateParseParseAndCheck(
                 date(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -2524,7 +2524,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateParseSpaceDayMonthYear() {
         this.dateParseParseAndCheck(
                 date(
-                        textLiteralSpace(),
+                        whitespace(),
                         day(),
                         month(),
                         year()
@@ -2537,7 +2537,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateParseParseAndCheck(
                 date(
                         day(),
-                        textLiteralSpace(),
+                        whitespace(),
                         month(),
                         year()
                 )
@@ -2550,7 +2550,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                 date(
                         day(),
                         month(),
-                        textLiteralSpace(),
+                        whitespace(),
                         year()
                 )
         );
@@ -2563,7 +2563,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         day(),
                         month(),
                         year(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -3188,7 +3188,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberFormatGeneralWhitespace() {
         this.numberFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -3198,9 +3198,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberFormatWhitespaceGeneralWhitespace() {
         this.numberFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -3220,7 +3220,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberFormatParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -3334,7 +3334,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberFormatSpace() {
         this.numberFormatParseAndCheck(
                 number(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -4036,7 +4036,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberFormatSpaceDigitSlashDigit() {
         this.numberFormatParseAndCheck(
                 number(
-                        textLiteralSpace(),
+                        whitespace(),
                         digit(),
                         decimalPoint(),
                         digit()
@@ -4049,7 +4049,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberFormatParseAndCheck(
                 number(
                         digit(),
-                        textLiteralSpace(),
+                        whitespace(),
                         decimalPoint(),
                         digit()
                 )
@@ -4060,10 +4060,10 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberFormatDigitSlashSpaceDigit() {
         this.numberFormatParseAndCheck(
                 number(
-                        textLiteralSpace(),
+                        whitespace(),
                         digit(),
                         decimalPoint(),
-                        textLiteralSpace(),
+                        whitespace(),
                         digit()
                 )
         );
@@ -4076,7 +4076,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         digit(),
                         decimalPoint(),
                         digit(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -4600,7 +4600,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberFormatParseAndCheck(
                 number(
                         digit(),
-                        exponent1(textLiteralSpace())
+                        exponent1(whitespace())
                 )
         );
     }
@@ -4610,7 +4610,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberFormatParseAndCheck(
                 number(
                         digit(),
-                        exponent2(textLiteralSpace())
+                        exponent2(whitespace())
                 )
         );
     }
@@ -4620,7 +4620,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberFormatParseAndCheck(
                 number(
                         digit(),
-                        exponent3(textLiteralSpace())
+                        exponent3(whitespace())
                 )
         );
     }
@@ -5298,7 +5298,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberParseGeneralWhitespace() {
         this.numberParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -5308,9 +5308,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberParseWhitespaceGeneralWhitespace() {
         this.numberParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -5330,7 +5330,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberParseParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -5444,7 +5444,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberParseSpace() {
         this.numberParseParseAndCheck(
                 number(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -6146,7 +6146,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberParseSpaceDigitSlashDigit() {
         this.numberParseParseAndCheck(
                 number(
-                        textLiteralSpace(),
+                        whitespace(),
                         digit(),
                         decimalPoint(),
                         digit()
@@ -6159,7 +6159,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberParseParseAndCheck(
                 number(
                         digit(),
-                        textLiteralSpace(),
+                        whitespace(),
                         decimalPoint(),
                         digit()
                 )
@@ -6170,10 +6170,10 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testNumberParseDigitSlashSpaceDigit() {
         this.numberParseParseAndCheck(
                 number(
-                        textLiteralSpace(),
+                        whitespace(),
                         digit(),
                         decimalPoint(),
-                        textLiteralSpace(),
+                        whitespace(),
                         digit()
                 )
         );
@@ -6186,7 +6186,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         digit(),
                         decimalPoint(),
                         digit(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -6710,7 +6710,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberParseParseAndCheck(
                 number(
                         digit(),
-                        exponent1(textLiteralSpace())
+                        exponent1(whitespace())
                 )
         );
     }
@@ -6720,7 +6720,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberParseParseAndCheck(
                 number(
                         digit(),
-                        exponent2(textLiteralSpace())
+                        exponent2(whitespace())
                 )
         );
     }
@@ -6730,7 +6730,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.numberParseParseAndCheck(
                 number(
                         digit(),
-                        exponent3(textLiteralSpace())
+                        exponent3(whitespace())
                 )
         );
     }
@@ -7492,22 +7492,22 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testFractionSpaceDigitSlashDigit() {
-        this.fractionParseAndCheck(textLiteralSpace(), digit(), fractionSymbol(), digit());
+        this.fractionParseAndCheck(whitespace(), digit(), fractionSymbol(), digit());
     }
 
     @Test
     public void testFractionDigitSpaceSlashDigit() {
-        this.fractionParseAndCheck(digit(), textLiteralSpace(), fractionSymbol(), digit());
+        this.fractionParseAndCheck(digit(), whitespace(), fractionSymbol(), digit());
     }
 
     @Test
     public void testFractionDigitSlashSpaceDigit() {
-        this.fractionParseAndCheck(textLiteralSpace(), digit(), fractionSymbol(), textLiteralSpace(), digit());
+        this.fractionParseAndCheck(whitespace(), digit(), fractionSymbol(), whitespace(), digit());
     }
 
     @Test
     public void testFractionDigitSlashDigitSpace() {
-        this.fractionParseAndCheck(digit(), fractionSymbol(), digit(), textLiteralSpace());
+        this.fractionParseAndCheck(digit(), fractionSymbol(), digit(), whitespace());
     }
 
     // thousands
@@ -7788,12 +7788,12 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testGeneralWhitespaceGeneral() {
-        this.generalParseAndCheck(whitespace(), generalSymbol());
+        this.generalParseAndCheck(whitespace3(), generalSymbol());
     }
 
     @Test
     public void testGeneralGeneralWhitespace() {
-        this.generalParseAndCheck(generalSymbol(), whitespace());
+        this.generalParseAndCheck(generalSymbol(), whitespace3());
     }
 
     @Test
@@ -7803,7 +7803,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testGeneralColorWhitespaceGeneral() {
-        this.generalParseAndCheck(color(), whitespace(), generalSymbol());
+        this.generalParseAndCheck(color(), whitespace3(), generalSymbol());
     }
 
     @Test
@@ -7813,12 +7813,12 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
 
     @Test
     public void testGeneralGeneralColorWhitespace() {
-        this.generalParseAndCheck(generalSymbol(), color(), whitespace());
+        this.generalParseAndCheck(generalSymbol(), color(), whitespace3());
     }
 
     @Test
     public void testGeneralGeneralWhitespaceColor() {
-        this.generalParseAndCheck(generalSymbol(), whitespace(), color());
+        this.generalParseAndCheck(generalSymbol(), whitespace3(), color());
     }
 
     /**
@@ -8048,7 +8048,16 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatSpace() {
         this.textFormatParseAndCheck(
                 text(
-                        textLiteralSpace()
+                        whitespace()
+                )
+        );
+    }
+
+    @Test
+    public void testTextFormatSpaceSpaceSpace() {
+        this.textFormatParseAndCheck(
+                text(
+                        whitespace3()
                 )
         );
     }
@@ -8113,7 +8122,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTextFormatAll() {
         this.textFormatParseAndCheck(
                 text(
-                        textLiteralSpace(),
+                        whitespace(),
                         quotedText(),
                         textPlaceholder(),
                         underscore()
@@ -8486,7 +8495,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeFormatWhitespaceGeneral() {
         this.timeFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -8497,7 +8506,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeFormatParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -8506,9 +8515,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeFormatWhitespaceGeneralWhitespace() {
         this.timeFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -8528,7 +8537,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeFormatParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -8620,7 +8629,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeFormatSpace() {
         this.timeFormatParseAndCheck(
                 time(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -9232,7 +9241,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeFormatSpaceHourMinuteSecond() {
         this.timeFormatParseAndCheck(
                 time(
-                        textLiteralSpace(),
+                        whitespace(),
                         hour(),
                         minute(),
                         second()
@@ -9245,7 +9254,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeFormatParseAndCheck(
                 time(
                         hour(),
-                        textLiteralSpace(),
+                        whitespace(),
                         minute(),
                         second()
                 )
@@ -9258,7 +9267,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                 time(
                         hour(),
                         minute(),
-                        textLiteralSpace(),
+                        whitespace(),
                         second()
                 )
         );
@@ -9271,7 +9280,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         hour(),
                         minute(),
                         second(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -9840,7 +9849,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeParseWhitespaceGeneral() {
         this.timeParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -9851,7 +9860,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeParseParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -9860,9 +9869,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeParseWhitespaceGeneralWhitespace() {
         this.timeParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -9882,7 +9891,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeParseParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -9974,7 +9983,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeParseSpace() {
         this.timeParseParseAndCheck(
                 time(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -10586,7 +10595,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testTimeParseSpaceHourMinuteSecond() {
         this.timeParseParseAndCheck(
                 time(
-                        textLiteralSpace(),
+                        whitespace(),
                         hour(),
                         minute(),
                         second()
@@ -10599,7 +10608,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.timeParseParseAndCheck(
                 time(
                         hour(),
-                        textLiteralSpace(),
+                        whitespace(),
                         minute(),
                         second()
                 )
@@ -10612,7 +10621,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                 time(
                         hour(),
                         minute(),
-                        textLiteralSpace(),
+                        whitespace(),
                         second()
                 )
         );
@@ -10625,7 +10634,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
                         hour(),
                         minute(),
                         second(),
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -11145,7 +11154,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeFormatWhitespaceGeneral() {
         this.dateTimeFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -11156,7 +11165,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateTimeFormatParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -11165,9 +11174,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeFormatWhitespaceGeneralWhitespace() {
         this.dateTimeFormatParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -11187,7 +11196,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateTimeFormatParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -11279,7 +11288,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeFormatSpace() {
         this.dateTimeFormatParseAndCheck(
                 dateTime(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }
@@ -11860,7 +11869,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeParseWhitespaceGeneral() {
         this.dateTimeParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -11871,7 +11880,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateTimeParseParseAndCheck(
                 general(
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -11880,9 +11889,9 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeParseWhitespaceGeneralWhitespace() {
         this.dateTimeParseParseAndCheck(
                 general(
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol(),
-                        whitespace()
+                        whitespace3()
                 )
         );
     }
@@ -11902,7 +11911,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
         this.dateTimeParseParseAndCheck(
                 general(
                         color(),
-                        whitespace(),
+                        whitespace3(),
                         generalSymbol()
                 )
         );
@@ -11994,7 +12003,7 @@ public final class SpreadsheetFormatParsersTest extends SpreadsheetFormatParserT
     public void testDateTimeParseSpace() {
         this.dateTimeParseParseAndCheck(
                 dateTime(
-                        textLiteralSpace()
+                        whitespace()
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespaceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespaceTest.java
@@ -41,12 +41,23 @@ public final class SpreadsheetNumberParsePatternComponentWhitespaceTest extends 
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createComponent(), " ");
+        this.toStringAndCheck(
+                this.createComponent(),
+                " "
+        );
+    }
+
+    @Test
+    public void testToString3() {
+        this.toStringAndCheck(
+                SpreadsheetNumberParsePatternComponentWhitespace.with(3),
+                "   "
+        );
     }
 
     @Override
     SpreadsheetNumberParsePatternComponentWhitespace createComponent() {
-        return SpreadsheetNumberParsePatternComponentWhitespace.INSTANCE;
+        return SpreadsheetNumberParsePatternComponentWhitespace.with(1);
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
- Previously whitespace was parsed into text literals.