### PR TITLE
SpreadsheetSelection.parseCellXXX InvalidCharacterException position fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -39,7 +39,7 @@ import walkingkooka.text.CaseKind;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.CharacterConstant;
 import walkingkooka.text.HasText;
-import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.MaxPositionTextCursor;
 import walkingkooka.text.cursor.TextCursorLineInfo;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.Parser;
@@ -473,7 +473,9 @@ public abstract class SpreadsheetSelection implements HasText,
                                                                                                                  final Function<Range<S>, R> rangeFactory) {
         checkText(text);
 
-        final TextCursor cursor = TextCursors.charSequence(text);
+        final MaxPositionTextCursor cursor = TextCursors.maxPosition(
+                TextCursors.charSequence(text)
+        );
         final SpreadsheetParserContext context = SpreadsheetParserContexts.fake();
 
         ParserToken lower = parser.parse(cursor, context)
@@ -490,8 +492,10 @@ public abstract class SpreadsheetSelection implements HasText,
         if (!cursor.isEmpty()) {
             final char separator = cursor.at();
             if (SEPARATOR.character() != separator) {
-                final TextCursorLineInfo lineInfo = cursor.lineInfo();
-                throw new InvalidCharacterException(text, lineInfo.column() - 1);
+                throw new InvalidCharacterException(
+                        text,
+                        cursor.max()
+                );
             }
             cursor.next();
 
@@ -502,14 +506,18 @@ public abstract class SpreadsheetSelection implements HasText,
             upper = parser.parse(cursor, context)
                     .orElse(null);
             if (null == upper) {
-                final TextCursorLineInfo lineInfo = cursor.lineInfo();
-                throw new InvalidCharacterException(text, lineInfo.column() - 1);
+                throw new InvalidCharacterException(
+                        text,
+                        cursor.max()
+                );
             }
             upperSelection = parserTokenToSelection.apply(upper);
 
             if (false == cursor.isEmpty()) {
-                final TextCursorLineInfo lineInfo = cursor.lineInfo();
-                throw new InvalidCharacterException(text, lineInfo.column() - 1);
+                throw new InvalidCharacterException(
+                        text,
+                        cursor.max()
+                );
             }
         }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -266,9 +266,32 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
         );
 
         this.checkEquals(
-                new InvalidCharacterException(text, 0).getMessage(),
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf('!')
+                ).getMessage(),
                 thrown.getMessage(),
                 () -> thrown.getClass().getName()
+        );
+    }
+
+    // parseCellRange...................................................................................................
+
+    @Test
+    public void testParseCellRangeFails() {
+        final String text = "A1:B!Hello";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseCellRange(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf("!")
+                ).getMessage(),
+                thrown.getMessage()
         );
     }
 
@@ -287,6 +310,24 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
         assertThrows(
                 IllegalArgumentException.class,
                 () -> SpreadsheetSelection.parseCellRangeOrLabel("")
+        );
+    }
+
+    @Test
+    public void testParseCellRangeOrLabelWithInvalidFails() {
+        final String text = "A1:B!Hello";
+
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetSelection.parseCellRange(text)
+        );
+
+        this.checkEquals(
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf("!")
+                ).getMessage(),
+                thrown.getMessage()
         );
     }
 
@@ -674,12 +715,17 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
 
     @Test
     public void testParseCellOrCellRangeInvalidCellFails() {
+        final String text = "A@@@";
+
         final InvalidCharacterException thrown = assertThrows(
                 InvalidCharacterException.class,
-                () -> SpreadsheetSelection.parseCellOrCellRange("A@@@")
+                () -> SpreadsheetSelection.parseCellOrCellRange(text)
         );
         this.checkEquals(
-                "Invalid character 'A' at 0 in \"A@@@\"",
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf('@')
+                ).getMessage(),
                 thrown.getMessage(),
                 "message"
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3164
- SpreadsheetSelection.parseCell and parseCellRange should report actual invalid character position rather than start etc