### PR TITLE
SpreadsheetEngineSpreadsheetExpressionEvaluationContext.parseFormula …

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContext.java
@@ -31,10 +31,12 @@ import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
+import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.ExpressionNumberContext;
@@ -99,10 +101,7 @@ final class SpreadsheetEngineSpreadsheetExpressionEvaluationContext implements S
 
     @Override
     public Object evaluate(final Expression expression) {
-        return this.context.evaluate(
-                expression,
-                this.cell
-        );
+        return expression.toValue(this);
     }
 
     @Override
@@ -334,7 +333,16 @@ final class SpreadsheetEngineSpreadsheetExpressionEvaluationContext implements S
 
     @Override
     public SpreadsheetParserToken parseFormula(final TextCursor formula) {
-        return this.context.parseFormula(formula);
+        return SpreadsheetParsers.expression()
+                .orFailIfCursorNotEmpty(ParserReporters.basic())
+                .parse(
+                        formula,
+                        this.spreadsheetMetadata()
+                                .parserContext(
+                                        this.context::now
+                                )
+                ).get()
+                .cast(SpreadsheetParserToken.class);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
@@ -54,6 +54,9 @@ public interface SpreadsheetExpressionEvaluationContext extends ExpressionEvalua
 
     /**
      * Parses the {@link TextCursor formula} into an {@link SpreadsheetParserToken} which can then be transformed into an {@link Expression}.
+     * Note a formula here is an expression without the leading equals sign. Value literals such as date like 1/2/2000 will actually probably
+     * be parsed into a series of division operations and not an actual date. Apostrophe string literals will fail,
+     * date/times and times will not actually return date/time or time values.
      */
     SpreadsheetParserToken parseFormula(final TextCursor formula);
 

--- a/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetEngineSpreadsheetExpressionEvaluationContextTest.java
@@ -19,36 +19,84 @@ package walkingkooka.spreadsheet.expression;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.net.Url;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.engine.FakeSpreadsheetEngineContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineContexts;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.UnknownExpressionFunctionException;
 
+import java.math.MathContext;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetEngineSpreadsheetExpressionEvaluationContextTest implements ClassTesting<SpreadsheetEngineSpreadsheetExpressionEvaluationContext>,
+        SpreadsheetExpressionEvaluationContextTesting<SpreadsheetEngineSpreadsheetExpressionEvaluationContext>,
         ToStringTesting<SpreadsheetEngineSpreadsheetExpressionEvaluationContext> {
 
     private final static AbsoluteUrl SERVER_URL = Url.parseAbsolute("https://example.com");
 
-    private final static Function<ExpressionReference, Optional<Optional<Object>>> REFERENCES = (r) -> {
+    private final static String CURRENCY = "CURR";
+
+    private final static char DECIMAL = '.';
+
+    private final static String EXPONENT = "e";
+
+    private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.DOUBLE;
+
+    private final static char GROUP_SEPARATOR = ',';
+
+    private final static char MINUS = '!';
+
+    private final static char PERCENT = '#';
+
+    private final static char PLUS = '@';
+
+    private final static char VALUE_SEPARATOR = ',';
+
+    private final static SpreadsheetMetadata METADATA = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
+            .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"))
+            .loadFromLocale()
+            .set(SpreadsheetMetadataPropertyName.DATETIME_PARSE_PATTERN, SpreadsheetFormatPattern.parseDateTimeParsePattern("dd/mm/yyyy hh:mm"))
+            .set(SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN, SpreadsheetFormatPattern.parseTextFormatPattern("@"))
+            .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, CURRENCY)
+            .set(SpreadsheetMetadataPropertyName.DECIMAL_SEPARATOR, DECIMAL)
+            .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, EXPONENT)
+            .set(SpreadsheetMetadataPropertyName.GROUP_SEPARATOR, GROUP_SEPARATOR)
+            .set(SpreadsheetMetadataPropertyName.NEGATIVE_SIGN, MINUS)
+            .set(SpreadsheetMetadataPropertyName.POSITIVE_SIGN, PLUS)
+            .set(SpreadsheetMetadataPropertyName.PERCENTAGE_SYMBOL, PERCENT)
+            .set(SpreadsheetMetadataPropertyName.CELL_CHARACTER_WIDTH, 1)
+            .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, EXPRESSION_NUMBER_KIND)
+            .set(SpreadsheetMetadataPropertyName.VALUE_SEPARATOR, VALUE_SEPARATOR);
+
+    private final static Function<ExpressionReference, Optional<Optional<Object>>> REFERENCES = (reference) -> {
+        Objects.requireNonNull(reference, "reference");
         throw new UnsupportedOperationException();
     };
 
-    private final static Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> FUNCTIONS = (n) -> {
-        throw new UnsupportedOperationException();
+    private final static Function<FunctionExpressionName, ExpressionFunction<?, ExpressionEvaluationContext>> FUNCTIONS = (name) -> {
+        Objects.requireNonNull(name, "name");
+        throw new UnknownExpressionFunctionException(name);
     };
 
     @Test
@@ -121,6 +169,64 @@ public final class SpreadsheetEngineSpreadsheetExpressionEvaluationContextTest i
         );
     }
 
+    // parseFormula.....................................................................................................
+
+    @Test
+    public void testParseFormulaNumber() {
+        final String text = "123";
+        this.parseFormulaAndCheck(
+                text,
+                SpreadsheetParserToken.number(
+                        Lists.of(
+                                SpreadsheetParserToken.digits(text, text)
+                        ),
+                        text
+                )
+        );
+    }
+
+    @Test
+    public void testParseFormulaNumber2() {
+        final String text = "1" + DECIMAL + "5";
+        this.parseFormulaAndCheck(
+                text,
+                SpreadsheetParserToken.number(
+                        Lists.of(
+                                SpreadsheetParserToken.digits("1", "1"),
+                                SpreadsheetParserToken.decimalSeparatorSymbol("" + DECIMAL, "" + DECIMAL),
+                                SpreadsheetParserToken.digits("5", "5")
+                        ),
+                        text
+                )
+        );
+    }
+
+    @Test
+    public void testParseFormulaExpression() {
+        final String text = "1+2";
+        this.parseFormulaAndCheck(
+                text,
+                SpreadsheetParserToken.addition(
+                        Lists.of(
+                                SpreadsheetParserToken.number(
+                                        Lists.of(
+                                                SpreadsheetParserToken.digits("1", "1")
+                                        ),
+                                        "1"
+                                ),
+                                SpreadsheetParserToken.plusSymbol("+", "+"),
+                                SpreadsheetParserToken.number(
+                                        Lists.of(
+                                                SpreadsheetParserToken.digits("2", "2")
+                                        ),
+                                        "2"
+                                )
+                        ),
+                        text
+                )
+        );
+    }
+
     // toString.........................................................................................................
 
     @Test
@@ -155,6 +261,71 @@ public final class SpreadsheetEngineSpreadsheetExpressionEvaluationContextTest i
                 ),
                 cell + " " + SERVER_URL + " " + context
         );
+    }
+
+    // SpreadsheetExpressionEvaluationContext...........................................................................
+
+    @Override
+    public SpreadsheetEngineSpreadsheetExpressionEvaluationContext createContext() {
+        return SpreadsheetEngineSpreadsheetExpressionEvaluationContext.with(
+                Optional.empty(), // cell
+                SERVER_URL,
+                REFERENCES, // references
+                FUNCTIONS, // functions
+                new FakeSpreadsheetEngineContext() {
+
+                    @Override
+                    public boolean isPure(final FunctionExpressionName name) {
+                        Objects.requireNonNull(name, "name");
+                        throw new UnknownExpressionFunctionException(name);
+                    }
+
+                    @Override
+                    public SpreadsheetMetadata spreadsheetMetadata() {
+                        return METADATA;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public String currencySymbol() {
+        return CURRENCY;
+    }
+
+    @Override
+    public char decimalSeparator() {
+        return DECIMAL;
+    }
+
+    @Override
+    public String exponentSymbol() {
+        return EXPONENT;
+    }
+
+    @Override
+    public char groupSeparator() {
+        return GROUP_SEPARATOR;
+    }
+
+    @Override
+    public MathContext mathContext() {
+        return METADATA.mathContext();
+    }
+
+    @Override
+    public char negativeSign() {
+        return MINUS;
+    }
+
+    @Override
+    public char percentageSymbol() {
+        return PERCENT;
+    }
+
+    @Override
+    public char positiveSign() {
+        return PLUS;
     }
 
     // ClassTesting......................................................................................................


### PR DESCRIPTION
…parses expressions not formulas

- Previously it was parsing formula expressions and values which meant it could not parse a simple addition like 1+2 because it expected a leading equals-sign for its expressions like =1+2.