### PR TITLE
SpreadsheetCellRange.test(SpreadsheetCellRange) implemented

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestSpreadsheetSelectionVisitor.java
@@ -32,7 +32,7 @@ final class SpreadsheetSelectionTestSpreadsheetSelectionVisitor extends Spreadsh
 
     @Override
     protected void visit(final SpreadsheetCellRange range) {
-        throw new UnsupportedOperationException(range.toString());
+        this.test = this.selection.testCellRange(range);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -428,14 +428,6 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     }
 
     @Test
-    public final void testTestWithCellRangeFails() {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> this.createSelection().test(SpreadsheetSelection.parseCellRange("A1:B2"))
-        );
-    }
-
-    @Test
     public final void testTestWithColumnRangeFails() {
         assertThrows(
                 UnsupportedOperationException.class,
@@ -512,6 +504,12 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 expected,
                 selection.testCellRange(range),
                 () -> selection + " testCellRange " + range
+        );
+
+        this.testAndCheck(
+                selection,
+                range,
+                expected
         );
     }
 


### PR DESCRIPTION
- previously would throw UOE, now delegates to testCellRange

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3341
- SpreadsheetCellRange.test(SpreadsheetCellRange) should return true if theres some overlap currently throws UOE