### PR TITLE
SpreadsheetCellStoreActionSpreadsheetMetadataStore Function<Spreadshe…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStores.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/store/SpreadsheetMetadataStores.java
@@ -18,7 +18,10 @@
 package walkingkooka.spreadsheet.meta.store;
 
 import walkingkooka.reflect.PublicStaticHelper;
+import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStore;
+
+import java.util.function.Function;
 
 /**
  * Contains many factory methods for a variety of {@link SpreadsheetMetadataStore} implementations.
@@ -43,7 +46,7 @@ public final class SpreadsheetMetadataStores implements PublicStaticHelper {
      * {@see SpreadsheetCellStoreActionSpreadsheetMetadataStore}
      */
     public static SpreadsheetMetadataStore spreadsheetCellStoreAction(final SpreadsheetMetadataStore metadataStore,
-                                                                      final SpreadsheetCellStore cellStore) {
+                                                                      final Function<SpreadsheetId, SpreadsheetCellStore> cellStore) {
         return SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 metadataStore,
                 cellStore

--- a/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/store/SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest.java
@@ -111,7 +111,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         cleared.incrementAndGet();
@@ -147,7 +147,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         cleared.incrementAndGet();
@@ -195,7 +195,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         cleared.incrementAndGet();
@@ -246,7 +246,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         cleared.incrementAndGet();
@@ -295,7 +295,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         clearParsed.incrementAndGet();
@@ -361,7 +361,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         clearParsed.incrementAndGet();
@@ -443,7 +443,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
 
         final SpreadsheetCellStoreActionSpreadsheetMetadataStore store = SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                new FakeSpreadsheetCellStore() {
+                (id) -> new FakeSpreadsheetCellStore() {
                     @Override
                     public void clearParsedFormulaExpressions() {
                         clearParsed.incrementAndGet();
@@ -548,7 +548,7 @@ public final class SpreadsheetCellStoreActionSpreadsheetMetadataStoreTest extend
     private SpreadsheetCellStoreActionSpreadsheetMetadataStore createStore(final SpreadsheetCellStore cellStore) {
         return SpreadsheetCellStoreActionSpreadsheetMetadataStore.with(
                 SpreadsheetMetadataStores.treeMap(),
-                cellStore
+                (id) -> cellStore
         );
     }
 


### PR DESCRIPTION
…etId, SpreadsheetCellStore>

- Previously no provision for different SpreadsheetCellStore for different SpreadsheetIds.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3092
- SpreadsheetCellStoreActionSpreadsheetMetadataStore replace SpreadsheetCellStore with Function<SpreadsheetId, SpreadsheetCellStore>