### PR TITLE
SpreadsheetSelectionReplaceReferencesMapperFunction skip absolute cel…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionReplaceReferencesMapperFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionReplaceReferencesMapperFunction.java
@@ -41,31 +41,45 @@ final class SpreadsheetSelectionReplaceReferencesMapperFunction implements Funct
     public Optional<SpreadsheetCellReference> apply(final SpreadsheetCellReference cell) {
         Objects.requireNonNull(cell, "cell");
 
-        final int deltaX = this.deltaX;
-        final int deltaY = this.deltaY;
+        SpreadsheetCellReference mapped = cell;
 
-        final SpreadsheetCellReference moved = cell
-                .addSaturated(
-                        deltaX,
-                        deltaY
-                );
-        // if clipped ignore this cell
-        return
-                Optional.ofNullable(
-                        cell.column()
-                                .value() +
-                                deltaX ==
-                                moved.column()
-                                        .value()
-                                &&
-                                cell.row()
-                                        .value() +
-                                        deltaY ==
-                                        moved.row()
-                                                .value() ?
-                                moved :
-                                null
-                );
+        final int deltaX = this.deltaX;
+        if (0 != deltaX) {
+            {
+                final SpreadsheetColumnReference column = cell.column();
+                if (SpreadsheetReferenceKind.RELATIVE == column.referenceKind()) {
+                    final int value = column.value() + deltaX;
+                    if (value < 0 || value > SpreadsheetColumnReference.MAX_VALUE) {
+                        mapped = null;
+                    } else {
+                        mapped = mapped.setColumn(
+                                column.setValue(value)
+                        );
+                    }
+                }
+            }
+        }
+
+        if (null != mapped) {
+            final int deltaY = this.deltaY;
+            if (0 != deltaY) {
+                {
+                    final SpreadsheetRowReference row = cell.row();
+                    if (SpreadsheetReferenceKind.RELATIVE == row.referenceKind()) {
+                        final int value = row.value() + deltaY;
+                        if (value < 0 || value > SpreadsheetRowReference.MAX_VALUE) {
+                            mapped = null;
+                        } else {
+                            mapped = mapped.setRow(
+                                    row.setValue(value)
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        return Optional.ofNullable(mapped);
     }
 
     final int deltaX;

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionReplaceReferencesMapperFunctionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionReplaceReferencesMapperFunctionTest.java
@@ -17,10 +17,106 @@
 
 package walkingkooka.spreadsheet.reference;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.util.FunctionTesting;
 
-public final class SpreadsheetSelectionReplaceReferencesMapperFunctionTest implements ClassTesting<SpreadsheetSelectionReplaceReferencesMapperFunction> {
+import java.util.Optional;
+
+public final class SpreadsheetSelectionReplaceReferencesMapperFunctionTest implements ClassTesting<SpreadsheetSelectionReplaceReferencesMapperFunction>,
+        FunctionTesting<SpreadsheetSelectionReplaceReferencesMapperFunction, SpreadsheetCellReference, Optional<SpreadsheetCellReference>> {
+
+    @Test
+    public void testRelativeCell() {
+        this.applyAndCheck(
+                "A1",
+                "B2"
+        );
+    }
+
+    @Test
+    public void testRelativeColumnAbsoluteRow() {
+        this.applyAndCheck(
+                "A$1",
+                "B$1"
+        );
+    }
+
+    @Test
+    public void testAbsoluteColumnRelativeRow() {
+        this.applyAndCheck(
+                "$A1",
+                "$A2"
+        );
+    }
+
+    @Test
+    public void testAbsoluteColumnAbsoluteRow() {
+        this.applyAndCheck(
+                "$A$1",
+                "$A$1"
+        );
+    }
+
+    @Test
+    public void testUnderflowColumnAndRow() {
+        this.applyAndCheck(
+                SpreadsheetSelectionReplaceReferencesMapperFunction.with(
+                        -1,
+                        -1
+                ),
+                SpreadsheetSelection.A1,
+                Optional.empty()
+        );
+    }
+
+    @Test
+    public void testUnderflowColumn() {
+        this.applyAndCheck(
+                SpreadsheetSelectionReplaceReferencesMapperFunction.with(
+                        -1,
+                        0
+                ),
+                SpreadsheetSelection.A1,
+                Optional.empty()
+        );
+    }
+
+    @Test
+    public void testUnderflowRow() {
+        this.applyAndCheck(
+                SpreadsheetSelectionReplaceReferencesMapperFunction.with(
+                        0,
+                        -1
+                ),
+                SpreadsheetSelection.A1,
+                Optional.empty()
+        );
+    }
+
+    private void applyAndCheck(final String cellBefore,
+                               final String cellAfter) {
+        this.applyAndCheck(
+                this.createFunction(),
+                SpreadsheetSelection.parseCell(cellBefore),
+                Optional.of(
+                        SpreadsheetSelection.parseCell(cellAfter)
+                )
+        );
+    }
+
+    // FunctionTesting..................................................................................................
+
+    @Override
+    public SpreadsheetSelectionReplaceReferencesMapperFunction createFunction() {
+        return SpreadsheetSelectionReplaceReferencesMapperFunction.with(
+                1,
+                1
+        );
+    }
+
+    // ClassTesting.....................................................................................................
 
     @Override
     public Class<SpreadsheetSelectionReplaceReferencesMapperFunction> type() {


### PR DESCRIPTION
…l components FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3813
- SpreadsheetSelectionReplaceReferencesMapperFunction should skip absolute references.