### PR TITLE
SpreadsheetMetadata.formatterContext report missing properties fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -700,11 +700,18 @@ public abstract class SpreadsheetMetadata implements HasConverter<SpreadsheetCon
      */
     public final SpreadsheetFormatterContext formatterContext(final Supplier<LocalDateTime> now,
                                                               final Function<SpreadsheetSelection, SpreadsheetSelection> resolveIfLabel) {
+        final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(this);
+
+        final int characterWidth = components.getOrNull(SpreadsheetMetadataPropertyName.CELL_CHARACTER_WIDTH);
+        final int generalNumberFormatDigitCount = components.getOrNull(SpreadsheetMetadataPropertyName.GENERAL_NUMBER_FORMAT_DIGIT_COUNT);
+
+        components.reportIfMissing();
+
         return SpreadsheetFormatterContexts.basic(
                 this.numberToColor(),
                 this.nameToColor(),
-                this.getOrFail(SpreadsheetMetadataPropertyName.CELL_CHARACTER_WIDTH),
-                this.getOrFail(SpreadsheetMetadataPropertyName.GENERAL_NUMBER_FORMAT_DIGIT_COUNT),
+                characterWidth,
+                generalNumberFormatDigitCount,
                 this.formatter(),
                 this.converterContext(
                         now,


### PR DESCRIPTION
- Reports SOME not ALL missing properties before attempting to create SpreadsheetFormatContext instance.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3364
- SpreadsheetMetadata.formatterContext needs to check required property using SpreadsheetMetadataComponents