### PR TITLE
SpreadsheetSelection.parseCell throws InvalidCharacterException.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -66,8 +66,8 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
 
     // Used by SpreadsheetSelection
     static final Parser<SpreadsheetParserContext> PARSER = SpreadsheetParsers.cell()
-            .orFailIfCursorNotEmpty(ParserReporters.basic())
-            .orReport(ParserReporters.basic());
+            .orFailIfCursorNotEmpty(ParserReporters.invalidCharacterException())
+            .orReport(ParserReporters.invalidCharacterException());
 
     /**
      * Factory that creates a {@link SpreadsheetCellReference} with the given column and row.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.reference;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.Range;
 import walkingkooka.compare.ComparableTesting2;
 import walkingkooka.net.http.server.hateos.HateosResourceTesting;
@@ -988,9 +989,14 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
 
     @Test
     public void testParseCellReferenceRangeFails() {
+        final String text = "A1:B2";
+
         this.parseStringFails(
-                "A1:B2",
-                new IllegalArgumentException("Invalid character ':' at (3,1) \"A1:B2\" expected cell")
+                text,
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf(':')
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -247,9 +247,29 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
 
     @Test
     public void testParseCell() {
-        this.checkEquals(SpreadsheetSelection.A1,
-                SpreadsheetSelection.cell(SpreadsheetSelection.parseColumn("A"),
-                        SpreadsheetSelection.parseRow("1")));
+        this.checkEquals(
+                SpreadsheetSelection.A1,
+                SpreadsheetSelection.cell(
+                        SpreadsheetSelection.parseColumn("A"),
+                        SpreadsheetSelection.parseRow("1")
+                )
+        );
+    }
+
+    @Test
+    public void testParseCellFails() {
+        final String text = "ABC!123";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseCell(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(text, 0).getMessage(),
+                thrown.getMessage(),
+                () -> thrown.getClass().getName()
+        );
     }
 
     // parseCellRangeOrLabel............................................................................................
@@ -636,12 +656,12 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
 
     @Test
     public void testParseCellOrCellRangeInvalidCellFails() {
-        final IllegalArgumentException thrown = assertThrows(
-                IllegalArgumentException.class,
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
                 () -> SpreadsheetSelection.parseCellOrCellRange("A@@@")
         );
         this.checkEquals(
-                "Invalid character 'A' at (1,1) \"A@@@\" expected cell",
+                "Invalid character 'A' at 0 in \"A@@@\"",
                 thrown.getMessage(),
                 "message"
         );


### PR DESCRIPTION
- Reports start of text rather than actual location of invalid character because SequenceParser restores upon failure.
- Probably needs a TextCursor that tracks the further character it advances, and uses that for the ICE.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3140
- SpreadsheetSelection.parseCell throws ICE