### PR TITLE
SpreadsheetCellRangePath.comparator.toString()

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePath.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePath.java
@@ -33,11 +33,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     LRTD(
-            SpreadsheetCellRangePathComparator.with(
-                    false, // xFirst
-                    1, // reverseX
-                    1 //reverseY
-            )
+            false, // xFirst
+            1, // reverseX
+            1 //reverseY,
     ),
 
     /**
@@ -48,11 +46,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     RLTD(
-            SpreadsheetCellRangePathComparator.with(
-                    false, // xFirst
-                    -1, // reverseX
-                    1//reverseY
-            )
+            false, // xFirst
+            -1, // reverseX
+            1//reverseY
     ),
 
     /**
@@ -63,11 +59,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     LRBU(
-            SpreadsheetCellRangePathComparator.with(
-                    false, // xFirst
-                    1, // reverseX
-                    -1 //reverseY
-            )
+            false, // xFirst
+            1, // reverseX
+            -1 //reverseY
     ),
 
     /**
@@ -78,11 +72,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     RLBU(
-            SpreadsheetCellRangePathComparator.with(
-                    false, // xFirst
-                    -1, // reverseX
-                    -1 //reverseY
-            )
+            false, // xFirst
+            -1, // reverseX
+            -1 //reverseY
     ),
 
     /**
@@ -93,11 +85,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     TDLR(
-            SpreadsheetCellRangePathComparator.with(
-                    true, // xFirst
-                    1, // reverseX
-                    1 //reverseY
-            )
+            true, // xFirst
+            1, // reverseX
+            1 //reverseY
     ),
 
     /**
@@ -108,11 +98,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     TDRL(
-            SpreadsheetCellRangePathComparator.with(
-                    true, // xFirst
-                    -1, // reverseX
-                    1//reverseY
-            )
+            true, // xFirst
+            -1, // reverseX
+            1//reverseY
     ),
 
     /**
@@ -123,11 +111,9 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     BULR(
-            SpreadsheetCellRangePathComparator.with(
-                    true, // xFirst
-                    1, // reverseX
-                    -1 //reverseY
-            )
+            true, // xFirst
+            1, // reverseX
+            -1 //reverseY
     ),
 
     /**
@@ -138,15 +124,20 @@ public enum SpreadsheetCellRangePath {
      * </pre>
      */
     BURL(
-            SpreadsheetCellRangePathComparator.with(
-                    true, // xFirst
-                    -1, // reverseX
-                    -1 //reverseY
-            )
+            true, // xFirst
+            -1, // reverseX
+            -1 //reverseY
     );
 
-    SpreadsheetCellRangePath(final SpreadsheetCellRangePathComparator comparator) {
-        this.comparator = comparator;
+    SpreadsheetCellRangePath(final boolean xFirst,
+                             final int reverseX,
+                             final int reverseY) {
+        this.comparator = SpreadsheetCellRangePathComparator.with(
+                xFirst,
+                reverseX,
+                reverseY,
+                this.name()
+        );
     }
 
     public Comparator<SpreadsheetCellReference> comparator() {

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePathComparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePathComparator.java
@@ -25,20 +25,24 @@ final class SpreadsheetCellRangePathComparator implements Comparator<Spreadsheet
 
     static SpreadsheetCellRangePathComparator with(final boolean xFirst,
                                                    final int reverseX,
-                                                   final int reverseY) {
+                                                   final int reverseY,
+                                                   final String toString) {
         return new SpreadsheetCellRangePathComparator(
                 xFirst,
                 reverseX,
-                reverseY
+                reverseY,
+                toString
         );
     }
 
     private SpreadsheetCellRangePathComparator(final boolean xFirst,
                                                final int reverseX,
-                                               final int reverseY) {
+                                               final int reverseY,
+                                               final String toString) {
         this.xFirst = xFirst;
         this.reverseX = reverseX;
         this.reverseY = reverseY;
+        this.toString = toString;
     }
 
     @Override
@@ -80,4 +84,11 @@ final class SpreadsheetCellRangePathComparator implements Comparator<Spreadsheet
     final int reverseX;
 
     final int reverseY;
+
+    @Override
+    public String toString() {
+        return this.toString;
+    }
+
+    private final String toString;
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePathTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangePathTest.java
@@ -312,6 +312,16 @@ public final class SpreadsheetCellRangePathTest implements ClassTesting<Spreadsh
         }
     }
 
+    @Test
+    public void testComparatorToString() {
+        for (final SpreadsheetCellRangePath path : SpreadsheetCellRangePath.values()) {
+            this.checkEquals(
+                    path.toString(),
+                    path.comparator().toString()
+            );
+        }
+    }
+
     // ClassTesting....................................................................................................
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3455
- SpreadsheetCellRangePath.comparator().toString() should use enum.name()