### PR TITLE
SpreadsheetPattern.treePrint includes pattern separator

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor.java
@@ -31,6 +31,7 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatNotEqualsParserTo
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatNumberParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserTokenVisitor;
+import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatSeparatorSymbolParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTextParserToken;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatTimeParserToken;
 import walkingkooka.text.CharSequences;
@@ -44,6 +45,7 @@ final class SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor exten
                           final IndentingPrinter printer) {
         new SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor(printer)
                 .accept(token);
+        printer.lineStart();
     }
 
     SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor(final IndentingPrinter printer) {
@@ -120,8 +122,15 @@ final class SpreadsheetPatternPrintTreeSpreadsheetFormatParserTokenVisitor exten
         return this.treePrint0(token);
     }
 
+    @Override
+    protected void visit(final SpreadsheetFormatSeparatorSymbolParserToken token) {
+        this.printer.print(" ");
+        this.printer.print(token.text());
+    }
+
     private Visiting treePrint0(final SpreadsheetFormatParserToken token) {
-        this.printer.println(
+        this.printer.lineStart();
+        this.printer.print(
                 CharSequences.quoteAndEscape(
                         token.text()
                 )

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateFormatPatternTest.java
@@ -594,6 +594,41 @@ public final class SpreadsheetDateFormatPatternTest extends SpreadsheetFormatPat
         );
     }
 
+    @Test
+    public void testTreePrintWithSeparator() {
+        final String pattern = "dd/mm/yyyy;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\" ;\n"
+        );
+    }
+
     // helpers..........................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePatternTest.java
@@ -411,7 +411,7 @@ public final class SpreadsheetDateParsePatternTest extends SpreadsheetParsePatte
         this.treePrintAndCheck(
                 SpreadsheetPattern.parseDateParsePattern("ddmmyy;yymmdd"),
                 "date-parse-pattern\n" +
-                        "  \"ddmmyy\"\n" +
+                        "  \"ddmmyy\" ;\n" +
                         "  \"yymmdd\"\n"
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeFormatPatternTest.java
@@ -963,6 +963,41 @@ public final class SpreadsheetDateTimeFormatPatternTest extends SpreadsheetForma
         );
     }
 
+    @Test
+    public void testTreePrintWithSeparator() {
+        final String pattern = "dd/mm/yyyy;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-time-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-time-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-time-format-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\" ;\n"
+        );
+    }
+
     // ClassTesting.....................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePatternTest.java
@@ -466,12 +466,37 @@ public final class SpreadsheetDateTimeParsePatternTest extends SpreadsheetParseP
     }
 
     @Test
-    public void testTreePrint2() {
+    public void testTreePrintWithSeparator() {
+        final String pattern = "dd/mm/yyyy;";
+
         this.treePrintAndCheck(
-                SpreadsheetPattern.parseDateTimeParsePattern("ddmmyyhhmmss;yymmdd"),
+                this.createPattern(pattern),
                 "date-time-parse-pattern\n" +
-                        "  \"ddmmyyhhmmss\"\n" +
-                        "  \"yymmdd\"\n"
+                        "  \"dd/mm/yyyy\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-time-parse-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "dd/mm/yyyy;dd/mmm/yyyy;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "date-time-parse-pattern\n" +
+                        "  \"dd/mm/yyyy\" ;\n" +
+                        "  \"dd/mmm/yyyy\" ;\n"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberFormatPatternTest.java
@@ -673,6 +673,41 @@ public final class SpreadsheetNumberFormatPatternTest extends SpreadsheetFormatP
         );
     }
 
+    @Test
+    public void testTreePrintWithSeparator() {
+        final String pattern = "$0.00;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-format-pattern\n" +
+                        "  \"$0.00\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "$0.0;$0.00";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-format-pattern\n" +
+                        "  \"$0.0\" ;\n" +
+                        "  \"$0.00\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "$0.0;$0.00;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-format-pattern\n" +
+                        "  \"$0.0\" ;\n" +
+                        "  \"$0.00\" ;\n"
+        );
+    }
+
     // ClassTesting.....................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
@@ -477,10 +477,44 @@ public final class SpreadsheetNumberParsePatternTest extends SpreadsheetParsePat
     @Test
     public void testTreePrint() {
         this.treePrintAndCheck(
-                SpreadsheetPattern.parseNumberParsePattern("##.##;##"),
+                SpreadsheetPattern.parseNumberParsePattern("#"),
                 "number-parse-pattern\n" +
-                        "  \"##.##\"\n" +
-                        "  \"##\"\n"
+                        "  \"#\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintWithSeparator() {
+        final String pattern = "$0.00;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-parse-pattern\n" +
+                        "  \"$0.00\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "$0.0;$0.00";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-parse-pattern\n" +
+                        "  \"$0.0\" ;\n" +
+                        "  \"$0.00\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "$0.0;$0.00;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "number-parse-pattern\n" +
+                        "  \"$0.0\" ;\n" +
+                        "  \"$0.00\" ;\n"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
@@ -386,11 +386,12 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
 
         final List<ParserToken> tokens = Lists.of(
                 this.parseFormatParserToken(patternText),
+                separator(),
                 this.parseFormatParserToken(patternText2)
         );
 
         this.parseStringAndCheck(
-                patternText + ";" + patternText2,
+                patternText + this.separator().text() + patternText2,
                 this.createPattern(
                         ParserTokens.sequence(
                                 tokens,

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTextFormatPatternTest.java
@@ -391,6 +391,8 @@ public final class SpreadsheetTextFormatPatternTest extends SpreadsheetFormatPat
         );
     }
 
+    // toString.........................................................................................................
+
     @Test
     public void testToString2() {
         this.toStringAndCheck(

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeFormatPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeFormatPatternTest.java
@@ -565,6 +565,41 @@ public final class SpreadsheetTimeFormatPatternTest extends SpreadsheetFormatPat
         );
     }
 
+    @Test
+    public void testTreePrintWithSeparator() {
+        final String pattern = "hhmmss;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "time-format-pattern\n" +
+                        "  \"hhmmss\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "hhmm;hhmmss";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "time-format-pattern\n" +
+                        "  \"hhmm\" ;\n" +
+                        "  \"hhmmss\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "hhmm;hhmmss;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "time-format-pattern\n" +
+                        "  \"hhmm\" ;\n" +
+                        "  \"hhmmss\" ;\n"
+        );
+    }
+
     // ClassTesting.....................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePatternTest.java
@@ -557,12 +557,37 @@ public final class SpreadsheetTimeParsePatternTest extends SpreadsheetParsePatte
     }
 
     @Test
-    public void testTreePrint2() {
+    public void testTreePrintWithSeparator() {
+        final String pattern = "hhmmss;";
+
         this.treePrintAndCheck(
-                SpreadsheetPattern.parseTimeParsePattern("hhmm;hhmmss"),
+                this.createPattern(pattern),
                 "time-parse-pattern\n" +
-                        "  \"hhmm\"\n" +
+                        "  \"hhmmss\" ;\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatterns() {
+        final String pattern = "hhmm;hhmmss";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "time-parse-pattern\n" +
+                        "  \"hhmm\" ;\n" +
                         "  \"hhmmss\"\n"
+        );
+    }
+
+    @Test
+    public void testTreePrintSeveralPatternsAndSeparator() {
+        final String pattern = "hhmm;hhmmss;";
+
+        this.treePrintAndCheck(
+                this.createPattern(pattern),
+                "time-parse-pattern\n" +
+                        "  \"hhmm\" ;\n" +
+                        "  \"hhmmss\" ;\n"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3004
- SpreadsheetPattern.printTree should print separator after previous pattern