### PR TITLE
SpreadsheetSelection.parseRow throws InvalidCharacterException previo…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -412,15 +412,19 @@ public abstract class SpreadsheetSelection implements HasText,
      * Parsers the text expecting a valid {@link SpreadsheetRowReference} or fails.
      */
     public static SpreadsheetRowReference parseRow(final String text) {
-        return parseColumnOrRow(text, ROW_PARSER, SpreadsheetRowReferenceParserToken.class).value();
+        return parseColumnOrRow(
+                text,
+                ROW_PARSER,
+                SpreadsheetRowReferenceParserToken.class)
+                .value();
     }
 
     /**
      * Leverages the {@link SpreadsheetParsers#row()} combined with an error reporter.
      */
     private static final Parser<SpreadsheetParserContext> ROW_PARSER = SpreadsheetParsers.row()
-            .orFailIfCursorNotEmpty(ParserReporters.basic())
-            .orReport(ParserReporters.basic());
+            .orFailIfCursorNotEmpty(ParserReporters.invalidCharacterException())
+            .orReport(ParserReporters.invalidCharacterException());
 
     /**
      * Parsers the text expecting a valid {@link SpreadsheetRowReference} or fails.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -647,18 +647,50 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
     // parseRow.........................................................................................................
 
     @Test
+    public void testParseRowWithCellFails() {
+        final String text = "A23";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseRow(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 0)
+                        .getMessage(),
+                thrown.getMessage()
+        );
+    }
+
+    @Test
     public void testParseRowWithColumnFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> SpreadsheetSelection.parseRow("A")
+        final String text = "A";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseRow(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 0)
+                        .getMessage(),
+                thrown.getMessage()
         );
     }
 
     @Test
     public void testParseRowWithRangeFails() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> SpreadsheetSelection.parseRow("12:3")
+        final String text = "12:34";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseRow(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 2)
+                        .getMessage(),
+                thrown.getMessage()
         );
     }
 


### PR DESCRIPTION
…usly IllegalArgumentException

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3146
- SpreadsheetSelection.parseRow should throw ICE