### PR TITLE
SpreadsheetExpressionEvaluationContext.parseFormula was parseExpression

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
@@ -140,7 +140,7 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
     private final SpreadsheetCellStore cellStore;
 
     @Override
-    public SpreadsheetParserToken parseExpression(final TextCursor expression) {
+    public SpreadsheetParserToken parseFormula(final TextCursor expression) {
         Objects.requireNonNull(expression, "expression");
 
         final SpreadsheetMetadata metadata = this.spreadsheetMetadata();

--- a/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
@@ -171,8 +171,8 @@ final class ConverterSpreadsheetExpressionEvaluationContext implements Spreadshe
     }
 
     @Override
-    public SpreadsheetParserToken parseExpression(final TextCursor expression) {
-        return this.context.parseExpression(expression);
+    public SpreadsheetParserToken parseFormula(final TextCursor expression) {
+        return this.context.parseFormula(expression);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
@@ -54,7 +54,7 @@ public class FakeSpreadsheetExpressionEvaluationContext extends FakeExpressionEv
     }
 
     @Override
-    public SpreadsheetParserToken parseExpression(final TextCursor expression) {
+    public SpreadsheetParserToken parseFormula(final TextCursor expression) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/LocalLabelsSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/LocalLabelsSpreadsheetExpressionEvaluationContext.java
@@ -114,8 +114,8 @@ final class LocalLabelsSpreadsheetExpressionEvaluationContext implements Spreads
     }
 
     @Override
-    public SpreadsheetParserToken parseExpression(final TextCursor cursor) {
-        return this.context.parseExpression(cursor);
+    public SpreadsheetParserToken parseFormula(final TextCursor cursor) {
+        return this.context.parseFormula(cursor);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContext.java
@@ -333,7 +333,7 @@ final class SpreadsheetEngineSpreadsheetExpressionEvaluationContext implements S
     }
 
     @Override
-    public SpreadsheetParserToken parseExpression(final TextCursor formula) {
+    public SpreadsheetParserToken parseFormula(final TextCursor formula) {
         return this.context.parseFormula(formula);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
@@ -53,9 +53,9 @@ public interface SpreadsheetExpressionEvaluationContext extends ExpressionEvalua
     }
 
     /**
-     * Parses the {@link String expression} into an {@link SpreadsheetParserToken} which can then be transformed into an {@link Expression}.
+     * Parses the {@link TextCursor formula} into an {@link SpreadsheetParserToken} which can then be transformed into an {@link Expression}.
      */
-    SpreadsheetParserToken parseExpression(final TextCursor formula);
+    SpreadsheetParserToken parseFormula(final TextCursor formula);
 
     @Override
     default boolean isText(final Object value) {

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
@@ -34,28 +34,32 @@ public interface SpreadsheetExpressionEvaluationContextTesting<C extends Spreads
     // parseExpression......................................................................................................
 
     @Test
-    default void testParseExpressionNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().parseExpression(null));
+    default void testParseFormulaNullFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext()
+                        .parseFormula(null)
+        );
     }
 
-    default void parseExpressionAndCheck(final String expression,
-                                         final SpreadsheetParserToken expected) {
-        this.parseExpressionAndCheck(
+    default void parseFormulaAndCheck(final String formula,
+                                      final SpreadsheetParserToken expected) {
+        this.parseFormulaAndCheck(
                 this.createContext(),
-                expression,
+                formula,
                 expected
         );
     }
 
-    default void parseExpressionAndCheck(final SpreadsheetExpressionEvaluationContext context,
-                                         final String expression,
-                                         final SpreadsheetParserToken expected) {
+    default void parseFormulaAndCheck(final SpreadsheetExpressionEvaluationContext context,
+                                      final String formula,
+                                      final SpreadsheetParserToken expected) {
         this.checkEquals(
                 expected,
-                context.parseExpression(
-                        TextCursors.charSequence(expression)
+                context.parseFormula(
+                        TextCursors.charSequence(formula)
                 ),
-                () -> "parseExpression " + expression + " with context " + context);
+                () -> "parseFormula " + formula + " with context " + context);
     }
 
     // loadCell.........................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
@@ -246,14 +246,14 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
         );
     }
 
-    // parseExpression.....................................................................................................
+    // parseFormula.....................................................................................................
 
     @Test
-    public void testParseExpressionQuotedString() {
+    public void testParseFormulaQuotedString() {
         final String text = "abc123";
         final String expression = '"' + text + '"';
 
-        this.parseExpressionAndCheck(
+        this.parseFormulaAndCheck(
                 expression,
                 SpreadsheetParserToken.text(
                         Lists.of(
@@ -267,10 +267,10 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
     }
 
     @Test
-    public void testParseExpressionNumber() {
+    public void testParseFormulaNumber() {
         final String text = "123";
 
-        this.parseExpressionAndCheck(
+        this.parseFormulaAndCheck(
                 text,
                 SpreadsheetParserToken.number(
                         Lists.of(
@@ -284,10 +284,10 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
     private final static char DECIMAL = '.';
 
     @Test
-    public void testParseExpressionNumber2() {
+    public void testParseFormulaNumber2() {
         final String text = "1" + DECIMAL + "5";
 
-        this.parseExpressionAndCheck(
+        this.parseFormulaAndCheck(
                 text,
                 SpreadsheetParserToken.number(
                         Lists.of(
@@ -301,10 +301,10 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
     }
 
     @Test
-    public void testParseExpressionAdditionExpression() {
+    public void testParseFormulaAdditionExpression() {
         final String text = "1+2";
 
-        this.parseExpressionAndCheck(
+        this.parseFormulaAndCheck(
                 text,
                 SpreadsheetParserToken.addition(
                         Lists.of(

--- a/src/test/java/walkingkooka/spreadsheet/expression/LocalLabelsSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/LocalLabelsSpreadsheetExpressionEvaluationContextTest.java
@@ -121,7 +121,7 @@ public final class LocalLabelsSpreadsheetExpressionEvaluationContextTest impleme
     }
 
     @Override
-    public void testParseExpressionNullFails() {
+    public void testParseFormulaNullFails() {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3385
- SpreadsheetEngineContext.parseFormula rename to parseExpression