### PR TITLE
SpreadsheetError.replaceWithValueIfPossible removed.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
@@ -21,7 +21,6 @@ import walkingkooka.Cast;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.UsesToStringBuilder;
 import walkingkooka.Value;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.text.CharSequences;
@@ -118,19 +117,6 @@ public final class SpreadsheetError implements Value<Optional<?>>,
     }
 
     private final String message;
-
-    /**
-     * Applies some cell formula value transformations such as turning formulas to missing cells should give a value of zero.
-     */
-    public Object replaceWithValueIfPossible(final SpreadsheetEngineContext context) {
-        Objects.requireNonNull(context, "context");
-
-        return this.isMissingCell() ?
-                context.spreadsheetMetadata()
-                        .expressionNumberKind()
-                        .zero() :
-                this;
-    }
 
     @Override
     public Optional<?> value() {

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -23,7 +23,6 @@ import walkingkooka.ToStringBuilderOption;
 import walkingkooka.UsesToStringBuilder;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.text.CharSequences;
@@ -282,27 +281,6 @@ public final class SpreadsheetFormula implements HasText,
 
     private static void checkValue(final Optional<Object> value) {
         Objects.requireNonNull(value, "value");
-    }
-
-    // magic...... ....................................................................................................
-
-    /**
-     * If the value is an error try and convert into a non error value.
-     * <br>
-     * This handles the special case of turning formulas to missing cells parse #NAME to a value of zero.
-     */
-    public SpreadsheetFormula replaceErrorWithValueIfPossible(final SpreadsheetEngineContext context) {
-        Objects.requireNonNull(context, "context");
-
-        final SpreadsheetError error = this.error()
-                .orElse(null);
-        return null == error ?
-                this :
-                this.setValue(
-                        Optional.of(
-                                error.replaceWithValueIfPossible(context)
-                        )
-                );
     }
 
     // clear ....................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1054,7 +1054,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                         cell,
                                         context
                                 )
-                        ).replaceErrorWithValueIfPossible(context)
+                        )
                 );
             }
 
@@ -1084,7 +1084,6 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                 .setValue(
                                         Optional.of(
                                                 SpreadsheetErrorKind.translate(cause)
-                                                        .replaceWithValueIfPossible(context)
                                         )
                                 )
                 ),

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -26,17 +26,11 @@ import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.spreadsheet.engine.FakeSpreadsheetEngineContext;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
-import walkingkooka.spreadsheet.engine.SpreadsheetEngineContexts;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
-import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursorSavePoint;
@@ -284,73 +278,6 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         this.checkExpression(different, differentExpression);
         this.checkValueAbsent(different);
         this.checkErrorAbsent(different);
-    }
-
-    // replaceErrorWithValueIfPossible......................................................................................
-
-    @Test
-    public void testReplaceErrorWithValueIfPossibleWithNullContextFails() {
-        assertThrows(
-                NullPointerException.class,
-                () -> SpreadsheetFormula.EMPTY
-                        .replaceErrorWithValueIfPossible(null)
-        );
-    }
-
-    @Test
-    public void testReplaceErrorWithValueIfPossibleWithMissingCellBecomesZero() {
-        final ExpressionNumberKind kind = ExpressionNumberKind.BIG_DECIMAL;
-        final SpreadsheetFormula formula = SpreadsheetFormula.EMPTY.setText("=1");
-
-
-        this.replaceErrorWithValueIfPossibleAndCheck(
-                formula.setValue(
-                        Optional.of(
-                                SpreadsheetError.selectionNotFound(SpreadsheetSelection.A1)
-                        )
-                ),
-                new FakeSpreadsheetEngineContext() {
-                    @Override
-                    public SpreadsheetMetadata spreadsheetMetadata() {
-                        return SpreadsheetMetadata.EMPTY.defaults()
-                                .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, kind);
-                    }
-                },
-                formula.setValue(
-                        Optional.of(
-                                kind.zero()
-                        )
-                )
-        );
-    }
-
-    @Test
-    public void testReplaceErrorWithValueIfPossibleWithNotMissingCell() {
-        this.replaceErrorWithValueIfPossibleAndCheck(
-                SpreadsheetFormula.EMPTY.setValue(
-                        Optional.of(
-                                "abc"
-                        )
-                )
-        );
-    }
-
-    private void replaceErrorWithValueIfPossibleAndCheck(final SpreadsheetFormula formula) {
-        this.replaceErrorWithValueIfPossibleAndCheck(
-                formula,
-                SpreadsheetEngineContexts.fake(),
-                formula
-        );
-    }
-
-    private void replaceErrorWithValueIfPossibleAndCheck(final SpreadsheetFormula formula,
-                                                         final SpreadsheetEngineContext context,
-                                                         final Object expected) {
-        this.checkEquals(
-                expected,
-                formula.replaceErrorWithValueIfPossible(context),
-                () -> formula + " replaceErrorWithValueIfPossible"
-        );
     }
 
     // clear.......................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -360,10 +360,11 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 a1,
                 SpreadsheetEngineEvaluation.COMPUTE_IF_NECESSARY,
                 context,
-                context.spreadsheetMetadata()
-                        .expressionNumberKind()
-                        .zero(),
-                " " + FORMATTED_PATTERN_SUFFIX
+                SpreadsheetErrorKind.NAME.setMessageAndValue(
+                        "Cell not found: Z99",
+                        SpreadsheetSelection.parseCell("Z99")
+                ),
+                "#NAME? " + FORMATTED_PATTERN_SUFFIX
         );
     }
 


### PR DESCRIPTION
- #NAME no longer translated into a value of 0.
- This solves formulas with a invalid cell reference from using 0, eg A1=A2 where A2 is empty would be 0, when it should be #NAME.