### PR TITLE
SpreadsheetSelection.ALL_CELLS.cellStream() fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRange.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 /**
@@ -334,9 +335,9 @@ public final class SpreadsheetCellRange extends SpreadsheetCellReferenceOrRange
         final int width = this.width();
         final int columnOffset = begin.column().value();
 
-        return IntStream.range(0, width * this.height())
-                .mapToObj(index -> CELL_SPREADSHEET_REFERENCE_KIND.column(columnOffset + (index % width))
-                        .setRow(CELL_SPREADSHEET_REFERENCE_KIND.row(rowOffset + (index / width)))
+        return LongStream.range(0, width * this.height())
+                .mapToObj(index -> CELL_SPREADSHEET_REFERENCE_KIND.column(columnOffset + (int)(index % width))
+                        .setRow(CELL_SPREADSHEET_REFERENCE_KIND.row(rowOffset + (int)(index / width)))
                 );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeTest.java
@@ -981,6 +981,18 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetCellReferenceOrRa
 
     @Test
     public void testCellStream() {
+        final SpreadsheetCellRange range = SpreadsheetSelection.parseCellRange("A1:A2");
+
+        this.checkStream(
+                range,
+                range.cellStream(),
+                SpreadsheetSelection.A1,
+                SpreadsheetSelection.parseCell("A2")
+        );
+    }
+
+    @Test
+    public void testCellStream2() {
         final SpreadsheetCellRange range = this.range(3, 7, 5, 10);
 
         this.checkStream(
@@ -990,6 +1002,17 @@ public final class SpreadsheetCellRangeTest extends SpreadsheetCellReferenceOrRa
                 this.cellReference(3, 8), this.cellReference(4, 8), this.cellReference(5, 8),
                 this.cellReference(3, 9), this.cellReference(4, 9), this.cellReference(5, 9),
                 this.cellReference(3, 10), this.cellReference(4, 10), this.cellReference(5, 10));
+    }
+
+    @Test
+    public void testCellStreamAllCells() {
+        final SpreadsheetCellRange range = SpreadsheetSelection.ALL_CELLS;
+
+        this.checkEquals(
+                Long.valueOf(range.width() * range.height()),
+                range.cellStream()
+                        .count()
+        );
     }
 
     @Test


### PR DESCRIPTION
- was returning zero because of width * height both ints overflowing to 0.
- SpreadsheetCellRange.cellStream() uses longs rather than ints to loop over cells.