### PR TITLE
SpreadsheetFormula.moveRelativeCellReferences also updates expression

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -30,6 +30,7 @@ import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReferenceOrRange;
+import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.text.cursor.TextCursor;
@@ -40,6 +41,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 import walkingkooka.tree.expression.Expression;
+import walkingkooka.tree.expression.ReferenceExpression;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonNodeException;
 import walkingkooka.tree.json.JsonObject;
@@ -368,6 +370,22 @@ public final class SpreadsheetFormula implements HasText,
                                         deltaRow
                                 )
                         ).cast(SpreadsheetParserToken.class)
+                )
+        ).setExpression(
+                this.expression.map(
+                        (e) -> e.replaceIf(
+                                ee -> ee.isReference(), // predicate
+                                ee -> {
+                                    final ReferenceExpression expression = (ReferenceExpression) ee;
+                                    final SpreadsheetExpressionReference spreadsheetExpressionReference = (SpreadsheetExpressionReference) expression.value();
+                                    return expression.setValue(
+                                            spreadsheetExpressionReference.addIfRelative(
+                                                    deltaColumn,
+                                                    deltaRow
+                                            )
+                                    );
+                                } // mapper
+                        )
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -860,6 +860,85 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         );
     }
 
+    @Test
+    public void testMoveRelativeCellReferencesWithCellExpression() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+B2")
+                        .setExpression(
+                                Optional.of(
+                                        Expression.add(
+                                                Expression.value(1),
+                                                Expression.reference(
+                                                        SpreadsheetSelection.parseCell("B2")
+                                                )
+                                        )
+                                )
+                        ),
+                1,
+                2,
+                this.parse("=1+C4")
+                        .setExpression(
+                                Optional.of(
+                                        Expression.add(
+                                                Expression.value(1),
+                                                Expression.reference(
+                                                        SpreadsheetSelection.parseCell("C4")
+                                                )
+                                        )
+                                )
+                        )
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesWithCellRangeExpression() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+B2:D4")
+                        .setExpression(
+                                Optional.of(
+                                        Expression.add(
+                                                Expression.value(1),
+                                                Expression.reference(
+                                                        SpreadsheetSelection.parseCellRange("B2:D4")
+                                                )
+                                        )
+                                )
+                        ),
+                1,
+                2,
+                this.parse("=1+C4:E6")
+                        .setExpression(
+                                Optional.of(
+                                        Expression.add(
+                                                Expression.value(1),
+                                                Expression.reference(
+                                                        SpreadsheetSelection.parseCellRange("C4:E6")
+                                                )
+                                        )
+                                )
+                        )
+        );
+    }
+
+    @Test
+    public void testMoveRelativeCellReferencesWithLabelExpression() {
+        this.moveRelativeCellReferencesAndCheck(
+                this.parse("=1+Label123")
+                        .setExpression(
+                                Optional.of(
+                                        Expression.add(
+                                                Expression.value(1),
+                                                Expression.reference(
+                                                        SpreadsheetSelection.labelName("Label123")
+                                                )
+                                        )
+                                )
+                        ),
+                1,
+                2
+        );
+    }
+
     private void moveRelativeCellReferencesAndCheck(final SpreadsheetFormula formula,
                                                     final int columnDelta,
                                                     final int rowDelta) {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3476
- SpreadsheetFormula.moveRelativeCellReferences after updating ParserToken should also update Expression.