### PR TITLE
SpreadsheetReferenceKind static initializer NPE fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetViewportWindows.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetViewportWindows.java
@@ -23,6 +23,7 @@ import walkingkooka.collect.set.Sets;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CharacterConstant;
@@ -163,11 +164,11 @@ public final class SpreadsheetViewportWindows implements Iterable<SpreadsheetCel
     private Optional<SpreadsheetCellRange> bounds;
 
     private Optional<SpreadsheetCellRange> boundsNotEmpty() {
-        SpreadsheetColumnReference left = SpreadsheetColumnReference.MAX;
-        SpreadsheetRowReference top = SpreadsheetRowReference.MAX;
+        SpreadsheetColumnReference left = SpreadsheetReferenceKind.RELATIVE.lastColumn();
+        SpreadsheetRowReference top = SpreadsheetReferenceKind.RELATIVE.lastRow();
 
-        SpreadsheetColumnReference right = SpreadsheetColumnReference.MIN;
-        SpreadsheetRowReference bottom = SpreadsheetRowReference.MIN;
+        SpreadsheetColumnReference right = SpreadsheetReferenceKind.RELATIVE.firstColumn();
+        SpreadsheetRowReference bottom = SpreadsheetReferenceKind.RELATIVE.firstRow();
 
         for (final SpreadsheetCellRange range : this.cellRanges()) {
             final SpreadsheetCellReference begin = range.begin();

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -40,39 +40,38 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
 
     final static String MAX_TOSTRING = toString0(MAX_VALUE + 1, SpreadsheetReferenceKind.RELATIVE);
 
-    static final SpreadsheetColumnReference[] ABSOLUTE = fillCache(
-            i -> new SpreadsheetColumnReference(
-                    i,
-                    SpreadsheetReferenceKind.ABSOLUTE
-            ),
-            new SpreadsheetColumnReference[CACHE_SIZE]
-    );
-
-    static final SpreadsheetColumnReference[] RELATIVE = fillCache(
-            i -> new SpreadsheetColumnReference(
-                    i,
-                    SpreadsheetReferenceKind.RELATIVE
-            ),
-            new SpreadsheetColumnReference[CACHE_SIZE]
-    );
-
-    // both MIN & MAX constants must appear after ABSOLUTE & RELATIVE to avoid nulls in j2cl...........................
+    static SpreadsheetColumnReference[] absoluteCache() {
+        if (null == ABSOLUTE_CACHE) {
+            ABSOLUTE_CACHE = fillCache(
+                    i -> new SpreadsheetColumnReference(
+                            i,
+                            SpreadsheetReferenceKind.ABSOLUTE
+                    ),
+                    new SpreadsheetColumnReference[CACHE_SIZE]
+            );
+        }
+        return ABSOLUTE_CACHE;
+    }
 
     /**
-     * The left most possible column
+     * Lazy cache to help prevent NPE from very early {@link SpreadsheetReferenceKind#firstColumn()}
      */
-    public final static SpreadsheetColumnReference MIN = with(
-            0,
-            SpreadsheetReferenceKind.RELATIVE
-    );
+    private static SpreadsheetColumnReference[] ABSOLUTE_CACHE;
 
-    /**
-     * The right most possible column
-     */
-    public final static SpreadsheetColumnReference MAX = with(
-            MAX_VALUE,
-            SpreadsheetReferenceKind.RELATIVE
-    );
+    static SpreadsheetColumnReference[] relativeCache() {
+        if (null == RELATIVE_CACHE) {
+            RELATIVE_CACHE = fillCache(
+                    i -> new SpreadsheetColumnReference(
+                            i,
+                            SpreadsheetReferenceKind.RELATIVE
+                    ),
+                    new SpreadsheetColumnReference[CACHE_SIZE]
+            );
+        }
+        return RELATIVE_CACHE;
+    }
+
+    private static SpreadsheetColumnReference[] RELATIVE_CACHE;
 
     /**
      * Factory that creates a new column.

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetReferenceKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetReferenceKind.java
@@ -26,12 +26,12 @@ public enum SpreadsheetReferenceKind {
 
         @Override
         SpreadsheetColumnReference columnFromCache(final int column) {
-            return SpreadsheetColumnReference.ABSOLUTE[column];
+            return SpreadsheetColumnReference.absoluteCache()[column];
         }
 
         @Override
         SpreadsheetRowReference rowFromCache(final int column) {
-            return SpreadsheetRowReference.ABSOLUTE[column];
+            return SpreadsheetRowReference.absoluteCache()[column];
         }
 
         @Override
@@ -48,12 +48,12 @@ public enum SpreadsheetReferenceKind {
 
         @Override
         SpreadsheetColumnReference columnFromCache(final int column) {
-            return SpreadsheetColumnReference.RELATIVE[column];
+            return SpreadsheetColumnReference.relativeCache()[column];
         }
 
         @Override
         SpreadsheetRowReference rowFromCache(final int column) {
-            return SpreadsheetRowReference.RELATIVE[column];
+            return SpreadsheetRowReference.relativeCache()[column];
         }
 
         @Override
@@ -69,7 +69,10 @@ public enum SpreadsheetReferenceKind {
 
     public final SpreadsheetColumnReference firstColumn() {
         if (null == this.firstColumn) {
-            this.firstColumn = SpreadsheetColumnReference.MIN.setReferenceKind(this);
+            this.firstColumn = SpreadsheetColumnReference.with(
+                    0,
+                    this
+            );
         }
         return this.firstColumn;
     }
@@ -78,7 +81,10 @@ public enum SpreadsheetReferenceKind {
 
     public final SpreadsheetColumnReference lastColumn() {
         if (null == this.lastColumn) {
-            this.lastColumn = SpreadsheetColumnReference.MAX.setReferenceKind(this);
+            this.lastColumn = SpreadsheetColumnReference.with(
+                    SpreadsheetColumnReference.MAX_VALUE,
+                    this
+            );
         }
         return this.lastColumn;
     }
@@ -93,7 +99,10 @@ public enum SpreadsheetReferenceKind {
 
     public final SpreadsheetRowReference firstRow() {
         if (null == this.firstRow) {
-            this.firstRow = SpreadsheetRowReference.MIN.setReferenceKind(this);
+            this.firstRow = SpreadsheetRowReference.with(
+                    0,
+                    this
+            );
         }
         return this.firstRow;
     }
@@ -102,7 +111,10 @@ public enum SpreadsheetReferenceKind {
 
     public final SpreadsheetRowReference lastRow() {
         if (null == this.lastRow) {
-            this.lastRow = SpreadsheetRowReference.MAX.setReferenceKind(this);
+            this.lastRow = SpreadsheetRowReference.with(
+                    SpreadsheetRowReference.MAX_VALUE,
+                    this
+            );
         }
         return this.lastRow;
     }
@@ -124,7 +136,7 @@ public enum SpreadsheetReferenceKind {
 
     // Force static initialization of column and row to avoid NPE when calling methods like #firstColumn
     static {
-        SpreadsheetColumnReference.MAX.toString();
-        SpreadsheetRowReference.MAX.toString();
+//        SpreadsheetColumnReference.MAX.toString();
+//        SpreadsheetRowReference.MAX.toString();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -36,38 +36,38 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
 
     public final static int RADIX = 10;
 
-    static final SpreadsheetRowReference[] ABSOLUTE = fillCache(
-            i -> new SpreadsheetRowReference(
-                    i,
-                    SpreadsheetReferenceKind.ABSOLUTE
-            ),
-            new SpreadsheetRowReference[CACHE_SIZE]
-    );
-    static final SpreadsheetRowReference[] RELATIVE = fillCache(
-            i -> new SpreadsheetRowReference(
-                    i,
-                    SpreadsheetReferenceKind.RELATIVE
-            ),
-            new SpreadsheetRowReference[CACHE_SIZE]
-    );
-
-    // both MIN & MAX constants must appear after ABSOLUTE & RELATIVE to avoid nulls in j2cl...........................
+    static SpreadsheetRowReference[] absoluteCache() {
+        if (null == ABSOLUTE_CACHE) {
+            ABSOLUTE_CACHE = fillCache(
+                    i -> new SpreadsheetRowReference(
+                            i,
+                            SpreadsheetReferenceKind.ABSOLUTE
+                    ),
+                    new SpreadsheetRowReference[CACHE_SIZE]
+            );
+        }
+        return ABSOLUTE_CACHE;
+    }
 
     /**
-     * The left most possible Row
+     * Lazy cache to help prevent NPE from very early {@link SpreadsheetReferenceKind#firstColumn()}
      */
-    public final static SpreadsheetRowReference MIN = with(
-            0,
-            SpreadsheetReferenceKind.RELATIVE
-    );
+    private static SpreadsheetRowReference[] ABSOLUTE_CACHE;
 
-    /**
-     * The right most possible Row
-     */
-    public final static SpreadsheetRowReference MAX = with(
-            MAX_VALUE,
-            SpreadsheetReferenceKind.RELATIVE
-    );
+    static SpreadsheetRowReference[] relativeCache() {
+        if (null == RELATIVE_CACHE) {
+            RELATIVE_CACHE = fillCache(
+                    i -> new SpreadsheetRowReference(
+                            i,
+                            SpreadsheetReferenceKind.RELATIVE
+                    ),
+                    new SpreadsheetRowReference[CACHE_SIZE]
+            );
+        }
+        return RELATIVE_CACHE;
+    }
+
+    private static SpreadsheetRowReference[] RELATIVE_CACHE;
 
     /**
      * Factory that creates a new row.

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -1246,9 +1246,9 @@ public abstract class SpreadsheetSelection implements HasText,
         );
 
         SpreadsheetCell.NO_FORMATTED_CELL.isPresent();
-        SpreadsheetColumnReference.MIN.column();
+        SpreadsheetReferenceKind.ABSOLUTE.firstColumn();
         SpreadsheetLabelMapping.init();
-        SpreadsheetRowReference.MIN.row();
+        SpreadsheetReferenceKind.ABSOLUTE.firstRow();
     }
 
     private static <T extends SpreadsheetSelection> void register(final BiFunction<JsonNode, JsonNodeUnmarshallContext, T> from,

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -30,20 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRowReferenceTestCase<SpreadsheetColumnReference> {
 
     @Test
-    public void testMin() {
-        final SpreadsheetColumnReference min = SpreadsheetColumnReference.MIN;
-        this.checkEquals(0, min.value(), "value");
-        this.checkEquals(SpreadsheetReferenceKind.RELATIVE, min.referenceKind(), "referenceKind");
-    }
-
-    @Test
-    public void testMax() {
-        final SpreadsheetColumnReference max = SpreadsheetColumnReference.MAX;
-        this.checkEquals(SpreadsheetColumnReference.MAX_VALUE, max.value(), "value");
-        this.checkEquals(SpreadsheetReferenceKind.RELATIVE, max.referenceKind(), "referenceKind");
-    }
-
-    @Test
     public void testSetRowNullFails() {
         assertThrows(NullPointerException.class, () -> SpreadsheetReferenceKind.ABSOLUTE.column(1).setRow(null));
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -20,28 +20,12 @@ package walkingkooka.spreadsheet.reference;
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.Range;
 import walkingkooka.predicate.Predicates;
-import walkingkooka.spreadsheet.store.SpreadsheetRowStore;
-import walkingkooka.spreadsheet.store.SpreadsheetRowStores;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowReferenceTestCase<SpreadsheetRowReference> {
-
-    @Test
-    public void testMin() {
-        final SpreadsheetRowReference min = SpreadsheetRowReference.MIN;
-        this.checkEquals(0, min.value(), "value");
-        this.checkEquals(SpreadsheetReferenceKind.RELATIVE, min.referenceKind(), "referenceKind");
-    }
-
-    @Test
-    public void testMax() {
-        final SpreadsheetRowReference max = SpreadsheetRowReference.MAX;
-        this.checkEquals(SpreadsheetRowReference.MAX_VALUE, max.value(), "value");
-        this.checkEquals(SpreadsheetReferenceKind.RELATIVE, max.referenceKind(), "referenceKind");
-    }
 
     @Test
     public void testSetColumnNullFails() {


### PR DESCRIPTION
- This was caused by cycles between SpreadsheetReferenceKind and SpreadsheetColumnReference/SpreadsheetRowReference constants, if a SpreadsheetReferenceKind method was called before SpreadsheetColumnReference/SpreadsheetRowReference were initialized.
- Also removed SpreadsheetColumnReference/SpreadsheetRowReference public MIN/MAX constants.