### PR TITLE
SpreadsheetViewportSelectionNavigation added Column & Row suffix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigation.java
@@ -33,59 +33,59 @@ import java.util.Optional;
 public abstract class SpreadsheetViewportSelectionNavigation implements HasText {
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationDown}
+     * {@see SpreadsheetViewportSelectionNavigationDownRow}
      */
-    public static SpreadsheetViewportSelectionNavigation extendDown() {
-        return SpreadsheetViewportSelectionNavigationExtendDown.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation extendDownRow() {
+        return SpreadsheetViewportSelectionNavigationExtendDownRow.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationExtendLeft}
+     * {@see SpreadsheetViewportSelectionNavigationExtendLeftColumn}
      */
-    public static SpreadsheetViewportSelectionNavigation extendLeft() {
-        return SpreadsheetViewportSelectionNavigationExtendLeft.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation extendLeftColumn() {
+        return SpreadsheetViewportSelectionNavigationExtendLeftColumn.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationExtendRight}
+     * {@see SpreadsheetViewportSelectionNavigationExtendRightColumn}
      */
-    public static SpreadsheetViewportSelectionNavigation extendRight() {
-        return SpreadsheetViewportSelectionNavigationExtendRight.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation extendRightColumn() {
+        return SpreadsheetViewportSelectionNavigationExtendRightColumn.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationExtendUp}
+     * {@see SpreadsheetViewportSelectionNavigationExtendUpRow}
      */
-    public static SpreadsheetViewportSelectionNavigation extendUp() {
-        return SpreadsheetViewportSelectionNavigationExtendUp.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation extendUpRow() {
+        return SpreadsheetViewportSelectionNavigationExtendUpRow.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationDown}
+     * {@see SpreadsheetViewportSelectionNavigationDownRow}
      */
-    public static SpreadsheetViewportSelectionNavigation down() {
-        return SpreadsheetViewportSelectionNavigationDown.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation downRow() {
+        return SpreadsheetViewportSelectionNavigationDownRow.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationLeft}
+     * {@see SpreadsheetViewportSelectionNavigationLeftColumn}
      */
-    public static SpreadsheetViewportSelectionNavigation left() {
-        return SpreadsheetViewportSelectionNavigationLeft.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation leftColumn() {
+        return SpreadsheetViewportSelectionNavigationLeftColumn.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationRight}
+     * {@see SpreadsheetViewportSelectionNavigationRightColumn}
      */
-    public static SpreadsheetViewportSelectionNavigation right() {
-        return SpreadsheetViewportSelectionNavigationRight.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation rightColumn() {
+        return SpreadsheetViewportSelectionNavigationRightColumn.INSTANCE;
     }
 
     /**
-     * {@see SpreadsheetViewportSelectionNavigationUp}
+     * {@see SpreadsheetViewportSelectionNavigationUpRow}
      */
-    public static SpreadsheetViewportSelectionNavigation up() {
-        return SpreadsheetViewportSelectionNavigationUp.INSTANCE;
+    public static SpreadsheetViewportSelectionNavigation upRow() {
+        return SpreadsheetViewportSelectionNavigationUpRow.INSTANCE;
     }
 
     SpreadsheetViewportSelectionNavigation() {
@@ -110,7 +110,7 @@ public abstract class SpreadsheetViewportSelectionNavigation implements HasText 
      * Accepts text that has a more pretty form of any {@link SpreadsheetViewportSelectionNavigation enum value}.
      * The text is identical to the enum name but in lower case and underscore replaced with dash.
      * <br>
-     * {@link #extendLeft()} = <pre>extend-left</pre>.
+     * {@link #extendLeftColumn()} = <pre>extend-left</pre>.
      */
     public static List<SpreadsheetViewportSelectionNavigation> parse(final String text) {
         return SpreadsheetViewportSelection.SEPARATOR.parse(
@@ -130,14 +130,14 @@ public abstract class SpreadsheetViewportSelectionNavigation implements HasText 
     }
 
     private final static SpreadsheetViewportSelectionNavigation[] VALUES = new SpreadsheetViewportSelectionNavigation[]{
-            down(),
-            left(),
-            right(),
-            up(),
-            extendDown(),
-            extendLeft(),
-            extendRight(),
-            extendUp()
+            downRow(),
+            leftColumn(),
+            rightColumn(),
+            upRow(),
+            extendDownRow(),
+            extendLeftColumn(),
+            extendRightColumn(),
+            extendUpRow()
     };
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationDownRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationDownRow.java
@@ -24,22 +24,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationExtendUp extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationDownRow extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationExtendUp INSTANCE = new SpreadsheetViewportSelectionNavigationExtendUp();
+    final static SpreadsheetViewportSelectionNavigationDownRow INSTANCE = new SpreadsheetViewportSelectionNavigationDownRow();
 
-    private SpreadsheetViewportSelectionNavigationExtendUp() {
+    private SpreadsheetViewportSelectionNavigationDownRow() {
         super();
     }
 
     @Override
     public String text() {
-        return "extend-up";
+        return "down";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationExtendDown;
+        return other instanceof SpreadsheetViewportSelectionNavigationUpRow;
     }
 
     @Override
@@ -47,10 +47,10 @@ final class SpreadsheetViewportSelectionNavigationExtendUp extends SpreadsheetVi
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.extendUp(
+        return selection.down(
                 anchor,
                 columnStore,
                 rowStore
-        );
+        ).map(s -> s.setAnchorOrDefault(anchor));
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendDownRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendDownRow.java
@@ -1,3 +1,6 @@
+
+
+
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -22,22 +25,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationLeft extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationExtendDownRow extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationLeft INSTANCE = new SpreadsheetViewportSelectionNavigationLeft();
+    final static SpreadsheetViewportSelectionNavigationExtendDownRow INSTANCE = new SpreadsheetViewportSelectionNavigationExtendDownRow();
 
-    private SpreadsheetViewportSelectionNavigationLeft() {
+    private SpreadsheetViewportSelectionNavigationExtendDownRow() {
         super();
     }
 
     @Override
     public String text() {
-        return "left";
+        return "extend-down";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationRight;
+        return other instanceof SpreadsheetViewportSelectionNavigationExtendUpRow;
     }
 
     @Override
@@ -45,10 +48,10 @@ final class SpreadsheetViewportSelectionNavigationLeft extends SpreadsheetViewpo
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.left(
+        return selection.extendDown(
                 anchor,
                 columnStore,
                 rowStore
-        ).map(s -> s.setAnchorOrDefault(anchor));
+        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendLeftColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendLeftColumn.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -23,22 +22,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationExtendRight extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationExtendLeftColumn extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationExtendRight INSTANCE = new SpreadsheetViewportSelectionNavigationExtendRight();
+    final static SpreadsheetViewportSelectionNavigationExtendLeftColumn INSTANCE = new SpreadsheetViewportSelectionNavigationExtendLeftColumn();
 
-    private SpreadsheetViewportSelectionNavigationExtendRight() {
+    private SpreadsheetViewportSelectionNavigationExtendLeftColumn() {
         super();
     }
 
     @Override
     public String text() {
-        return "extend-right";
+        return "extend-left";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationExtendLeft;
+        return other instanceof SpreadsheetViewportSelectionNavigationExtendRightColumn;
     }
 
     @Override
@@ -46,7 +45,7 @@ final class SpreadsheetViewportSelectionNavigationExtendRight extends Spreadshee
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.extendRight(
+        return selection.extendLeft(
                 anchor,
                 columnStore,
                 rowStore

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendRightColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendRightColumn.java
@@ -23,22 +23,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationRight extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationExtendRightColumn extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationRight INSTANCE = new SpreadsheetViewportSelectionNavigationRight();
+    final static SpreadsheetViewportSelectionNavigationExtendRightColumn INSTANCE = new SpreadsheetViewportSelectionNavigationExtendRightColumn();
 
-    private SpreadsheetViewportSelectionNavigationRight() {
+    private SpreadsheetViewportSelectionNavigationExtendRightColumn() {
         super();
     }
 
     @Override
     public String text() {
-        return "right";
+        return "extend-right";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationLeft;
+        return other instanceof SpreadsheetViewportSelectionNavigationExtendLeftColumn;
     }
 
     @Override
@@ -46,10 +46,10 @@ final class SpreadsheetViewportSelectionNavigationRight extends SpreadsheetViewp
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.right(
+        return selection.extendRight(
                 anchor,
                 columnStore,
                 rowStore
-        ).map(s -> s.setAnchorOrDefault(anchor));
+        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendUpRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendUpRow.java
@@ -24,22 +24,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationDown extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationExtendUpRow extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationDown INSTANCE = new SpreadsheetViewportSelectionNavigationDown();
+    final static SpreadsheetViewportSelectionNavigationExtendUpRow INSTANCE = new SpreadsheetViewportSelectionNavigationExtendUpRow();
 
-    private SpreadsheetViewportSelectionNavigationDown() {
+    private SpreadsheetViewportSelectionNavigationExtendUpRow() {
         super();
     }
 
     @Override
     public String text() {
-        return "down";
+        return "extend-up";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationUp;
+        return other instanceof SpreadsheetViewportSelectionNavigationExtendDownRow;
     }
 
     @Override
@@ -47,10 +47,10 @@ final class SpreadsheetViewportSelectionNavigationDown extends SpreadsheetViewpo
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.down(
+        return selection.extendUp(
                 anchor,
                 columnStore,
                 rowStore
-        ).map(s -> s.setAnchorOrDefault(anchor));
+        );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationLeftColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationLeftColumn.java
@@ -22,22 +22,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationExtendLeft extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationLeftColumn extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationExtendLeft INSTANCE = new SpreadsheetViewportSelectionNavigationExtendLeft();
+    final static SpreadsheetViewportSelectionNavigationLeftColumn INSTANCE = new SpreadsheetViewportSelectionNavigationLeftColumn();
 
-    private SpreadsheetViewportSelectionNavigationExtendLeft() {
+    private SpreadsheetViewportSelectionNavigationLeftColumn() {
         super();
     }
 
     @Override
     public String text() {
-        return "extend-left";
+        return "left";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationExtendRight;
+        return other instanceof SpreadsheetViewportSelectionNavigationRightColumn;
     }
 
     @Override
@@ -45,10 +45,10 @@ final class SpreadsheetViewportSelectionNavigationExtendLeft extends Spreadsheet
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.extendLeft(
+        return selection.left(
                 anchor,
                 columnStore,
                 rowStore
-        );
+        ).map(s -> s.setAnchorOrDefault(anchor));
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationRightColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationRightColumn.java
@@ -23,22 +23,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationUp extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationRightColumn extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationUp INSTANCE = new SpreadsheetViewportSelectionNavigationUp();
+    final static SpreadsheetViewportSelectionNavigationRightColumn INSTANCE = new SpreadsheetViewportSelectionNavigationRightColumn();
 
-    private SpreadsheetViewportSelectionNavigationUp() {
+    private SpreadsheetViewportSelectionNavigationRightColumn() {
         super();
     }
 
     @Override
     public String text() {
-        return "up";
+        return "right";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationDown;
+        return other instanceof SpreadsheetViewportSelectionNavigationLeftColumn;
     }
 
     @Override
@@ -46,7 +46,7 @@ final class SpreadsheetViewportSelectionNavigationUp extends SpreadsheetViewport
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.up(
+        return selection.right(
                 anchor,
                 columnStore,
                 rowStore

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationUpRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationUpRow.java
@@ -1,6 +1,4 @@
 
-
-
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -25,22 +23,22 @@ import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
 
 import java.util.Optional;
 
-final class SpreadsheetViewportSelectionNavigationExtendDown extends SpreadsheetViewportSelectionNavigation {
+final class SpreadsheetViewportSelectionNavigationUpRow extends SpreadsheetViewportSelectionNavigation {
 
-    final static SpreadsheetViewportSelectionNavigationExtendDown INSTANCE = new SpreadsheetViewportSelectionNavigationExtendDown();
+    final static SpreadsheetViewportSelectionNavigationUpRow INSTANCE = new SpreadsheetViewportSelectionNavigationUpRow();
 
-    private SpreadsheetViewportSelectionNavigationExtendDown() {
+    private SpreadsheetViewportSelectionNavigationUpRow() {
         super();
     }
 
     @Override
     public String text() {
-        return "extend-down";
+        return "up";
     }
 
     @Override
     boolean isOpposite(final SpreadsheetViewportSelectionNavigation other) {
-        return other instanceof SpreadsheetViewportSelectionNavigationExtendUp;
+        return other instanceof SpreadsheetViewportSelectionNavigationDownRow;
     }
 
     @Override
@@ -48,10 +46,10 @@ final class SpreadsheetViewportSelectionNavigationExtendDown extends Spreadsheet
                                                          final SpreadsheetViewportSelectionAnchor anchor,
                                                          final SpreadsheetColumnStore columnStore,
                                                          final SpreadsheetRowStore rowStore) {
-        return selection.extendDown(
+        return selection.up(
                 anchor,
                 columnStore,
                 rowStore
-        );
+        ).map(s -> s.setAnchorOrDefault(anchor));
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -11617,7 +11617,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                         .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.right()
+                                        SpreadsheetViewportSelectionNavigation.rightColumn()
                                 )
                         ),
                 context,
@@ -11643,7 +11643,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 engine,
                 viewportSelection.setNavigations(
                         Lists.of(
-                                SpreadsheetViewportSelectionNavigation.left()
+                                SpreadsheetViewportSelectionNavigation.leftColumn()
                         )
                 ),
                 context,
@@ -11667,7 +11667,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 selection.setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.right()
+                                        SpreadsheetViewportSelectionNavigation.rightColumn()
                                 )
                         ),
                 context,
@@ -11692,7 +11692,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 selection.setAnchor(SpreadsheetViewportSelectionAnchor.TOP_LEFT)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.extendRight()
+                                        SpreadsheetViewportSelectionNavigation.extendRightColumn()
                                 )
                         ),
                 context,
@@ -11727,7 +11727,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                         .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.left()
+                                        SpreadsheetViewportSelectionNavigation.leftColumn()
                                 )
                         ),
                 context,
@@ -11754,7 +11754,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                         .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.right()
+                                        SpreadsheetViewportSelectionNavigation.rightColumn()
                                 )
                         ),
                 context,
@@ -11781,7 +11781,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                         .setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
                         .setNavigations(
                                 Lists.of(
-                                        SpreadsheetViewportSelectionNavigation.down()
+                                        SpreadsheetViewportSelectionNavigation.downRow()
                                 )
                         ),
                 context,

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationDownRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationDownRowTest.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationLeftTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationLeft> {
+public final class SpreadsheetViewportSelectionNavigationDownRowTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationDownRow> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationLeft> type() {
-        return SpreadsheetViewportSelectionNavigationLeft.class;
+    public Class<SpreadsheetViewportSelectionNavigationDownRow> type() {
+        return SpreadsheetViewportSelectionNavigationDownRow.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendDownRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendDownRowTest.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -17,9 +18,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationUpTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationUp> {
+public final class SpreadsheetViewportSelectionNavigationExtendDownRowTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendDownRow> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationUp> type() {
-        return SpreadsheetViewportSelectionNavigationUp.class;
+    public Class<SpreadsheetViewportSelectionNavigationExtendDownRow> type() {
+        return SpreadsheetViewportSelectionNavigationExtendDownRow.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendLeftColumnTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendLeftColumnTest.java
@@ -18,9 +18,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationExtendUpTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendUp> {
+public final class SpreadsheetViewportSelectionNavigationExtendLeftColumnTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendLeftColumn> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationExtendUp> type() {
-        return SpreadsheetViewportSelectionNavigationExtendUp.class;
+    public Class<SpreadsheetViewportSelectionNavigationExtendLeftColumn> type() {
+        return SpreadsheetViewportSelectionNavigationExtendLeftColumn.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendRightColumnTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendRightColumnTest.java
@@ -18,9 +18,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationExtendDownTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendDown> {
+public final class SpreadsheetViewportSelectionNavigationExtendRightColumnTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendRightColumn> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationExtendDown> type() {
-        return SpreadsheetViewportSelectionNavigationExtendDown.class;
+    public Class<SpreadsheetViewportSelectionNavigationExtendRightColumn> type() {
+        return SpreadsheetViewportSelectionNavigationExtendRightColumn.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendUpRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationExtendUpRowTest.java
@@ -18,9 +18,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationExtendRightTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendRight> {
+public final class SpreadsheetViewportSelectionNavigationExtendUpRowTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendUpRow> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationExtendRight> type() {
-        return SpreadsheetViewportSelectionNavigationExtendRight.class;
+    public Class<SpreadsheetViewportSelectionNavigationExtendUpRow> type() {
+        return SpreadsheetViewportSelectionNavigationExtendUpRow.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationLeftColumnTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationLeftColumnTest.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationDownTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationDown> {
+public final class SpreadsheetViewportSelectionNavigationLeftColumnTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationLeftColumn> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationDown> type() {
-        return SpreadsheetViewportSelectionNavigationDown.class;
+    public Class<SpreadsheetViewportSelectionNavigationLeftColumn> type() {
+        return SpreadsheetViewportSelectionNavigationLeftColumn.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationRightColumnTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationRightColumnTest.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -18,9 +17,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationExtendLeftTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationExtendLeft> {
+public final class SpreadsheetViewportSelectionNavigationRightColumnTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationRightColumn> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationExtendLeft> type() {
-        return SpreadsheetViewportSelectionNavigationExtendLeft.class;
+    public Class<SpreadsheetViewportSelectionNavigationRightColumn> type() {
+        return SpreadsheetViewportSelectionNavigationRightColumn.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationTest.java
@@ -63,7 +63,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         this.parseStringAndCheck(
                 "left",
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left()
+                        SpreadsheetViewportSelectionNavigation.leftColumn()
                 )
         );
     }
@@ -73,7 +73,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         this.parseStringAndCheck(
                 "extend-right",
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendRight()
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn()
                 )
         );
     }
@@ -83,10 +83,10 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         this.parseStringAndCheck(
                 "left,right,up,extend-down",
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.extendDown()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.extendDownRow()
                 )
         );
     }
@@ -96,7 +96,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnLeft() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.left(),
+                SpreadsheetViewportSelectionNavigation.leftColumn(),
                 SpreadsheetSelection.parseColumn("C"),
                 SpreadsheetSelection.parseColumn("B")
 
@@ -106,7 +106,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateRowLeft() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.left(),
+                SpreadsheetViewportSelectionNavigation.leftColumn(),
                 SpreadsheetSelection.parseRow("12")
         );
     }
@@ -114,7 +114,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateRowDown() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.down(),
+                SpreadsheetViewportSelectionNavigation.downRow(),
                 SpreadsheetSelection.parseRow("12"),
                 SpreadsheetSelection.parseRow("13")
 
@@ -124,7 +124,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateCellUp() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.up(),
+                SpreadsheetViewportSelectionNavigation.upRow(),
                 SpreadsheetSelection.parseCell("C3"),
                 SpreadsheetSelection.parseCell("C2")
 
@@ -134,7 +134,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnRangeUp() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.up(),
+                SpreadsheetViewportSelectionNavigation.upRow(),
                 SpreadsheetSelection.parseColumnRange("B:C")
         );
     }
@@ -142,7 +142,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnRangeAnchorLeftNavigateLeft() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.left(),
+                SpreadsheetViewportSelectionNavigation.leftColumn(),
                 SpreadsheetSelection.parseColumnRange("B:C"),
                 SpreadsheetViewportSelectionAnchor.LEFT,
                 SpreadsheetSelection.parseColumn("B").setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
@@ -156,7 +156,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         columnStore.save(SpreadsheetSelection.parseColumn("D").column().setHidden(true));
 
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendRight(),
+                SpreadsheetViewportSelectionNavigation.extendRightColumn(),
                 SpreadsheetSelection.parseColumnRange("B:C"),
                 SpreadsheetViewportSelectionAnchor.LEFT,
                 columnStore,
@@ -167,7 +167,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnRangeAnchorRightNavigateLeft() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.left(),
+                SpreadsheetViewportSelectionNavigation.leftColumn(),
                 SpreadsheetSelection.parseColumnRange("B:C"),
                 SpreadsheetViewportSelectionAnchor.RIGHT,
                 SpreadsheetSelection.parseColumn("A").setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
@@ -177,7 +177,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnRangeAnchorLeftNavigateRight() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.right(),
+                SpreadsheetViewportSelectionNavigation.rightColumn(),
                 SpreadsheetSelection.parseColumnRange("B:C"),
                 SpreadsheetViewportSelectionAnchor.LEFT,
                 SpreadsheetSelection.parseColumn("D").setAnchor(SpreadsheetViewportSelectionAnchor.NONE)
@@ -191,7 +191,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         columnStore.save(SpreadsheetSelection.parseColumn("E").column().setHidden(true));
 
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendRight(),
+                SpreadsheetViewportSelectionNavigation.extendRightColumn(),
                 SpreadsheetSelection.parseColumnRange("B:C"),
                 SpreadsheetViewportSelectionAnchor.LEFT,
                 columnStore,
@@ -202,7 +202,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnExtendLeft() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendLeft(),
+                SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
                 SpreadsheetSelection.parseColumn("C"),
                 SpreadsheetViewportSelectionAnchor.LEFT,
                 SpreadsheetSelection.parseColumnRange("B:C").setAnchor(SpreadsheetViewportSelectionAnchor.RIGHT)
@@ -212,7 +212,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateColumnExtendUp() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendUp(),
+                SpreadsheetViewportSelectionNavigation.extendUpRow(),
                 SpreadsheetSelection.parseColumn("C")
         );
     }
@@ -224,7 +224,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         rowStore.save(SpreadsheetSelection.parseRow("4").row().setHidden(true));
 
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendUp(),
+                SpreadsheetViewportSelectionNavigation.extendUpRow(),
                 SpreadsheetSelection.parseRowRange("5:6"),
                 SpreadsheetViewportSelectionAnchor.BOTTOM,
                 rowStore,
@@ -235,7 +235,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateRowExtendRight() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendRight(),
+                SpreadsheetViewportSelectionNavigation.extendRightColumn(),
                 SpreadsheetSelection.parseRow("3")
         );
     }
@@ -243,7 +243,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testUpdateRowRangeExtendDown() {
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendDown(),
+                SpreadsheetViewportSelectionNavigation.extendDownRow(),
                 SpreadsheetSelection.parseRowRange("3:4"),
                 SpreadsheetViewportSelectionAnchor.TOP,
                 SpreadsheetSelection.parseRowRange("3:5").setAnchor(SpreadsheetViewportSelectionAnchor.TOP)
@@ -257,7 +257,7 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
         rowStore.save(SpreadsheetSelection.parseRow("6").row().setHidden(true));
 
         this.updateAndCheck(
-                SpreadsheetViewportSelectionNavigation.extendDown(),
+                SpreadsheetViewportSelectionNavigation.extendDownRow(),
                 SpreadsheetSelection.parseRowRange("3:4"),
                 SpreadsheetViewportSelectionAnchor.TOP,
                 rowStore,
@@ -388,55 +388,55 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     @Test
     public void testCompactOne() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.up()
+                SpreadsheetViewportSelectionNavigation.upRow()
         );
     }
 
     @Test
     public void testCompactOne2() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.right()
+                SpreadsheetViewportSelectionNavigation.rightColumn()
         );
     }
 
     @Test
     public void testCompactManyNoOpposites() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.left()
+                SpreadsheetViewportSelectionNavigation.leftColumn()
         );
     }
 
     @Test
     public void testCompactManyNoOpposites2() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.right(),
-                SpreadsheetViewportSelectionNavigation.right()
+                SpreadsheetViewportSelectionNavigation.rightColumn(),
+                SpreadsheetViewportSelectionNavigation.rightColumn()
         );
     }
 
     @Test
     public void testCompactManyNoOpposites3() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.up(),
-                SpreadsheetViewportSelectionNavigation.extendUp()
+                SpreadsheetViewportSelectionNavigation.upRow(),
+                SpreadsheetViewportSelectionNavigation.extendUpRow()
         );
     }
 
     @Test
     public void testCompactManyNoOpposites4() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.down(),
-                SpreadsheetViewportSelectionNavigation.extendUp()
+                SpreadsheetViewportSelectionNavigation.downRow(),
+                SpreadsheetViewportSelectionNavigation.extendUpRow()
         );
     }
 
     @Test
     public void testCompactManyNoOpposites5() {
         this.compactAndCheck(
-                SpreadsheetViewportSelectionNavigation.left(),
-                SpreadsheetViewportSelectionNavigation.extendRight(),
-                SpreadsheetViewportSelectionNavigation.up(),
-                SpreadsheetViewportSelectionNavigation.extendDown()
+                SpreadsheetViewportSelectionNavigation.leftColumn(),
+                SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                SpreadsheetViewportSelectionNavigation.upRow(),
+                SpreadsheetViewportSelectionNavigation.extendDownRow()
         );
     }
 
@@ -444,8 +444,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftRight() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn()
                 )
         );
     }
@@ -454,8 +454,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactUpDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.down()
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.downRow()
                 )
         );
     }
@@ -464,8 +464,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactRightLeft() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left()
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn()
                 )
         );
     }
@@ -474,8 +474,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactDownUp() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.down(),
-                        SpreadsheetViewportSelectionNavigation.up()
+                        SpreadsheetViewportSelectionNavigation.downRow(),
+                        SpreadsheetViewportSelectionNavigation.upRow()
                 )
         );
     }
@@ -485,8 +485,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendLeftExtendRight() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendLeft(),
-                        SpreadsheetViewportSelectionNavigation.extendRight()
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn()
                 )
         );
     }
@@ -495,8 +495,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendUpExtendDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendUp(),
-                        SpreadsheetViewportSelectionNavigation.extendDown()
+                        SpreadsheetViewportSelectionNavigation.extendUpRow(),
+                        SpreadsheetViewportSelectionNavigation.extendDownRow()
                 )
         );
     }
@@ -505,8 +505,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendRightExtendLeft() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendRight(),
-                        SpreadsheetViewportSelectionNavigation.extendLeft()
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn()
                 )
         );
     }
@@ -515,8 +515,8 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendDownExtendUp() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendDown(),
-                        SpreadsheetViewportSelectionNavigation.extendUp()
+                        SpreadsheetViewportSelectionNavigation.extendDownRow(),
+                        SpreadsheetViewportSelectionNavigation.extendUpRow()
                 )
         );
     }
@@ -525,10 +525,10 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftRightLeftRight() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn()
                 )
         );
     }
@@ -537,13 +537,13 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftRightLeftRightLeft() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn()
                 ),
-                SpreadsheetViewportSelectionNavigation.left()
+                SpreadsheetViewportSelectionNavigation.leftColumn()
         );
     }
 
@@ -551,13 +551,13 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftRightLeftRightRight() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.right()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn()
                 ),
-                SpreadsheetViewportSelectionNavigation.right()
+                SpreadsheetViewportSelectionNavigation.rightColumn()
         );
     }
 
@@ -565,13 +565,13 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftRightLeftRightUp() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.up()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow()
                 ),
-                SpreadsheetViewportSelectionNavigation.up()
+                SpreadsheetViewportSelectionNavigation.upRow()
         );
     }
 
@@ -579,10 +579,10 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactLeftUpRightDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.left(),
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.down()
+                        SpreadsheetViewportSelectionNavigation.leftColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.downRow()
                 )
         );
     }
@@ -591,10 +591,10 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendLeftExtendUpExtendRightExtendDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendLeft(),
-                        SpreadsheetViewportSelectionNavigation.extendUp(),
-                        SpreadsheetViewportSelectionNavigation.extendRight(),
-                        SpreadsheetViewportSelectionNavigation.extendDown()
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
+                        SpreadsheetViewportSelectionNavigation.extendUpRow(),
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                        SpreadsheetViewportSelectionNavigation.extendDownRow()
                 )
         );
     }
@@ -603,10 +603,10 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendLeftUpExtendRightDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendLeft(),
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.extendRight(),
-                        SpreadsheetViewportSelectionNavigation.down()
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                        SpreadsheetViewportSelectionNavigation.downRow()
                 )
         );
     }
@@ -615,13 +615,13 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendLeftUpExtendRightDownDown() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendLeft(),
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.extendRight(),
-                        SpreadsheetViewportSelectionNavigation.down(),
-                        SpreadsheetViewportSelectionNavigation.down()
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                        SpreadsheetViewportSelectionNavigation.downRow(),
+                        SpreadsheetViewportSelectionNavigation.downRow()
                 ),
-                SpreadsheetViewportSelectionNavigation.down()
+                SpreadsheetViewportSelectionNavigation.downRow()
         );
     }
 
@@ -629,15 +629,15 @@ public final class SpreadsheetViewportSelectionNavigationTest implements ParseSt
     public void testCompactExtendLeftUpExtendRightDownRightExtendLeft() {
         this.compactAndCheck(
                 Lists.of(
-                        SpreadsheetViewportSelectionNavigation.extendLeft(),
-                        SpreadsheetViewportSelectionNavigation.up(),
-                        SpreadsheetViewportSelectionNavigation.extendRight(),
-                        SpreadsheetViewportSelectionNavigation.down(),
-                        SpreadsheetViewportSelectionNavigation.right(),
-                        SpreadsheetViewportSelectionNavigation.extendLeft()
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn(),
+                        SpreadsheetViewportSelectionNavigation.upRow(),
+                        SpreadsheetViewportSelectionNavigation.extendRightColumn(),
+                        SpreadsheetViewportSelectionNavigation.downRow(),
+                        SpreadsheetViewportSelectionNavigation.rightColumn(),
+                        SpreadsheetViewportSelectionNavigation.extendLeftColumn()
                 ),
-                SpreadsheetViewportSelectionNavigation.right(),
-                SpreadsheetViewportSelectionNavigation.extendLeft()
+                SpreadsheetViewportSelectionNavigation.rightColumn(),
+                SpreadsheetViewportSelectionNavigation.extendLeftColumn()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationUpRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionNavigationUpRowTest.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.reference;
 
-public final class SpreadsheetViewportSelectionNavigationRightTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationRight> {
+public final class SpreadsheetViewportSelectionNavigationUpRowTest extends SpreadsheetViewportSelectionNavigationTestCase<SpreadsheetViewportSelectionNavigationUpRow> {
     @Override
-    public Class<SpreadsheetViewportSelectionNavigationRight> type() {
-        return SpreadsheetViewportSelectionNavigationRight.class;
+    public Class<SpreadsheetViewportSelectionNavigationUpRow> type() {
+        return SpreadsheetViewportSelectionNavigationUpRow.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportSelectionTest.java
@@ -54,7 +54,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
     private static final SpreadsheetSelection SELECTION = CELL_RANGE;
     private static final SpreadsheetViewportSelectionAnchor ANCHOR = SpreadsheetViewportSelectionAnchor.TOP_LEFT;
     private static final List<SpreadsheetViewportSelectionNavigation> NAVIGATIONS = Lists.of(
-            SpreadsheetViewportSelectionNavigation.left()
+            SpreadsheetViewportSelectionNavigation.leftColumn()
     );
 
     @Test
@@ -145,7 +145,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
     private void withNonRangeAndCheck(final SpreadsheetSelection selection) {
         final SpreadsheetViewportSelectionAnchor anchor = SpreadsheetViewportSelectionAnchor.NONE;
         final List<SpreadsheetViewportSelectionNavigation> navigations = Lists.of(
-                SpreadsheetViewportSelectionNavigation.left()
+                SpreadsheetViewportSelectionNavigation.leftColumn()
         );
 
         final SpreadsheetViewportSelection viewportSelection = SpreadsheetViewportSelection.with(
@@ -444,7 +444,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
     public void testSetNavigationsDifferent() {
         final SpreadsheetViewportSelection selection = this.createObject();
         final List<SpreadsheetViewportSelectionNavigation> navigations = Lists.of(
-                SpreadsheetViewportSelectionNavigation.extendRight()
+                SpreadsheetViewportSelectionNavigation.extendRightColumn()
         );
         this.checkNotEquals(
                 NAVIGATIONS,
@@ -529,7 +529,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
                         SELECTION,
                         SpreadsheetViewportSelectionAnchor.BOTTOM_RIGHT,
                         Lists.of(
-                                SpreadsheetViewportSelectionNavigation.right()
+                                SpreadsheetViewportSelectionNavigation.rightColumn()
                         )
                 )
         );
@@ -571,7 +571,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
                         SpreadsheetSelection.A1,
                         SpreadsheetViewportSelectionAnchor.NONE,
                         Lists.of(
-                                SpreadsheetViewportSelectionNavigation.left()
+                                SpreadsheetViewportSelectionNavigation.leftColumn()
                         )
                 ),
                 "cell A1 left" + EOL
@@ -585,8 +585,8 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
                         SpreadsheetSelection.A1,
                         SpreadsheetViewportSelectionAnchor.NONE,
                         Lists.of(
-                                SpreadsheetViewportSelectionNavigation.left(),
-                                SpreadsheetViewportSelectionNavigation.up()
+                                SpreadsheetViewportSelectionNavigation.leftColumn(),
+                                SpreadsheetViewportSelectionNavigation.upRow()
                         )
                 ),
                 "cell A1 left,up" + EOL
@@ -600,7 +600,7 @@ public final class SpreadsheetViewportSelectionTest implements ClassTesting<Spre
                         SpreadsheetSelection.parseRowRange("12:34"),
                         SpreadsheetViewportSelectionAnchor.TOP,
                         Lists.of(
-                                SpreadsheetViewportSelectionNavigation.left()
+                                SpreadsheetViewportSelectionNavigation.leftColumn()
                         )
                 ),
                 "row-range 12:34 TOP left" + EOL


### PR DESCRIPTION
- Did not modify text form of each navigation, SpreadsheetViewportSelectionNavigationLeftColumn.text() remains "left".