### PR TITLE
SpreadsheetFormula.moveRelativeCellReferences

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -335,6 +335,51 @@ public final class SpreadsheetFormula implements HasText,
         );
     }
 
+    // moveRelativeCellReferences.......................................................................................
+
+    /**
+     * Returns a {@link SpreadsheetFormula} updating any present relative {@link SpreadsheetCellReference}.
+     * If ALL cell references are absolute or none are present this will be returned.
+     */
+    public SpreadsheetFormula moveRelativeCellReferences(final int deltaColumn,
+                                                         final int deltaRow) {
+        return 0 == deltaColumn && 0 == deltaRow ||
+                false == this.token()
+                        .isPresent() ?
+                this :
+                moveRelativeCellReferences0(
+                        deltaColumn,
+                        deltaRow
+                );
+    }
+
+    private SpreadsheetFormula moveRelativeCellReferences0(final int deltaColumn,
+                                                           final int deltaRow) {
+        return this.setToken(
+                Optional.of(
+                        this.token.get()
+                                .replaceIf(
+                                        (t) -> t instanceof SpreadsheetCellReferenceParserToken,
+                                        (t) -> moveRelativeCellReferencesMapper(
+                                                (SpreadsheetCellReferenceParserToken) t,
+                                                deltaColumn,
+                                                deltaRow
+                                        )
+                                ).cast(SpreadsheetParserToken.class)
+                )
+        );
+    }
+
+    private static ParserToken moveRelativeCellReferencesMapper(final SpreadsheetCellReferenceParserToken token,
+                                                                final int deltaColumn,
+                                                                final int deltaRow) {
+        return token.cell().
+                addIfRelative(
+                        deltaColumn,
+                        deltaRow
+                ).toParserToken();
+    }
+
     // Patchable.......................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -811,6 +811,89 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         );
     }
 
+    // moveRelativeCellReferences.......................................................................................
+
+    @Test
+    public void testMoveRelativeCellReferencesMissingToken() {
+        this.moveRelativeCellReferencesAndCheck(
+                SpreadsheetFormula.EMPTY.setText("=1"),
+                1,
+                1
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesMissingToken2() {
+        this.moveRelativeCellReferencesAndCheck(
+                SpreadsheetFormula.EMPTY.setText("=1+B2"),
+                1,
+                1
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesAbsoluteCellReferences() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+$B$2"),
+                1,
+                2
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesRelativeCellReferences() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+B2"),
+                1,
+                2,
+                this.parse("=1+C4")
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesAbsoluteAndRelativeCellReferences() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+B2+$C$3+D4"),
+                1,
+                2,
+                this.parse("=1+C4+$C$3+E6")
+        );
+    }
+
+    private void moveRelativeCellReferencesAndCheck(final SpreadsheetFormula formula,
+                                                    final int columnDelta,
+                                                    final int rowDelta) {
+        assertSame(
+                formula,
+                formula.moveRelativeCellReferences(
+                        columnDelta,
+                        rowDelta
+                ),
+                () -> formula + " moveRelativeCellReferences " + columnDelta + ", " + rowDelta
+        );
+    }
+
+    private void moveRelativeCellReferencesAndCheck(final SpreadsheetFormula formula,
+                                                    final int columnDelta,
+                                                    final int rowDelta,
+                                                    final SpreadsheetFormula expected) {
+        final SpreadsheetFormula moved = formula.moveRelativeCellReferences(
+                columnDelta,
+                rowDelta
+        );
+        this.checkEquals(
+                expected,
+                moved,
+                () -> formula + " moveRelativeCellReferences " + columnDelta + ", " + rowDelta
+        );
+        this.checkEquals(
+                expected.text(),
+                expected.token()
+                        .map(Object::toString)
+                        .orElse(null)
+        );
+    }
+
     // TreePrintable.....................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3466
- SpreadsheetFormula.move(deltaColumn, deltaRow), rewrites relative cells