### PR TITLE
SpreadsheetSelection.parseColumn throws InvalidCharacterException pre…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -383,8 +383,8 @@ public abstract class SpreadsheetSelection implements HasText,
      * Leverages the {@link SpreadsheetParsers#column()} combined with an error reporter.
      */
     private static final Parser<SpreadsheetParserContext> COLUMN_PARSER = SpreadsheetParsers.column()
-            .orFailIfCursorNotEmpty(ParserReporters.basic())
-            .orReport(ParserReporters.basic());
+            .orFailIfCursorNotEmpty(ParserReporters.invalidCharacterException())
+            .orReport(ParserReporters.invalidCharacterException());
 
     /**
      * Parses the text into a {@link SpreadsheetColumnReference} or {@link SpreadsheetColumnReferenceRange}.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -306,17 +306,39 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
     // parseColumn......................................................................................................
 
     @Test
+    public void testParseColumnWithCellails() {
+        final String text = "ZY99";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseColumn(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 2).getMessage(),
+                thrown.getMessage()
+        );
+    }
+
+    @Test
     public void testParseColumnWithRangeFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> SpreadsheetSelection.parseColumn("B:C")
+        final String text = "B:C";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseColumn(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 1).getMessage(),
+                thrown.getMessage()
         );
     }
 
     @Test
     public void testParseColumnWithRowFails() {
         assertThrows(
-                IllegalArgumentException.class,
+                InvalidCharacterException.class,
                 () -> SpreadsheetSelection.parseColumn("1")
         );
     }


### PR DESCRIPTION
…viously IllegalArgumentException.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3145
- SpreadsheetSelection.parseColumn should throw ICE