### PR TITLE
SpreadsheetCellStore.deleteCells(SpreadsheetCellRange) made abstract

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/store/FakeSpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/FakeSpreadsheetCellStore.java
@@ -35,6 +35,11 @@ public class FakeSpreadsheetCellStore extends FakeStore<SpreadsheetCellReference
     }
 
     @Override
+    public void deleteCells(final SpreadsheetCellRange range) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public int rows() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetCellStore.java
@@ -26,7 +26,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.store.SpreadsheetStore;
 import walkingkooka.store.Store;
 
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -44,12 +43,7 @@ public interface SpreadsheetCellStore extends SpreadsheetStore<SpreadsheetCellRe
     /**
      * Default implementation that deletes all the cells in the given {@link SpreadsheetCellRange}.
      */
-    default void deleteCells(final SpreadsheetCellRange range) {
-        Objects.requireNonNull(range, "ranges");
-
-        range.cellStream()
-                .forEach(this::delete);
-    }
+    void deleteCells(final SpreadsheetCellRange range);
 
     /**
      * Clears the parsed formula for all existing cells.

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore.java
@@ -172,6 +172,11 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore imple
                 .collect(Collectors.toCollection(TreeSet::new));
     }
 
+    @Override
+    public void deleteCells(final SpreadsheetCellRange range) {
+        this.store.deleteCells(range);
+    }
+
     // watchers.........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStore.java
@@ -96,6 +96,18 @@ final class TreeMapSpreadsheetCellStore implements SpreadsheetCellStore {
     }
 
     @Override
+    public void deleteCells(final SpreadsheetCellRange range) {
+        Objects.requireNonNull(range, "range");
+
+        this.store.all()
+                .stream()
+                .filter(c -> range.testCell(c.reference()))
+                .forEach(
+                        c -> this.delete(c.reference())
+                );
+    }
+
+    @Override
     public Runnable addDeleteWatcher(final Consumer<SpreadsheetCellReference> deleted) {
         return this.store.addDeleteWatcher(deleted);
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3075
- SpreadsheetCellStore.deleteCells(SpreadsheetCellRange) make abstract remove default implementation