### PR TITLE
SpreadsheetMetadata.nameToColor default lookup fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor.java
@@ -31,18 +31,19 @@ import java.util.Optional;
 final class SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor extends SpreadsheetMetadataVisitor {
 
     static Map<SpreadsheetColorName, Color> nameToColorMap(final SpreadsheetMetadata metadata) {
-        final SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor();
+        final SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor(metadata);
+        visitor.accept(metadata.defaults());
         visitor.accept(metadata);
         return visitor.colors;
     }
 
-    SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor() {
+    SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor(final SpreadsheetMetadata metadata) {
         super();
+        this.metadata = metadata;
     }
 
     @Override
     protected Visiting startVisit(final SpreadsheetMetadata metadata) {
-        this.metadata = metadata;
         return super.startVisit(metadata);
     }
 
@@ -60,6 +61,9 @@ final class SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor extends Spr
         }
     }
 
+    /**
+     * The parent {@link SpreadsheetMetadata} necessary for defaults to resolve color numbers.
+     */
     private SpreadsheetMetadata metadata;
 
     private final Map<SpreadsheetColorName, Color> colors = Maps.ordered();

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest.java
@@ -36,16 +36,15 @@ public final class SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest 
 
     @Test
     public void testToString() {
-        final SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor();
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"))
+                .set(SpreadsheetMetadataPropertyName.numberedColor(1), Color.parse("#123456"))
+                .set(SpreadsheetMetadataPropertyName.numberedColor(2), Color.parse("#89abcd"))
+                .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("apple")), 1)
+                .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("banana")), 2);
+        final SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor visitor = new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor(metadata);
 
-        visitor.accept(
-                SpreadsheetMetadata.EMPTY
-                        .set(SpreadsheetMetadataPropertyName.CREATOR, EmailAddress.parse("user@example.com"))
-                        .set(SpreadsheetMetadataPropertyName.numberedColor(1), Color.parse("#123456"))
-                        .set(SpreadsheetMetadataPropertyName.numberedColor(2), Color.parse("#89abcd"))
-                        .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("apple")), 1)
-                        .set(SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.with("banana")), 2)
-        );
+        visitor.accept(metadata);
         this.toStringAndCheck(
                 visitor,
                 "{apple=#123456, banana=#89abcd}"
@@ -54,7 +53,7 @@ public final class SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitorTest 
 
     @Override
     public SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor createVisitor() {
-        return new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor();
+        return new SpreadsheetMetadataNameToColorSpreadsheetMetadataVisitor(null);
     }
 
     // ClassTesting.....................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1135,6 +1135,118 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     }
 
     @Test
+    public void testNameToColorBlack() {
+        final Color black = Color.BLACK;
+        final SpreadsheetColorName blackName = SpreadsheetColorName.BLACK;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.numberedColor(1), black)
+                .set(SpreadsheetMetadataPropertyName.namedColor(blackName), 1)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH);
+
+        this.nameToColorAndCheck(
+                metadata,
+                blackName,
+                black
+        );
+    }
+
+    @Test
+    public void testNameToColorRed() {
+        final Color red = Color.parse("#f00");
+        final SpreadsheetColorName redName = SpreadsheetColorName.RED;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.numberedColor(12), red)
+                .set(SpreadsheetMetadataPropertyName.namedColor(redName), 12)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH);
+
+        this.nameToColorAndCheck(
+                metadata,
+                redName,
+                red
+        );
+    }
+
+    @Test
+    public void testNameToColorUsesDefaults() {
+        final Color red = Color.parse("#f00");
+        final SpreadsheetColorName redName = SpreadsheetColorName.RED;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .setDefaults(
+                        SpreadsheetMetadata.EMPTY
+                                .set(SpreadsheetMetadataPropertyName.numberedColor(23), red)
+                                .set(SpreadsheetMetadataPropertyName.namedColor(redName), 23)
+                );
+
+        this.nameToColorAndCheck(
+                metadata,
+                redName,
+                red
+        );
+    }
+
+    @Test
+    public void testNameToColorUsesDefaults2() {
+        final Color red = Color.parse("#f00");
+        final SpreadsheetColorName redName = SpreadsheetColorName.RED;
+        final int number = 12;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.numberedColor(number), red)
+                .setDefaults(
+                        SpreadsheetMetadata.EMPTY
+                                .set(SpreadsheetMetadataPropertyName.namedColor(redName), number)
+                );
+
+        this.numberToColorAndCheck(
+                metadata,
+                number,
+                red
+        );
+        this.nameToColorAndCheck(
+                metadata,
+                redName,
+                red
+        );
+    }
+
+    @Test
+    public void testNameToColorIgnoresDefaults() {
+        final Color red = Color.parse("#f00");
+        final SpreadsheetColorName redName = SpreadsheetColorName.RED;
+        final int number = 23;
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.numberedColor(number), red)
+                .setDefaults(
+                        SpreadsheetMetadata.EMPTY
+                                .set(SpreadsheetMetadataPropertyName.numberedColor(number), Color.parse("#999"))
+                                .set(SpreadsheetMetadataPropertyName.namedColor(redName), number)
+                );
+
+        this.numberToColorAndCheck(
+                metadata,
+                number,
+                red
+        );
+        this.nameToColorAndCheck(
+                metadata,
+                redName,
+                red
+        );
+    }
+
+    @Test
     public void testNameToColorDifferentCase() {
         final Color color1 = Color.fromRgb(0x111);
         final SpreadsheetColorName name1 = SpreadsheetColorName.with("title");


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3053
- SpreadsheetMetadata.nameToColor broken ignores default colors.