### PR TITLE
SpreadsheetCellStoreActionSpreadsheetMetadataStore

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStore.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta.store;
+
+import walkingkooka.spreadsheet.SpreadsheetId;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.reference.store.SpreadsheetCellStoreAction;
+import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A {@link SpreadsheetMetadataStore} that watches each save {@link SpreadsheetMetadata} and determines if the cells
+ * belonging to the matching spreadsheet need to be cleared in some way. For example if the {@link SpreadsheetMetadataPropertyName#NUMBER_FORMAT_PATTERN}
+ * changes, then all cells need to be reformatted.
+ */
+final class SpreadsheetCellStoreActionSpreadsheetMetadataStore implements SpreadsheetMetadataStore {
+
+    static SpreadsheetCellStoreActionSpreadsheetMetadataStore with(final SpreadsheetMetadataStore metadataStore,
+                                                                   final SpreadsheetCellStore cellStore) {
+        Objects.requireNonNull(metadataStore, "metadataStore");
+        Objects.requireNonNull(cellStore, "cellStore");
+
+        return new SpreadsheetCellStoreActionSpreadsheetMetadataStore(
+                metadataStore,
+                cellStore
+        );
+    }
+
+    private SpreadsheetCellStoreActionSpreadsheetMetadataStore(final SpreadsheetMetadataStore metadataStore,
+                                                               final SpreadsheetCellStore cellStore) {
+        super();
+        this.metadataStore = metadataStore;
+        this.cellStore = cellStore;
+    }
+
+    @Override
+    public Optional<SpreadsheetMetadata> load(final SpreadsheetId spreadsheetId) {
+        return this.metadataStore.load(spreadsheetId);
+    }
+
+    @Override
+    public SpreadsheetMetadata save(final SpreadsheetMetadata metadata) {
+        final SpreadsheetMetadataStore metadataStore = this.metadataStore;
+        final Optional<SpreadsheetId> id = metadata.id();
+
+        final SpreadsheetMetadata saved;
+        if (id.isPresent()) {
+            final Optional<SpreadsheetMetadata> maybeBefore = metadataStore.load(id.get());
+
+            saved = metadataStore.save(metadata);
+
+            if (maybeBefore.isPresent()) {
+                final Map<SpreadsheetMetadataPropertyName<?>, Object> beforeMap = maybeBefore.get()
+                        .value();
+                final Map<SpreadsheetMetadataPropertyName<?>, Object> afterMap = metadata.value();
+
+                SpreadsheetCellStoreAction action = SpreadsheetCellStoreAction.NONE;
+
+                for (final Map.Entry<SpreadsheetMetadataPropertyName<?>, Object> nameAndValue : beforeMap.entrySet()) {
+                    final SpreadsheetMetadataPropertyName<?> name = nameAndValue.getKey();
+                    final Object value = nameAndValue.getValue();
+
+                    final Object otherValue = afterMap.get(name);
+                    if (false == value.equals(otherValue)) {
+                        action = action.max(name.spreadsheetCellStoreAction());
+
+                        if (action == SpreadsheetCellStoreAction.EVALUATE_AND_FORMAT) {
+                            break;
+                        }
+                    }
+                }
+
+                if (action != SpreadsheetCellStoreAction.EVALUATE_AND_FORMAT) {
+                    for (final Map.Entry<SpreadsheetMetadataPropertyName<?>, Object> nameAndValue : afterMap.entrySet()) {
+                        final SpreadsheetMetadataPropertyName<?> name = nameAndValue.getKey();
+                        final Object value = nameAndValue.getValue();
+
+                        final Object otherValue = beforeMap.get(name);
+                        if (false == value.equals(otherValue)) {
+                            action = action.max(name.spreadsheetCellStoreAction());
+
+                            if (action == SpreadsheetCellStoreAction.EVALUATE_AND_FORMAT) {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                switch (action) {
+                    case NONE:
+                        break;
+                    case PARSE_FORMULA:
+                        this.cellStore.clearParsedFormulaExpressions();
+                        break;
+                    case EVALUATE_AND_FORMAT:
+                        this.cellStore.clearFormatted();
+                        break;
+                }
+            }
+
+        } else {
+            saved = metadataStore.save(metadata);
+        }
+
+        return saved;
+    }
+
+    /**
+     * Holds the cells for the same spreadsheet.
+     */
+    private final SpreadsheetCellStore cellStore;
+
+    @Override
+    public Runnable addSaveWatcher(final Consumer<SpreadsheetMetadata> watcher) {
+        return this.metadataStore.addSaveWatcher(watcher);
+    }
+
+    @Override
+    public void delete(final SpreadsheetId spreadsheetId) {
+        this.metadataStore.delete(spreadsheetId);
+    }
+
+    @Override
+    public Runnable addDeleteWatcher(final Consumer<SpreadsheetId> watcher) {
+        return this.metadataStore.addDeleteWatcher(watcher);
+    }
+
+    @Override
+    public int count() {
+        return this.metadataStore.count();
+    }
+
+    @Override
+    public Set<SpreadsheetId> ids(final int from,
+                                  final int count) {
+        return this.metadataStore.ids(
+                from,
+                count
+        );
+    }
+
+    @Override
+    public List<SpreadsheetMetadata> values(final SpreadsheetId spreadsheetId,
+                                            final int count) {
+        return this.metadataStore.values(
+                spreadsheetId,
+                count
+        );
+    }
+
+    private final SpreadsheetMetadataStore metadataStore;
+
+    @Override
+    public String toString() {
+        return this.metadataStore.toString();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStores.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStores.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta.store;
 
 import walkingkooka.reflect.PublicStaticHelper;
+import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
 
 /**
  * Contains many factory methods for a variety of {@link SpreadsheetMetadataStore} implementations.
@@ -36,6 +37,17 @@ public final class SpreadsheetMetadataStores implements PublicStaticHelper {
      */
     public static SpreadsheetMetadataStore readOnly(final SpreadsheetMetadataStore store) {
         return ReadOnlySpreadsheetMetadataStore.with(store);
+    }
+
+    /**
+     * {@see SpreadsheetCellStoreActionSpreadsheetMetadataStore}
+     */
+    public static SpreadsheetMetadataStore spreadsheetCellStoreAction(final SpreadsheetMetadataStore metadataStore,
+                                                                      final SpreadsheetCellStore cellStore) {
+        return SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                metadataStore,
+                cellStore
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta.store;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.color.Color;
+import walkingkooka.net.email.EmailAddress;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.reference.SpreadsheetViewportSelectionAnchor;
+import walkingkooka.spreadsheet.reference.store.SpreadsheetCellStoreAction;
+import walkingkooka.spreadsheet.store.FakeSpreadsheetCellStore;
+import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
+import walkingkooka.spreadsheet.store.SpreadsheetCellStores;
+import walkingkooka.tree.text.TextStyle;
+import walkingkooka.tree.text.TextStylePropertyName;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extends SpreadsheetMetadataStoreTestCase<SpreadsheetCellStoreActionSpreadsheetMetadataStore> {
+
+    @Test
+    public void testSaveSameMetadataTwice() {
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = this.createStore(
+                SpreadsheetCellStores.fake() // interactions will throw UOE
+        );
+
+        final SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+        store.save(metadata);
+    }
+
+    @Test
+    public void testSaveSameMetadataTwice2() {
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = this.createStore(
+                SpreadsheetCellStores.fake() // interactions will throw UOE
+        );
+
+        final SpreadsheetMetadata metadata = store.save(this.metadata()
+                .set(
+                        SpreadsheetMetadataPropertyName.STYLE,
+                        TextStyle.EMPTY
+                                .set(TextStylePropertyName.COLOR, Color.BLACK)
+                )
+        );
+        store.save(metadata);
+    }
+
+    @Test
+    public void testSaveOnlyTimestampsUpdated() {
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = this.createStore(
+                SpreadsheetCellStores.fake() // interactions will throw UOE
+        );
+
+        final SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME,
+                        LocalDateTime.now()
+                )
+        );
+    }
+
+    @Test
+    public void testSaveSelectionChange() {
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = this.createStore(
+                SpreadsheetCellStores.fake() // interactions will throw UOE
+        );
+
+        final SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.SELECTION,
+                        SpreadsheetSelection.A1
+                                .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
+                )
+        );
+    }
+
+    // parse pattern....................................................................................................
+
+    @Test
+    public void testSaveParsePattern() {
+        final AtomicInteger cleared = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        cleared.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternSameTwice() {
+        final AtomicInteger cleared = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        cleared.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternSameTwice2() {
+        final AtomicInteger cleared = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        cleared.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                ).set(
+                        SpreadsheetMetadataPropertyName.CREATOR,
+                        EmailAddress.parse("different@example.com")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternDifferent() {
+        final AtomicInteger cleared = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        cleared.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                cleared.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.000")
+                )
+        );
+
+        this.checkEquals(
+                2,
+                cleared.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternThenTextFormat() {
+        final AtomicInteger clearParsed = new AtomicInteger();
+        final AtomicInteger clearFormatted = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        clearParsed.incrementAndGet();
+                    }
+
+                    @Override
+                    public void clearFormatted() {
+                        clearFormatted.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN,
+                        SpreadsheetPattern.parseTextFormatPattern("@@")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                1,
+                clearFormatted.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternThenTextFormatTwice() {
+        final AtomicInteger clearParsed = new AtomicInteger();
+        final AtomicInteger clearFormatted = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        clearParsed.incrementAndGet();
+                    }
+
+                    @Override
+                    public void clearFormatted() {
+                        clearFormatted.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN,
+                        SpreadsheetPattern.parseTextFormatPattern("@@")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                1,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN,
+                        SpreadsheetPattern.parseTextFormatPattern("@@@")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                2,
+                clearFormatted.get()
+        );
+    }
+
+    @Test
+    public void testSaveParsePatternThenTextFormatTwice2() {
+        final AtomicInteger clearParsed = new AtomicInteger();
+        final AtomicInteger clearFormatted = new AtomicInteger();
+
+        final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                new FakeSpreadsheetCellStore() {
+                    @Override
+                    public void clearParsedFormulaExpressions() {
+                        clearParsed.incrementAndGet();
+                    }
+
+                    @Override
+                    public void clearFormatted() {
+                        clearFormatted.incrementAndGet();
+                    }
+                }
+        );
+
+        SpreadsheetMetadata metadata = store.save(
+                this.metadata()
+        );
+
+        this.checkEquals(
+                0,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.NUMBER_PARSE_PATTERN,
+                        SpreadsheetPattern.parseNumberParsePattern("0.00")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                0,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.set(
+                        SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN,
+                        SpreadsheetPattern.parseTextFormatPattern("@@")
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                1,
+                clearFormatted.get()
+        );
+
+        metadata = store.save(
+                metadata.remove(
+                        SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN
+                )
+        );
+
+        this.checkEquals(
+                1,
+                clearParsed.get()
+        );
+        this.checkEquals(
+                2,
+                clearFormatted.get()
+        );
+    }
+
+    private SpreadsheetMetadata metadata() {
+        final LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        return SpreadsheetMetadata.EMPTY
+                .set(
+                        SpreadsheetMetadataPropertyName.LOCALE,
+                        Locale.ENGLISH
+                ).set(
+                        SpreadsheetMetadataPropertyName.CREATOR,
+                        EmailAddress.parse("creator@example")
+                ).set(
+                        SpreadsheetMetadataPropertyName.CREATE_DATE_TIME,
+                        yesterday
+                ).set(
+                        SpreadsheetMetadataPropertyName.MODIFIED_BY,
+                        EmailAddress.parse("creator@example")
+                ).set(
+                        SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME,
+                        yesterday
+                );
+    }
+
+    @Override
+    public SpreadsheetCellStoreActionSpreadsheetMetadataStore createStore() {
+        return this.createStore(
+                SpreadsheetCellStores.treeMap()
+        );
+    }
+
+    private SpreadsheetCellStoreActionSpreadsheetMetadataStore createStore(final SpreadsheetCellStore cellStore) {
+        return SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
+                SpreadsheetMetadataStores.treeMap(),
+                cellStore
+        );
+    }
+
+    @Override
+    public Class<SpreadsheetCellStoreActionSpreadsheetMetadataStore> type() {
+        return SpreadsheetCellStoreActionSpreadsheetMetadataStore.class;
+    }
+
+    @Override
+    public String typeNamePrefix() {
+        return SpreadsheetCellStoreAction.class.getSimpleName();
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/796
- Updating certain SpreadsheetMetadata properties should clear all cell formatted text

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/795
- Updating certain SpreadsheetMetadata properties should clear all cell parsed formulas