### PR TITLE
SpreadsheetColumnRangeReference.setRowRange was setRowRangeReference

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1455,7 +1455,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
 
         SpreadsheetCellRangeReference nonFrozenCells = null;
         if (null != nonFrozenColumns && null != nonFrozenRows) {
-            nonFrozenCells = nonFrozenColumns.setRowRangeReference(nonFrozenRows);
+            nonFrozenCells = nonFrozenColumns.setRowRange(nonFrozenRows);
         }
 
         // compute other ranges parse frozenColumns/frozenRows .........................................................
@@ -1466,7 +1466,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
             // FCR fr fr fr
             // fc  n  n  n
             // fc  n  n  n
-            final SpreadsheetCellRangeReference frozenColumnsRowsCells = frozenColumns.setRowRangeReference(frozenRows);
+            final SpreadsheetCellRangeReference frozenColumnsRowsCells = frozenColumns.setRowRange(frozenRows);
 
             window.add(frozenColumnsRowsCells);
 
@@ -1490,7 +1490,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
             // fcr fr fr fr
             // FC  n  n  n
             // FC  n  n  n
-            final SpreadsheetCellRangeReference frozenColumnCells = frozenColumns.setRowRangeReference(nonFrozenRows);
+            final SpreadsheetCellRangeReference frozenColumnCells = frozenColumns.setRowRange(nonFrozenRows);
             window.add(frozenColumnCells);
 
             skipPan = skipPan ||

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
@@ -449,7 +449,7 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
         return null != left ?
                 Optional.of(
                         left.columnRange(right)
-                                .setRowRangeReference(
+                                .setRowRange(
                                         top.rowRange(bottom)
                                 )
                 ) :

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
@@ -62,7 +62,7 @@ public final class SpreadsheetCellRangeReference extends SpreadsheetCellReferenc
      * A {@link SpreadsheetColumnRangeReference} that includes all cells.
      */
     public static final SpreadsheetCellRangeReference ALL = SpreadsheetColumnRangeReference.ALL
-            .setRowRangeReference(SpreadsheetRowRangeReference.ALL);
+            .setRowRange(SpreadsheetRowRangeReference.ALL);
 
     /**
      * Computes the range of the given cells.

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
@@ -70,7 +70,7 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnOrRo
     /**
      * Creates a {@link SpreadsheetCellRangeReference} combining this column range and the given row range.
      */
-    public SpreadsheetCellRangeReference setRowRangeReference(final SpreadsheetRowRangeReference row) {
+    public SpreadsheetCellRangeReference setRowRange(final SpreadsheetRowRangeReference row) {
         checkRowRangeReference(row);
 
         final SpreadsheetColumnReference columnBegin = this.begin();

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -65,7 +65,7 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
     public SpreadsheetCellRangeReference setColumnRangeReference(final SpreadsheetColumnRangeReference columnRangeReference) {
         checkColumnRangeReference(columnRangeReference);
 
-        return columnRangeReference.setRowRangeReference(this);
+        return columnRangeReference.setRowRange(this);
     }
 
     public SpreadsheetRowRangeReference setRange(final Range<SpreadsheetRowReference> range) {

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVisitor.java
@@ -62,7 +62,7 @@ final class SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVi
 
     @Override
     protected void visit(final SpreadsheetColumnRangeReference columns) {
-        this.cellRange = columns.setRowRangeReference(SpreadsheetSelection.ALL_ROWS);
+        this.cellRange = columns.setRowRange(SpreadsheetSelection.ALL_ROWS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationSelectionExtendCell.java
@@ -183,7 +183,7 @@ final class SpreadsheetViewportNavigationSelectionExtendCell extends Spreadsheet
             }
 
             newAnchored = newSelectionColumn.toColumnRange()
-                    .setRowRangeReference(
+                    .setRowRange(
                             newSelectionRow.toRowRange()
                     ).setAnchor(newAnchor);
         }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -553,35 +553,39 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
         );
     }
 
-    // setRowRangeReference............................................................................................
+    // setRowRange......................................................................................................
 
     @Test
-    public void testSetRowRangeReferenceNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createSelection().setRowRangeReference(null));
+    public void testSetRowRangeWithNullFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createSelection()
+                        .setRowRange(null)
+        );
     }
 
     @Test
-    public void testSetRowRangeReference() {
-        this.setRowRangeReferenceAndCheck("B:D", "2:4", "B2:D4");
+    public void testSetRowRange1() {
+        this.setRowRangeAndCheck("B:D", "2:4", "B2:D4");
     }
 
     @Test
-    public void testSetRowRangeReference2() {
-        this.setRowRangeReferenceAndCheck("B", "2", "B2");
+    public void testSetRowRange2() {
+        this.setRowRangeAndCheck("B", "2", "B2");
     }
 
     @Test
-    public void testSetRowRangeReference3() {
-        this.setRowRangeReferenceAndCheck("B:D", "2", "B2:D2");
+    public void testSetRowRange3() {
+        this.setRowRangeAndCheck("B:D", "2", "B2:D2");
     }
 
-    private void setRowRangeReferenceAndCheck(final String column,
-                                              final String row,
-                                              final String range) {
+    private void setRowRangeAndCheck(final String column,
+                                     final String row,
+                                     final String range) {
         this.checkEquals(
                 SpreadsheetSelection.parseCellRange(range),
-                SpreadsheetSelection.parseColumnRange(column).setRowRangeReference(SpreadsheetSelection.parseRowRange(row)),
-                () -> column + " setRowRangeReference " + row
+                SpreadsheetSelection.parseColumnRange(column).setRowRange(SpreadsheetSelection.parseRowRange(row)),
+                () -> column + " setRowRange " + row
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -443,8 +443,8 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
                                                  final String range) {
         this.checkEquals(
                 SpreadsheetSelection.parseCellRange(range),
-                SpreadsheetSelection.parseColumnRange(column).setRowRangeReference(SpreadsheetSelection.parseRowRange(row)),
-                () -> column + " setRowRangeReference " + row
+                SpreadsheetSelection.parseColumnRange(column).setRowRange(SpreadsheetSelection.parseRowRange(row)),
+                () -> column + " setRowRange " + row
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4008
- rename SpreadsheetColumnRangeReference.setRowRangeReference to setRowRange