### PR TITLE
BasicSpreadsheetEngine.window selection resolveIfLabel support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1313,8 +1313,21 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                              final SpreadsheetEngineContext context) {
         Objects.requireNonNull(viewportRectangle, "viewportRectangle");
         Objects.requireNonNull(selection, "selection");
-        selection.ifPresent(BasicSpreadsheetEngine::windowSelectionCheck);
         checkContext(context);
+
+        return this.window0(
+                viewportRectangle,
+                includeFrozenColumnsRows,
+                selection.map(context::resolveIfLabel),
+                context
+        );
+    }
+
+    private SpreadsheetViewportWindows window0(final SpreadsheetViewportRectangle viewportRectangle,
+                                               final boolean includeFrozenColumnsRows,
+                                               final Optional<SpreadsheetSelection> selection,
+                                               final SpreadsheetEngineContext context) {
+        selection.ifPresent(BasicSpreadsheetEngine::windowSelectionCheck);
 
         double width = viewportRectangle.width();
         double height = viewportRectangle.height();

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -206,6 +206,7 @@ public interface SpreadsheetEngine {
      *     <li>{@link SpreadsheetColumnReference}</li>
      *     <li>{@link SpreadsheetRowReference}</li>
      * </ul>
+     * If the selection is a {@link SpreadsheetLabelName} it will be resolved into a non label before continuing.
      */
     SpreadsheetViewportWindows window(final SpreadsheetViewportRectangle viewportRectangle,
                                       final boolean includeFrozenColumnsRows,

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -11728,6 +11728,32 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         );
     }
 
+    @Test
+    public void testWindowSelectionLabel() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+        final SpreadsheetEngineContext context = this.createContext();
+
+        final SpreadsheetCellReference home = SpreadsheetSelection.parseCell("B2");
+        engine.saveLabel(
+                LABEL.mapping(
+                        home
+                ),
+                context
+        );
+
+        this.windowAndCheck(
+                engine,
+                home.viewportRectangle(
+                        COLUMN_WIDTH * 3,
+                        ROW_HEIGHT * 3
+                ), // viewport
+                false, // includeFrozenColumnsRows
+                Optional.of((SpreadsheetSelection) LABEL), // selection
+                context,
+                "B2:D4"
+        );
+    }
+
     //  navigate........................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/2329
- BasicSpreadsheetEngine.window selection parameter fails when a label