### PR TITLE
SpreadsheetFormatPatterns parsing fails when only color

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersFormatColorParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersFormatColorParser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorSavePoint;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link Parser} that wraps another returning {@link Optional#empty()} and resetting the {@link TextCursor} if only a {@link SpreadsheetFormatColorParserToken} is matched.
+ */
+final class SpreadsheetFormatParsersFormatColorParser implements Parser<SpreadsheetFormatParserContext> {
+
+    static SpreadsheetFormatParsersFormatColorParser with(final Parser<SpreadsheetFormatParserContext> parser) {
+        return new SpreadsheetFormatParsersFormatColorParser(parser);
+    }
+
+    private SpreadsheetFormatParsersFormatColorParser(final Parser<SpreadsheetFormatParserContext> parser) {
+        super();
+        this.parser = parser;
+    }
+
+    @Override
+    public Optional<ParserToken> parse(final TextCursor cursor,
+                                       final SpreadsheetFormatParserContext context) {
+        final TextCursorSavePoint save = cursor.save();
+        Optional<ParserToken> maybeToken = parser.parse(
+                cursor,
+                context
+        );
+        if (maybeToken.isPresent()) {
+            final List<ParserToken> tokens = maybeToken.get()
+                    .children();
+            if (tokens.size() == 1) {
+                if (tokens.get(0) instanceof SpreadsheetFormatColorParserToken) {
+                    maybeToken = Optional.empty();
+                    save.restore();
+                }
+            }
+        }
+
+        return maybeToken;
+    }
+
+    private final Parser<SpreadsheetFormatParserContext> parser;
+
+    @Override
+    public String toString() {
+        return this.parser.toString();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKindTest.java
@@ -983,17 +983,23 @@ public final class SpreadsheetFormatParserTokenKindTest implements ClassTesting<
 
     @Test
     public void testPatternsColorName() {
-        this.patternsParseAndCheck(
-                SpreadsheetFormatParserTokenKind.COLOR_NAME,
-                SpreadsheetPattern::parseDateFormatPattern
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> this.patternsParseAndCheck(
+                        SpreadsheetFormatParserTokenKind.COLOR_NAME,
+                        SpreadsheetPattern::parseDateFormatPattern
+                )
         );
     }
 
     @Test
     public void testPatternsColorNumber() {
-        this.patternsParseAndCheck(
-                SpreadsheetFormatParserTokenKind.COLOR_NUMBER,
-                SpreadsheetPattern::parseDateFormatPattern
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> this.patternsParseAndCheck(
+                        SpreadsheetFormatParserTokenKind.COLOR_NUMBER,
+                        SpreadsheetPattern::parseDateFormatPattern
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersFormatColorParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParsersFormatColorParserTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.format.parser;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.CaseSensitivity;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserReporters;
+import walkingkooka.text.cursor.parser.ParserTesting2;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokens;
+import walkingkooka.text.cursor.parser.Parsers;
+
+import java.util.Optional;
+
+public final class SpreadsheetFormatParsersFormatColorParserTest implements ParserTesting2<SpreadsheetFormatParsersFormatColorParser, SpreadsheetFormatParserContext>,
+        ToStringTesting<SpreadsheetFormatParsersFormatColorParser> {
+
+    @Test
+    public void testParseNotColor() {
+        final String text = "123";
+        final ParserToken expected = ParserTokens.sequence(
+                Lists.of(
+                        SpreadsheetFormatParserToken.number(
+                                Lists.of(
+                                        SpreadsheetFormatParserToken.digit(text, text)
+                                ),
+                                text
+                        )
+                ),
+                text
+        );
+        this.parseAndCheck(
+                SpreadsheetFormatParsersFormatColorParser.with(
+                        new Parser<SpreadsheetFormatParserContext>() {
+                            @Override
+                            public Optional<ParserToken> parse(final TextCursor cursor,
+                                                               final SpreadsheetFormatParserContext context) {
+                                Parsers.string(text, CaseSensitivity.SENSITIVE)
+                                        .orFailIfCursorNotEmpty(ParserReporters.basic())
+                                        .parse(cursor, context);
+
+                                return Optional.of(
+                                        expected
+                                );
+                            }
+                        }
+                ),
+                this.createContext(),
+                text,
+                expected,
+                text
+        );
+    }
+
+    @Test
+    public void testParseNotColor2() {
+        final String text = "123";
+        final ParserToken expected = ParserTokens.sequence(
+                Lists.of(
+                        SpreadsheetFormatParserToken.number(
+                                Lists.of(
+                                        SpreadsheetFormatParserToken.digit(text, text)
+                                ),
+                                text
+                        )
+                ),
+                text
+        );
+        this.parseAndCheck(
+                SpreadsheetFormatParsersFormatColorParser.with(
+                        new Parser<SpreadsheetFormatParserContext>() {
+                            @Override
+                            public Optional<ParserToken> parse(final TextCursor cursor,
+                                                               final SpreadsheetFormatParserContext context) {
+                                checkNotEquals(
+                                        Optional.empty(),
+                                        Parsers.string(text, CaseSensitivity.SENSITIVE)
+                                                .parse(cursor, context)
+                                );
+
+                                return Optional.of(
+                                        expected
+                                );
+                            }
+                        }
+                ),
+                this.createContext(),
+                text + "!",
+                expected,
+                text,
+                "!"
+        );
+    }
+
+    @Test
+    public void testParseColorEmpty() {
+        final String text = "[Black]";
+
+        this.parseFailAndCheck(
+                SpreadsheetFormatParsersFormatColorParser.with(
+                        new Parser<SpreadsheetFormatParserContext>() {
+                            @Override
+                            public Optional<ParserToken> parse(final TextCursor cursor,
+                                                               final SpreadsheetFormatParserContext context) {
+                                Parsers.string(text, CaseSensitivity.SENSITIVE)
+                                        .orFailIfCursorNotEmpty(ParserReporters.basic())
+                                        .parse(cursor, context);
+
+                                return Optional.of(
+                                        ParserTokens.sequence(
+                                                Lists.of(
+                                                        SpreadsheetFormatParserToken.color(
+                                                                Lists.of(
+                                                                        SpreadsheetFormatParserToken.colorName(text, text)
+                                                                ),
+                                                                text
+                                                        )
+                                                ),
+                                                text
+                                        )
+                                );
+                            }
+                        }
+                ),
+                this.createContext(),
+                text
+        );
+    }
+
+    @Test
+    public void testParseColorAndMoreTokens() {
+        final String color = "[Black]";
+        final String textPlaceholder = "@";
+        final String text = color + textPlaceholder;
+
+        final ParserToken expected = ParserTokens.sequence(
+                Lists.of(
+                        SpreadsheetFormatParserToken.text(
+                                Lists.of(
+                                        SpreadsheetFormatParserToken.color(
+                                                Lists.of(
+                                                        SpreadsheetFormatParserToken.colorName(color, color)
+                                                ),
+                                                color
+                                        ),
+                                        SpreadsheetFormatParserToken.textLiteral(
+                                                textPlaceholder,
+                                                textPlaceholder
+                                        )
+                                ),
+                                text
+                        )
+                ),
+                text
+        );
+
+        this.parseAndCheck(
+                SpreadsheetFormatParsersFormatColorParser.with(
+                        new Parser<SpreadsheetFormatParserContext>() {
+                            @Override
+                            public Optional<ParserToken> parse(final TextCursor cursor,
+                                                               final SpreadsheetFormatParserContext context) {
+                                Parsers.string(text, CaseSensitivity.SENSITIVE)
+                                        .orFailIfCursorNotEmpty(ParserReporters.basic())
+                                        .parse(cursor, context);
+
+                                return Optional.of(
+                                        expected
+                                );
+                            }
+                        }
+                ),
+                text,
+                expected,
+                text
+        );
+    }
+
+    @Test
+    public void testToString() {
+        final String toString = "wrapped parser toString";
+
+        this.toStringAndCheck(
+                SpreadsheetFormatParsersFormatColorParser.with(
+                        Parsers.fake()
+                ).setToString(toString),
+                toString
+        );
+    }
+
+    // ParserTesting...................................................................................................
+
+    @Override
+    public SpreadsheetFormatParsersFormatColorParser createParser() {
+        return SpreadsheetFormatParsersFormatColorParser.with(
+                Parsers.fake()
+        );
+    }
+
+    @Override
+    public SpreadsheetFormatParserContext createContext() {
+        return SpreadsheetFormatParserContexts.basic();
+    }
+
+    // ToStringTesting..................................................................................................
+
+    @Override
+    public Class<SpreadsheetFormatParsersFormatColorParser> type() {
+        return SpreadsheetFormatParsersFormatColorParser.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
@@ -552,6 +552,22 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
     }
 
     @Test
+    public void testParseDateFormatPatternColorNameFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseDateFormatPattern("[Black]")
+        );
+    }
+
+    @Test
+    public void testParseDateFormatPatternColorNumberFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseDateFormatPattern("[Color 1]")
+        );
+    }
+
+    @Test
     public void testParseDateFormatPatternIncompleteTextLiteralFails() {
         assertThrows(
                 IllegalArgumentException.class,
@@ -741,6 +757,22 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
     }
 
     @Test
+    public void testParseDateTimeFormatPatternColorNameFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseDateTimeFormatPattern("[Black]")
+        );
+    }
+
+    @Test
+    public void testParseDateTimeFormatPatternColorNumberFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseDateTimeFormatPattern("[Color 1]")
+        );
+    }
+
+    @Test
     public void testParseDateTimeFormatPatternIncompleteAmpmFails() {
         assertThrows(
                 IllegalArgumentException.class,
@@ -900,6 +932,22 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
         assertThrows(
                 NullPointerException.class,
                 () -> SpreadsheetPattern.parseNumberFormatPattern(null)
+        );
+    }
+
+    @Test
+    public void testParseNumberFormatPatternColorNameFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseNumberFormatPattern("[Black]")
+        );
+    }
+
+    @Test
+    public void testParseNumberFormatPatternColorNumberFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseNumberFormatPattern("[Color 1]")
         );
     }
 
@@ -1370,6 +1418,22 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
     }
 
     @Test
+    public void testParseTextFormatPatternColorNameFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseTextFormatPattern("[Black]")
+        );
+    }
+
+    @Test
+    public void testParseTextFormatPatternColorNumberFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseTextFormatPattern("[Color 1]")
+        );
+    }
+
+    @Test
     public void testParseTextFormatPatternGeneralFails() {
         assertThrows(
                 IllegalArgumentException.class,
@@ -1484,6 +1548,22 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
     @Test
     public void testParseTimeFormatPatternGeneralShouldFail() {
         SpreadsheetPattern.parseTimeFormatPattern("General");
+    }
+
+    @Test
+    public void testParseTimeFormatPatternColorNameFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseTimeFormatPattern("[Black]")
+        );
+    }
+
+    @Test
+    public void testParseTimeFormatPatternColorNumberFails() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetPattern.parseTimeFormatPattern("[Color 1]")
+        );
     }
 
     @Test


### PR DESCRIPTION
- date/datetime/time/number/text parsers now return empty token if only a color name/color number was parsed.