### PR TITLE
SpreadsheetNumberParsePatterns require text-literals & whitespace

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentNonDigit.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentNonDigit.java
@@ -17,10 +17,18 @@
 
 package walkingkooka.spreadsheet.format.pattern;
 
+import walkingkooka.text.cursor.parser.ParserContext;
+import walkingkooka.text.cursor.parser.ParserContexts;
+
 /**
  * Base {@link SpreadsheetNumberParsePatternComponent} for all non digit {@link SpreadsheetNumberParsePatternComponent}.
  */
 abstract class SpreadsheetNumberParsePatternComponentNonDigit extends SpreadsheetNumberParsePatternComponent {
+
+    /**
+     * A {@link ParserContext} used by any {@link walkingkooka.text.cursor.parser.Parser}.
+     */
+    final static ParserContext PARSER_CONTEXT = ParserContexts.fake();
 
     SpreadsheetNumberParsePatternComponentNonDigit() {
         super();

--- a/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/GeneralSpreadsheetConverterTest.java
@@ -1014,7 +1014,7 @@ public final class GeneralSpreadsheetConverterTest extends GeneralSpreadsheetCon
     @Test
     public void testStringNumber() {
         this.convertAndCheck(
-                "123",
+                "N 123",
                 EXPRESSION_NUMBER_KIND.create(123)
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentTestCase.java
@@ -84,13 +84,20 @@ public abstract class SpreadsheetNumberParsePatternComponentTestCase<C extends S
     }
 
     final void parseFails(final String text) {
+        this.parseFails(
+                this.createComponent(),
+                text
+        );
+    }
+
+    final void parseFails(final C component,
+                          final String text) {
         final TextCursor cursor = TextCursors.charSequence(text);
 
         final SpreadsheetNumberParsePatternRequest request = this.createRequest(NEXT_SKIPPED);
         this.checkEquals(
                 false,
-                this.createComponent()
-                        .parse(cursor, request),
+                component.parse(cursor, request),
                 () -> "parse of " + CharSequences.quoteAndEscape(text) + " should have returned false"
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentTextLiteralTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentTextLiteralTest.java
@@ -18,26 +18,37 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 public final class SpreadsheetNumberParsePatternComponentTextLiteralTest extends SpreadsheetNumberParsePatternComponentTestCase2<SpreadsheetNumberParsePatternComponentTextLiteral> {
 
     private final static String TOKEN = "ghi";
 
     @Test
-    public void testDifferentCase() {
-        this.parseAndCheck2(
-                "",
-                TOKEN.toUpperCase(),
-                NEXT_CALLED
+    public void testIncompleteFails() {
+        this.parseFails(
+                "gh"
+        );
+    }
+
+    @Test
+    public void testDifferentCaseFails() {
+        this.parseFails(
+                TOKEN.toUpperCase()
         );
     }
 
     @Test
     public void testMatchingCase() {
+        final String text = "ghi";
         this.parseAndCheck2(
-                "",
+                text,
                 TOKEN,
-                NEXT_CALLED
+                NEXT_CALLED,
+                SpreadsheetParserToken.textLiteral(
+                        text,
+                        text
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespaceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentWhitespaceTest.java
@@ -18,24 +18,66 @@
 package walkingkooka.spreadsheet.format.pattern;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 
 public final class SpreadsheetNumberParsePatternComponentWhitespaceTest extends SpreadsheetNumberParsePatternComponentTestCase2<SpreadsheetNumberParsePatternComponentWhitespace> {
 
     @Test
+    public void testNonWhitespaceFails() {
+        this.parseFails("failed!");
+    }
+
+    @Test
+    public void testInsufficientSpaceFails() {
+        this.parseFails(
+                SpreadsheetNumberParsePatternComponentWhitespace.with(3),
+                " a"
+        );
+    }
+
+    @Test
     public void testSpace() {
+        final String text = " ";
         this.parseAndCheck2(
-                "",
-                " ",
-                NEXT_CALLED
+                text,
+                "A",
+                NEXT_CALLED,
+                SpreadsheetParserToken.whitespace(
+                        text,
+                        text
+                )
+        );
+    }
+
+    @Test
+    public void testSpaceSpace() {
+        final String text = "  ";
+
+        this.parseAndCheck2(
+                SpreadsheetNumberParsePatternComponentWhitespace.with(2),
+                text, // text
+                "A", // textAfter
+                this.createRequest(true),
+                NEXT_CALLED,
+                SpreadsheetParserToken.whitespace(
+                        text,
+                        text
+                )
         );
     }
 
     @Test
     public void testTab() {
+        final String text = "\t";
+
         this.parseAndCheck2(
-                "",
-                "\t",
-                NEXT_CALLED
+                text,
+                "A",
+                NEXT_CALLED,
+                SpreadsheetParserToken.whitespace(
+                        text,
+                        text
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
@@ -377,6 +377,26 @@ public final class SpreadsheetNumberParsePatternTest extends SpreadsheetParsePat
         );
     }
 
+    @Test
+    public void testParseTextLiteralDigit() {
+        this.parseAndCheck2(
+                "\"Number\"#",
+                "Number5",
+                SpreadsheetParserToken.textLiteral("Number", "Number"),
+                digit5()
+        );
+    }
+
+    @Test
+    public void testParseWhitespaceDigit() {
+        this.parseAndCheck2(
+                " #",
+                " 5",
+                SpreadsheetParserToken.whitespace(" ", " "),
+                digit5()
+        );
+    }
+
     // TreePrintable....................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1286,47 +1286,74 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
     @Test
     public void testConverterStringToExpressionNumber() {
-        this.convertAndCheck2("123.500", EXPRESSION_NUMBER_KIND.create(123.5));
+        this.convertAndCheck2(
+                "Number 123.500",
+                EXPRESSION_NUMBER_KIND.create(123.5)
+        );
     }
 
     @Test
     public void testConverterStringToBigDecimal() {
-        this.convertAndCheck2("123.500", BigDecimal.valueOf(123.5));
+        this.convertAndCheck2(
+                "Number 123.500",
+                BigDecimal.valueOf(123.5)
+        );
     }
 
     @Test
     public void testConverterStringToBigInteger() {
-        this.convertAndCheck2("123.000", BigInteger.valueOf(123));
+        this.convertAndCheck2(
+                "Number 123.000",
+                BigInteger.valueOf(123)
+        );
     }
 
     @Test
     public void testConverterStringToByte() {
-        this.convertAndCheck2("123.000", (byte) 123);
+        this.convertAndCheck2(
+                "Number 123.000",
+                (byte) 123
+        );
     }
 
     @Test
     public void testConverterStringToShort() {
-        this.convertAndCheck2("123.000", (short) 123);
+        this.convertAndCheck2(
+                "Number 123.000",
+                (short) 123
+        );
     }
 
     @Test
     public void testConverterStringToInteger() {
-        this.convertAndCheck2("123.000", 123);
+        this.convertAndCheck2(
+                "Number 123.000",
+                123
+        );
     }
 
     @Test
     public void testConverterStringToLong() {
-        this.convertAndCheck2("123.000", 123L);
+        this.convertAndCheck2(
+                "Number 123.000",
+                123L
+        );
     }
 
     @Test
     public void testConverterStringToFloat() {
-        this.convertAndCheck2("123.500", 123.5f);
+        this.convertAndCheck2(
+                "Number 123.500",
+                123.5f
+        );
     }
 
     @Test
     public void testConverterStringToDouble() {
-        this.convertAndCheck2("123.500", 123.5);
+        this.convertAndCheck2(
+                "Number 123.500",
+                123.5
+        );
     }
 
     @Test


### PR DESCRIPTION
- Previously text literals & whitespace were ignored during parsing of inputs.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2883
- Whitespace within a number pattern is also not required during parsing.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/1366
- SpreadsheetNumberParserPatterns ignores text literals within pattern during parsing of values.