### PR TITLE
SpreadsheetMetadata.numberToColor default values first fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor.java
@@ -29,6 +29,7 @@ final class SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor extends S
 
     static Map<Integer, Color> numberToColorMap(final SpreadsheetMetadata metadata) {
         final SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNumberToColorSpreadsheetMetadataVisitor();
+        visitor.accept(metadata.defaults()); // defaults get overridden
         visitor.accept(metadata);
         return visitor.colors;
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1199,6 +1199,53 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     }
 
     @Test
+    public void testNumberToColorDefaults() {
+        final Color color = Color.parse("#123456");
+        final int number = 23;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .setDefaults(
+                        SpreadsheetMetadata.EMPTY
+                                .set(
+                                        SpreadsheetMetadataPropertyName.numberedColor(number),
+                                        color
+                                )
+                );
+
+        this.numberToColorAndCheck(
+                metadata,
+                number,
+                color
+        );
+    }
+
+    @Test
+    public void testNumberToColorIgnoresDefaults() {
+        final Color color = Color.parse("#123456");
+        final int number = 23;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.numberedColor(number), color)
+                .setDefaults(
+                        SpreadsheetMetadata.EMPTY
+                                .set(
+                                        SpreadsheetMetadataPropertyName.numberedColor(number),
+                                        Color.parse("#999")
+                                )
+                );
+
+        this.numberToColorAndCheck(
+                metadata,
+                number,
+                color
+        );
+    }
+
+    @Test
     public void testNumberToColorCached() {
         final SpreadsheetMetadata metadata = this.createSpreadsheetMetadata();
         assertSame(metadata.numberToColor(), metadata.numberToColor());


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3054
- SpreadsheetMetadata.numberToColor when colors are present in defaults needs tests probably broken