### PR TITLE
SpreadsheetSelection.toScalar never returns range

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
@@ -686,7 +686,7 @@ public final class SpreadsheetCellRangeReference extends SpreadsheetCellReferenc
         return other.map(
                 s -> anchor.cell(this)
                         .cellRange((SpreadsheetCellReference) s)
-                        .toScalar()
+                        .toScalarIfUnit()
         );
     }
 
@@ -706,6 +706,11 @@ public final class SpreadsheetCellRangeReference extends SpreadsheetCellReferenc
 
     @Override
     public SpreadsheetSelection toScalar() {
+        return this.begin();
+    }
+
+    @Override
+    SpreadsheetSelection toScalarIfUnit() {
         return this.isSingleCell() ?
                 this.begin() :
                 this;

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -278,6 +278,11 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
     }
 
     @Override
+    SpreadsheetSelection toScalarIfUnit() {
+        return this;
+    }
+
+    @Override
     Set<SpreadsheetViewportAnchor> anchors() {
         return ANCHORS;
     }
@@ -653,7 +658,7 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
                                                final SpreadsheetViewportAnchor anchor) {
         return other.map(
                 o -> this.cellRange((SpreadsheetCellReference) o)
-                        .toScalar()
+                        .toScalarIfUnit()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
@@ -159,6 +159,11 @@ abstract class SpreadsheetColumnOrRowRangeReference<T extends SpreadsheetColumnO
 
     @Override
     public SpreadsheetSelection toScalar() {
+        return this.begin();
+    }
+
+    @Override
+    SpreadsheetSelection toScalarIfUnit() {
         return this.isSingle() ?
                 this.begin() :
                 this;

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
@@ -158,6 +158,11 @@ abstract public class SpreadsheetColumnOrRowReference extends SpreadsheetSelecti
     }
 
     @Override
+    final SpreadsheetSelection toScalarIfUnit() {
+        return this;
+    }
+
+    @Override
     public final SpreadsheetCellReference toCell() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
@@ -391,7 +391,7 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnOrRo
         return other.map(
                 s -> anchor.column(this)
                         .columnRange((SpreadsheetColumnReference) s)
-                        .toScalar()
+                        .toScalarIfUnit()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -491,7 +491,8 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
     Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
                                                final SpreadsheetViewportAnchor anchor) {
         return other.map(
-                o -> this.columnRange((SpreadsheetColumnReference) o).toScalar()
+                o -> this.columnRange((SpreadsheetColumnReference) o)
+                        .toScalarIfUnit()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
@@ -183,6 +183,11 @@ final public class SpreadsheetLabelName extends SpreadsheetExpressionReference
     }
 
     @Override
+    SpreadsheetSelection toScalarIfUnit() {
+        return this;
+    }
+
+    @Override
     Set<SpreadsheetViewportAnchor> anchors() {
         return ANCHORS;
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -464,7 +464,7 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
         return other.map(
                 s -> anchor.row(this)
                         .rowRange((SpreadsheetRowReference) s)
-                        .toScalar()
+                        .toScalarIfUnit()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -484,7 +484,8 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
     Optional<SpreadsheetSelection> extendRange(final Optional<? extends SpreadsheetSelection> other,
                                                final SpreadsheetViewportAnchor anchor) {
         return other.map(
-                o -> this.rowRange((SpreadsheetRowReference) o).toScalar()
+                o -> this.rowRange((SpreadsheetRowReference) o)
+                        .toScalarIfUnit()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -889,9 +889,15 @@ public abstract class SpreadsheetSelection implements HasText,
     public abstract SpreadsheetSelection toRelative();
 
     /**
-     * If this selection has a range and the lower and upper bounds are the same return the bound otherwise return this.
+     * Always returns a non range {@link SpreadsheetSelection}, ranges will return the lower bounds, and
+     * {@link SpreadsheetLabelName} which fails and throws a {@link UnsupportedOperationException}.
      */
     public abstract SpreadsheetSelection toScalar();
+
+    /**
+     * If a non range selection returns this, ranges if they have a coubt of 1 returns the begin, otherwise they return this..
+     */
+    abstract SpreadsheetSelection toScalarIfUnit();
 
     /**
      * Returns true if this selection matches everything. Non range selections will always return false.

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
@@ -688,32 +688,26 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
     // toScalar.........................................................................................................
 
     @Test
-    public void testToScalarDifferentBeginAndEnd() {
+    public void testToScalar() {
         this.toScalarAndCheck(
-                "A1:B2"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndDifferentKind() {
-        this.toScalarAndCheck(
-                "A1:$B$2"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndSame() {
-        this.toScalarAndCheck(
-                "A1:A1",
+                "A1:B2",
                 SpreadsheetSelection.A1
         );
     }
 
     @Test
-    public void testToScalarBeginAndEndSame2() {
+    public void testToScalar2() {
         this.toScalarAndCheck(
-                "$A$1:A1",
-                SpreadsheetSelection.parseCell("$A$1")
+                "B2:C3",
+                SpreadsheetSelection.parseCell("B2")
+        );
+    }
+
+    @Test
+    public void testToScalar3() {
+        this.toScalarAndCheck(
+                "$C$3:D4",
+                SpreadsheetSelection.parseCell("$C$3")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
@@ -88,15 +88,6 @@ public abstract class SpreadsheetColumnOrRowRangeReferenceTestCase<S extends Spr
         );
     }
 
-    // toScalar.........................................................................................................
-
-    @Test
-    public final void testToScalar() {
-        this.toScalarAndCheck(
-                this.createSelection()
-        );
-    }
-
     // toCellOrFail.....................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -1222,32 +1222,26 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
     // toScalar.........................................................................................................
 
     @Test
-    public void testToScalarDifferentBeginAndEnd() {
+    public void testToScalar() {
         this.toScalarAndCheck(
-                "A:B"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndDifferentKind() {
-        this.toScalarAndCheck(
-                "A:$B"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndSame() {
-        this.toScalarAndCheck(
-                "A:A",
+                "A:B",
                 SpreadsheetSelection.parseColumn("A")
         );
     }
 
     @Test
-    public void testToScalarBeginAndEndSame2() {
+    public void testToScalar2() {
         this.toScalarAndCheck(
-                "$A:A",
+                "$A:B",
                 SpreadsheetSelection.parseColumn("$A")
+        );
+    }
+
+    @Test
+    public void testToScalar3() {
+        this.toScalarAndCheck(
+                "B:C",
+                SpreadsheetSelection.parseColumn("B")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -1216,40 +1216,26 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
     // toScalar.........................................................................................................
 
     @Test
-    public void testToScalarDifferentBeginAndEnd() {
+    public void testToScalar() {
         this.toScalarAndCheck(
-                "1:2"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndDifferentKind() {
-        this.toScalarAndCheck(
-                "1:$2"
-        );
-    }
-
-    @Test
-    public void testToScalarBeginAndEndSame() {
-        this.toScalarAndCheck(
-                "1:1",
+                "1:2",
                 SpreadsheetSelection.parseRow("1")
         );
     }
 
     @Test
-    public void testToScalarBeginAndEndSame2() {
+    public void testToScalar2() {
         this.toScalarAndCheck(
-                "$1:1",
+                "$1:2",
                 SpreadsheetSelection.parseRow("$1")
         );
     }
 
     @Test
-    public void testToScalarBeginAndEndSame3() {
+    public void testToScalar3() {
         this.toScalarAndCheck(
-                "1:$1",
-                SpreadsheetSelection.parseRow("1")
+                "2:3",
+                SpreadsheetSelection.parseRow("2")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -788,7 +788,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                   final Predicate<SpreadsheetRowReference> hiddenRows,
                                   final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.leftColumn(
                         anchor,
                         SpreadsheetViewportNavigationContexts.basic(
@@ -834,7 +834,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                   final Function<SpreadsheetRowReference, Double> rowHeight,
                                   final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.leftPixels(
                         anchor,
                         count,
@@ -872,7 +872,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                              final Predicate<SpreadsheetRowReference> hiddenRows,
                              final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.upRow(
                         anchor,
                         SpreadsheetViewportNavigationContexts.basic(
@@ -918,7 +918,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                    final Function<SpreadsheetRowReference, Double> rowHeight,
                                    final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.upPixels(
                         anchor,
                         count,
@@ -956,7 +956,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                    final Predicate<SpreadsheetRowReference> hiddenRows,
                                    final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.rightColumn(
                         anchor,
                         SpreadsheetViewportNavigationContexts.basic(
@@ -1002,7 +1002,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                   final Function<SpreadsheetRowReference, Double> rowHeight,
                                   final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.rightPixels(
                         anchor,
                         count,
@@ -1040,7 +1040,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                final Predicate<SpreadsheetRowReference> hiddenRows,
                                final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.downRow(
                         anchor,
                         SpreadsheetViewportNavigationContexts.basic(
@@ -1086,7 +1086,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                   final Function<SpreadsheetRowReference, Double> rowHeight,
                                   final Optional<SpreadsheetSelection> expected) {
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.downPixels(
                         anchor,
                         count,
@@ -1120,7 +1120,8 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
         this.extendRangeAndCheck(
                 parsed,
-                this.parseString(moved).toScalar(),
+                this.parseString(moved)
+                        .toScalarIfUnit(),
                 anchor,
                 parsed
         );
@@ -1143,7 +1144,8 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                                    final String expected) {
         this.extendRangeAndCheck(
                 this.parseString(selection),
-                this.parseString(moved).toScalar(),
+                this.parseString(moved)
+                        .toScalarIfUnit(),
                 anchor,
                 this.parseRange(expected)
         );
@@ -1173,7 +1175,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             );
         }
         this.checkEquals(
-                expected.map(SpreadsheetSelection::toScalar),
+                expected.map(SpreadsheetSelection::toScalarIfUnit),
                 selection.extendRange(Cast.to(moved), anchor),
                 () -> selection + " extendRange " + moved + " " + anchor
         );
@@ -1285,7 +1287,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 this.hiddenColumns(hiddenColumns),
                 this.hiddenRows(hiddenRows),
                 this.parseStringOrEmpty(expectedSelection).map(
-                        s -> s.toScalar()
+                        s -> s.toScalarIfUnit()
                                 .setAnchor(expectedAnchor)
                 )
         );
@@ -1564,7 +1566,8 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         return Optional.ofNullable(
                 CharSequences.isNullOrEmpty(text) ?
                         null :
-                        this.parseRange(text).toScalar()
+                        this.parseRange(text)
+                                .toScalarIfUnit()
         );
     }
 
@@ -1641,7 +1644,8 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         this.focusedAndCheck(
                 this.parseString(selection),
                 anchor,
-                this.parseString(expected).toScalar()
+                this.parseString(expected)
+                        .toScalarIfUnit()
         );
     }
 
@@ -1686,9 +1690,15 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     final void toScalarAndCheck(final S selection,
                                 final SpreadsheetSelection expected) {
+        final SpreadsheetSelection scalar = selection.toScalar();
+
+        if (scalar.isCellRangeReference() || scalar.isColumnRangeReference() || scalar.isRowRangeReference()) {
+            throw new IllegalStateException("Scalar " + scalar + " of " + selection + " must not be a range");
+        }
+
         this.checkEquals(
                 expected,
-                selection.toScalar(),
+                scalar,
                 () -> "toScalar " + selection
         );
     }


### PR DESCRIPTION
- Previously cell/column/row ranges would only return the begin() if the count() was 1 otherwise they would return this, now they always return this.begin().
- new package private SpreadsheetSelection.toScalarIfUnit introduced with same functionality as old SpreadsheetSelection.toScalar()