### PR TITLE
SpreadsheetEnginesExpressionReferenceFunction: cell-range missing cel…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunction.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 /**
  * A {@link Function} which may be passed to {@link walkingkooka.tree.expression.ExpressionEvaluationContexts#basic}
  * and acts as a bridge resolving {@link ExpressionReference} to a {@link Expression}.
+ * Note a {@link walkingkooka.spreadsheet.reference.SpreadsheetCellRange} will have missing cells given a {@link walkingkooka.spreadsheet.SpreadsheetErrorKind#NAME}.
  */
 final class SpreadsheetEnginesExpressionReferenceFunction implements Function<ExpressionReference, Optional<Optional<Object>>> {
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelectionVisitor.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.engine;
 
 import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.SpreadsheetError;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -111,8 +112,16 @@ final class SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelectionVis
         return delta.cell(reference)
                 .map(c -> c.formula()
                         .value()
-                        .orElse(null)
-                ).orElse(null);
+                        .orElseGet(
+                                () -> this.missingCellReference(reference)
+                        )
+                ).orElseGet(
+                        () -> this.missingCellReference(reference)
+                );
+    }
+
+    private SpreadsheetError missingCellReference(final SpreadsheetCellReference reference) {
+        return SpreadsheetError.selectionNotFound(reference);
     }
 
     private Optional<Object> value;

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelectionVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelectionVisitorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.SpreadsheetError;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
@@ -312,8 +313,12 @@ public final class SpreadsheetEnginesExpressionReferenceFunctionSpreadsheetSelec
                         Optional.of(
                                 Lists.of(
                                         b2Value, // B2
-                                        null, // B3
-                                        null, // C2
+                                        SpreadsheetError.selectionNotFound(
+                                                SpreadsheetSelection.parseCell("C2")
+                                        ), // C2
+                                        SpreadsheetError.selectionNotFound(
+                                                SpreadsheetSelection.parseCell("B3")
+                                        ), // B3
                                         c3Value // C3
                                 )
                         )


### PR DESCRIPTION
…ls SpreadsheetError.NAME

- This should fix Sum(A1:A2) where the range has no cells, with the #NAME becoming 0 and not causing NPE.