### PR TITLE
SpreadsheetSelection.toCell never throws UOE

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
@@ -171,7 +171,8 @@ abstract class SpreadsheetColumnOrRowRangeReference<T extends SpreadsheetColumnO
 
     @Override
     public final SpreadsheetCellReference toCell() {
-        throw new UnsupportedOperationException();
+        return this.toScalar()
+                .toCell();
     }
 
     // Iterable.........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
@@ -162,11 +162,6 @@ abstract public class SpreadsheetColumnOrRowReference extends SpreadsheetSelecti
         return this;
     }
 
-    @Override
-    public final SpreadsheetCellReference toCell() {
-        throw new UnsupportedOperationException();
-    }
-
     // Object...........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -234,6 +234,15 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
         return false;
     }
 
+    // toCell............................................................................................................
+
+    @Override
+    public SpreadsheetCellReference toCell() {
+        return this.setRow(
+                SpreadsheetReferenceKind.RELATIVE.firstRow()
+        );
+    }
+
     // toRelative.......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -255,6 +255,15 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
         return SpreadsheetRowRangeReference.with(this.range(other));
     }
 
+    // toCell............................................................................................................
+
+    @Override
+    public SpreadsheetCellReference toCell() {
+        return this.setColumn(
+                SpreadsheetReferenceKind.RELATIVE.firstColumn()
+        );
+    }
+
     @Override
     public SpreadsheetColumnReference toColumn() {
         throw new UnsupportedOperationException(this.toString());

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
@@ -88,13 +88,6 @@ public abstract class SpreadsheetColumnOrRowRangeReferenceTestCase<S extends Spr
         );
     }
 
-    // toCellOrFail.....................................................................................................
-
-    @Test
-    public final void testToCellOrFailFails() {
-        this.toCellFails();
-    }
-
     // toCellOrCellRange................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTestCase.java
@@ -334,20 +334,6 @@ public abstract class SpreadsheetColumnOrRowReferenceTestCase<R extends Spreadsh
         this.checkEquals(this.createReference(max), reference.addSaturated(+2));
     }
 
-    // toCellOrFail.....................................................................................................
-
-    @Test
-    public final void testToCellOrFailFails() {
-        this.toCellFails();
-    }
-
-    // toCellOrCellRange................................................................................................
-
-    @Test
-    public final void testToCellOrCellRangeFails() {
-        this.toCellOrCellRangeFails();
-    }
-
     // toStringMaybeStar................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -1245,6 +1245,24 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
         );
     }
 
+    // toCell...........................................................................................................
+
+    @Test
+    public void testToCell() {
+        this.toCellAndCheck(
+                "A:B",
+                "A1"
+        );
+    }
+
+    @Test
+    public void testToCell2() {
+        this.toCellAndCheck(
+                "B:C",
+                "B1"
+        );
+    }
+
     // IterableTesting..................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -569,6 +569,24 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
         );
     }
 
+    // toCell...........................................................................................................
+
+    @Test
+    public void testToCell() {
+        this.toCellAndCheck(
+                "A",
+                "A1"
+        );
+    }
+
+    @Test
+    public void testToCell2() {
+        this.toCellAndCheck(
+                "B",
+                "B1"
+        );
+    }
+
     // columnRange...................................................................................................,,,
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameTest.java
@@ -268,8 +268,12 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetExpressionReferen
     // toCellOrFail.....................................................................................................
 
     @Test
-    public void testToCellOrFailFails() {
-        this.toCellFails();
+    public void testToCellFails() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> this.createSelection()
+                        .toCell()
+        );
     }
 
     // toCellOrCellRange................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -1239,6 +1239,24 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
         );
     }
 
+    // toCell...........................................................................................................
+
+    @Test
+    public void testToCell() {
+        this.toCellAndCheck(
+                "1:2",
+                "A1"
+        );
+    }
+
+    @Test
+    public void testToCell2() {
+        this.toCellAndCheck(
+                "2:3",
+                "A2"
+        );
+    }
+
     // toCellRange.....................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -562,6 +562,24 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
                 () -> "min of " + reference + " and " + other);
     }
 
+    // toCell...........................................................................................................
+
+    @Test
+    public void testToCell() {
+        this.toCellAndCheck(
+                "1",
+                "A1"
+        );
+    }
+
+    @Test
+    public void testToCell2() {
+        this.toCellAndCheck(
+                "2",
+                "A2"
+        );
+    }
+
     // toCellRange.....................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -236,10 +236,19 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     // toCell...........................................................................................................
 
-    final void toCellFails() {
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> this.createSelection().toCell()
+    final void toCellAndCheck(final String selection,
+                              final String expected) {
+        this.toCellAndCheck(
+                this.parseString(selection),
+                expected
+        );
+    }
+
+    final void toCellAndCheck(final SpreadsheetSelection selection,
+                              final String expected) {
+        this.toCellAndCheck(
+                selection,
+                SpreadsheetSelection.parseCell(expected)
         );
     }
 


### PR DESCRIPTION
- SpreadsheetColumnReference, SpreadsheetRowReference, SpreadsheetColumnRangeReference, SpreadsheetRowRangeReference no longer throw UOE but return a SpreadsheetCellReference