### PR TITLE
SpreadsheetFormula.printTree skip value/error fix

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -371,21 +371,21 @@ public final class SpreadsheetFormula implements HasText,
                     this.expression(),
                     printer
             );
+        }
 
-            final Optional<Object> possibleValue = this.value();
-            if (possibleValue.isPresent()) {
-                final Object value = possibleValue.get();
+        final Optional<Object> possibleValue = this.value();
+        if (possibleValue.isPresent()) {
+            final Object value = possibleValue.get();
 
-                printer.print("value: ");
-                if (value instanceof TreePrintable) {
+            printer.print("value: ");
+            if (value instanceof TreePrintable) {
 
-                    final TreePrintable treePrintable = Cast.to(value);
-                    printer.indent();
-                    treePrintable.printTree(printer);
-                    printer.outdent();
-                } else {
-                    printer.println(CharSequences.quoteIfChars(value) + " (" + value.getClass().getName() + ")");
-                }
+                final TreePrintable treePrintable = Cast.to(value);
+                printer.indent();
+                treePrintable.printTree(printer);
+                printer.outdent();
+            } else {
+                printer.println(CharSequences.quoteIfChars(value) + " (" + value.getClass().getName() + ")");
             }
         }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -681,6 +681,37 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         );
     }
 
+    @Test
+    public void testTreePrintTextError() {
+        this.treePrintAndCheck(
+                formula("=123/0")
+                        .setValue(
+                                Optional.of(
+                                        SpreadsheetErrorKind.DIV0.toError()
+                                )
+                        ),
+                "Formula\n" +
+                        "  text: \"=123/0\"\n" +
+                        "  value: #DIV/0!\n"
+        );
+    }
+
+    public void testTreePrintError() {
+        this.treePrintAndCheck(
+                SpreadsheetFormula.EMPTY.setValue(
+                        Optional.of(
+                                SpreadsheetErrorKind.DIV0.toError()
+                        )
+                ),
+                "Formula\n" +
+                        "  token:\n" +
+                        "    SpreadsheetText \"1+2\"\n" +
+                        "      SpreadsheetTextLiteral \"1+2\" \"1+2\" (java.lang.String)\n" +
+                        "  expression:\n" +
+                        "    ValueExpression \"1+2\" (java.lang.String)\n"
+        );
+    }
+
     // equals.......................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3419
- SpreadsheetFormula.treePrint with only text and value not printing value/error only text