### PR TITLE
SpreadsheetViewportNavigationExtendRow anchor FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendRow.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.reference;
 
-import walkingkooka.NeverError;
 import walkingkooka.collect.Range;
 
 import java.util.Optional;
@@ -54,38 +53,27 @@ final class SpreadsheetViewportNavigationSelectionExtendRow extends SpreadsheetV
             } else {
                 final SpreadsheetRowRangeReference range = selection.toRowRange();
 
-                SpreadsheetViewportAnchor newAnchor = anchor;
-                if (SpreadsheetViewportAnchor.NONE == newAnchor) {
-                    newAnchor =
-                            selection.toRow()
-                                    .compareTo(newRow) <= 0 ?
-                                    SpreadsheetViewportAnchor.TOP :
-                                    SpreadsheetViewportAnchor.BOTTOM;
+                final SpreadsheetRowReference top = range.begin();
+                final SpreadsheetRowReference bottom = range.end();
+
+                final SpreadsheetRowReference newTop = newRow.min(top);
+                final SpreadsheetRowReference newBottom = newRow.max(bottom);
+
+                SpreadsheetViewportAnchor newAnchor;
+
+                // try to compute the anchor for the furthest row
+                if (newRow.compareTo(top) <= 0) {
+                    newAnchor = SpreadsheetViewportAnchor.BOTTOM;
+                } else {
+                    newAnchor = SpreadsheetViewportAnchor.TOP;
                 }
 
-                switch (newAnchor) {
-                    case TOP:
-                        anchored = range.setRange(
-                                Range.greaterThanEquals(range.begin())
-                                        .and(
-                                                Range.lessThanEquals(newRow)
-                                        )
-                        ).setAnchor(SpreadsheetViewportAnchor.TOP);
-                        break;
-                    case BOTTOM:
-                        anchored = range.setRange(
-                                Range.greaterThanEquals(newRow)
-                                        .and(
-                                                Range.lessThanEquals(range.end())
-                                        )
-                        ).setAnchor(SpreadsheetViewportAnchor.BOTTOM);
-                        break;
-                    default:
-                        anchored = NeverError.unhandledEnum(
-                                anchor,
-                                SpreadsheetViewportAnchor.NONE, SpreadsheetViewportAnchor.TOP, SpreadsheetViewportAnchor.BOTTOM
-                        );
-                }
+                anchored = range.setRange(
+                        Range.greaterThanEquals(newTop)
+                                .and(
+                                        Range.lessThanEquals(newBottom)
+                                )
+                ).setAnchor(newAnchor);
             }
         } else {
             // previous selection was not a row/row-range

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendRowTest.java
@@ -84,79 +84,215 @@ public final class SpreadsheetViewportNavigationSelectionExtendRowTest extends S
     }
 
     @Test
-    public void testUpdateRowPreviousDifferentRowTop() {
-        this.updateAndCheck(
-                this.createSpreadsheetViewportNavigation(SpreadsheetSelection.parseRow("3")),
-                Optional.of(
-                        SpreadsheetSelection.parseRow("2")
-                                .setDefaultAnchor()
-                ),
-                Optional.of(
-                        SpreadsheetSelection.parseRowRange("2:3")
-                                .setAnchor(SpreadsheetViewportAnchor.TOP)
-                )
-        );
-    }
-
-    @Test
-    public void testUpdateRowPreviousDifferentRowBottom() {
-        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("3");
+    public void testUpdateRowPreviousRowBefore() {
+        final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("4");
 
         this.updateAndCheck(
                 this.createSpreadsheetViewportNavigation(row),
                 Optional.of(
-                        SpreadsheetSelection.parseRow("4")
+                        SpreadsheetSelection.parseRow("3")
                                 .setDefaultAnchor()
                 ),
                 Optional.of(
                         SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowAfter() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(SpreadsheetSelection.parseRow("2")),
+                Optional.of(
+                        SpreadsheetSelection.parseRow("3")
+                                .setDefaultAnchor()
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("2:3")
                                 .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
                 )
         );
     }
 
     @Test
-    public void testUpdateRowPreviousRowRangeTop() {
+    public void testUpdateRowPreviousRowRangeTopBefore() {
         this.updateAndCheck(
                 this.createSpreadsheetViewportNavigation(
-                        SpreadsheetSelection.parseRow("3")
+                        SpreadsheetSelection.parseRow("5")
                 ),
                 Optional.of(
-                        SpreadsheetSelection.parseRowRange("2")
+                        SpreadsheetSelection.parseRowRange("3")
                                 .setAnchor(SpreadsheetViewportAnchor.TOP)
                 ),
                 Optional.of(
-                        SpreadsheetSelection.parseRowRange("2:3")
+                        SpreadsheetSelection.parseRowRange("3:5")
                                 .setAnchor(SpreadsheetViewportAnchor.TOP)
                 )
         );
     }
 
     @Test
-    public void testUpdateRowPreviousRowRangeTop2() {
+    public void testUpdateRowPreviousRowRangeTopBefore2() {
         this.updateAndCheck(
                 this.createSpreadsheetViewportNavigation(
-                        SpreadsheetSelection.parseRow("3")
+                        SpreadsheetSelection.parseRow("4")
                 ),
                 Optional.of(
-                        SpreadsheetSelection.parseRowRange("2:3")
+                        SpreadsheetSelection.parseRowRange("3:4")
                                 .setAnchor(SpreadsheetViewportAnchor.TOP)
                 ),
                 Optional.of(
-                        SpreadsheetSelection.parseRowRange("2:3")
+                        SpreadsheetSelection.parseRowRange("3:4")
                                 .setAnchor(SpreadsheetViewportAnchor.TOP)
                 )
         );
     }
 
     @Test
-    public void testUpdateRowPreviousRowRangeBottom() {
+    public void testUpdateRowPreviousRowRangeTopBefore3() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("5")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:5")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeBottomBefore() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("5")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:5")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeBottomBefore2() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("4")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeBottomBefore3() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("5")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:5")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeTopAfter() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("2")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("2:3")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeTopAfter2() {
         this.updateAndCheck(
                 this.createSpreadsheetViewportNavigation(
                         SpreadsheetSelection.parseRow("3")
                 ),
                 Optional.of(
-                        SpreadsheetSelection.parseRowRange("4")
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeTopAfter3() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("2")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.TOP)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("2:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeBottomAfter() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("2")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("2:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateRowPreviousRowRangeBottomAfter2() {
+        this.updateAndCheck(
+                this.createSpreadsheetViewportNavigation(
+                        SpreadsheetSelection.parseRow("3")
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("3:4")
                                 .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
                 ),
                 Optional.of(
@@ -167,17 +303,17 @@ public final class SpreadsheetViewportNavigationSelectionExtendRowTest extends S
     }
 
     @Test
-    public void testUpdateRowPreviousRowRangeBottom2() {
+    public void testUpdateRowPreviousRowRangeBottomAfter3() {
         this.updateAndCheck(
                 this.createSpreadsheetViewportNavigation(
-                        SpreadsheetSelection.parseRow("3")
-                ),
-                Optional.of(
-                        SpreadsheetSelection.parseRowRange("1:4")
-                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                        SpreadsheetSelection.parseRow("2")
                 ),
                 Optional.of(
                         SpreadsheetSelection.parseRowRange("3:4")
+                                .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
+                ),
+                Optional.of(
+                        SpreadsheetSelection.parseRowRange("2:4")
                                 .setAnchor(SpreadsheetViewportAnchor.BOTTOM)
                 )
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/3999
- SpreadsheetViewportNavigationSelectionExtendRow not using opposite anchor to new row