### PR TITLE
SpreadsheetFormula.replaceCellReferences

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -24,10 +24,11 @@ import walkingkooka.UsesToStringBuilder;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellRangeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
@@ -52,6 +53,7 @@ import walkingkooka.tree.json.patch.Patchable;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * A spreadsheet formula, including its compiled {@link Expression} and possibly its {@link Object value} or {@link SpreadsheetError}.
@@ -451,6 +453,26 @@ public final class SpreadsheetFormula implements HasText,
                                 }
                         )
                 );
+    }
+
+    // replaceCellsReferences...........................................................................................
+
+    public SpreadsheetFormula replaceCellsReferences(final Function<SpreadsheetCellReference, SpreadsheetCellReference> mapper) {
+        Objects.requireNonNull(mapper, "mapper");
+
+        return this.setToken(
+                Cast.to(
+                        this.token.map(
+                                t -> t.replaceIf(
+                                        (tt) -> tt instanceof SpreadsheetCellReferenceParserToken,
+                                        (tt) -> mapper.apply(
+                                                tt.cast(SpreadsheetCellReferenceParserToken.class)
+                                                        .cell()
+                                        ).toParserToken()
+                                )
+                        )
+                )
+        );
     }
 
     // JsonNodeContext..................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -36,6 +36,7 @@ import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CharSequences;
@@ -58,9 +59,10 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 import walkingkooka.tree.json.patch.PatchableTesting;
 
 import java.math.MathContext;
-import java.util.Locale;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -706,6 +708,106 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
                 ),
                 consumer,
                 () -> formula.toString()
+        );
+    }
+
+    // replaceCells.....................................................................................................
+
+    @Test
+    public void testReplaceCellReferencesWithNullFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> SpreadsheetFormula.EMPTY.replaceCellsReferences(
+                        null
+                )
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesNoCells() {
+        final SpreadsheetFormula formula = parse("=1+2");
+        assertSame(
+                formula,
+                formula.replaceCellsReferences(
+                        Function.identity()
+                )
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesNoCellsAndLabel() {
+        final SpreadsheetFormula formula = parse("=1+Label123");
+
+        assertSame(
+                formula,
+                formula.replaceCellsReferences(
+                        Function.identity()
+                )
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesWithCellReference() {
+        this.replaceCellReferencesAndCheck(
+                "=1+A1",
+                (t) -> t.add(1, 1),
+                "=1+B2"
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesWithSeveralCellReference() {
+        this.replaceCellReferencesAndCheck(
+                "=1+A1+2+B2",
+                (t) -> t.add(1, 1),
+                "=1+B2+2+C3"
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesWithCellRange() {
+        this.replaceCellReferencesAndCheck(
+                "=1+A1:B2",
+                (t) -> t.add(1, 1),
+                "=1+B2:C3"
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesWithCellRangeAndCell() {
+        this.replaceCellReferencesAndCheck(
+                "=1+A1:B2+D4",
+                (t) -> t.add(1, 1),
+                "=1+B2:C3+E5"
+        );
+    }
+
+    @Test
+    public void testReplaceCellReferencesWithCellRangeAndCellMixedAbsolutes() {
+        this.replaceCellReferencesAndCheck(
+                "=1+A1:$B$2+$D4",
+                (t) -> t.add(1, 1),
+                "=1+B2:$C$3+$E5"
+        );
+    }
+
+    private void replaceCellReferencesAndCheck(final String formula,
+                                               final Function<SpreadsheetCellReference, SpreadsheetCellReference> mapper,
+                                               final String expected) {
+        this.checkEquals(
+                parse(expected),
+                parse(formula).replaceCellsReferences(mapper),
+                () -> formula
+        );
+    }
+
+    private SpreadsheetFormula parse(final String formula) {
+        return SpreadsheetFormula.parse(
+                TextCursors.charSequence(formula),
+                SpreadsheetParsers.valueOrExpression(
+                        Parsers.never()
+                ),
+                this.parserContext()
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3376
- SpreadsheetFormula.replaceCellReferences(Function<SpreadsheetCellReference, SpreadsheetCellReference>)