### PR TITLE
SpreadsheetDelta.patchFormatPattern with null absent cell fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
@@ -1227,7 +1227,7 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
         }
 
         if (patched.size() < cellRange.count()) {
-            final Optional<SpreadsheetFormatPattern> formatPattern = Optional.of(
+            final Optional<SpreadsheetFormatPattern> formatPattern = Optional.ofNullable(
                     context.unmarshallWithType(
                             format.objectOrFail()
                                     .getOrFail(FORMAT_PATTERN_PROPERTY)

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTest.java
@@ -1432,6 +1432,41 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
     }
 
     @Test
+    public void testPatchCellsWithFormatPatternNullClears2() {
+        final SpreadsheetCell a1 = SpreadsheetSelection.A1
+                .setFormula(SpreadsheetFormula.EMPTY);
+
+        final Optional<SpreadsheetFormatPattern> format = Optional.of(
+                SpreadsheetPattern.parseTextFormatPattern("@\"before\"")
+        );
+
+        final SpreadsheetDelta before = SpreadsheetDelta.EMPTY
+                .setCells(
+                        Sets.of(
+                                a1.setFormatPattern(format)
+                        )
+                );
+
+        final SpreadsheetDelta after = before.setCells(
+                Sets.of(
+                        a1,
+                        SpreadsheetSelection.parseCell("A2")
+                                .setFormula(SpreadsheetFormula.EMPTY)
+                )
+        );
+
+        this.patchCellsAndCheck(
+                before,
+                SpreadsheetSelection.parseCellRange("A1:A2"),
+                SpreadsheetDelta.formatPatternPatch(
+                        null,
+                        MARSHALL_CONTEXT
+                ),
+                after
+        );
+    }
+
+    @Test
     public void testPatchCellsWithFormatPatternAndWindow() {
         final Optional<SpreadsheetFormatPattern> beforeFormat = Optional.of(
                 SpreadsheetPattern.parseTextFormatPattern("@\"before\"")


### PR DESCRIPTION
- Attempting to patch a cell or range missing from the SpreadsheetDelta with a null (remove) format-pattern would fail.