### PR TITLE
SpreadsheetRowRangeReference.setColumnRange was setColumnRangeReference

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1478,7 +1478,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
             // fcr FR FR FR
             // fc  n  n  n
             // fc  n  n  n
-            final SpreadsheetCellRangeReference frozenRowsCells = frozenRows.setColumnRangeReference(nonFrozenColumns);
+            final SpreadsheetCellRangeReference frozenRowsCells = frozenRows.setColumnRange(nonFrozenColumns);
 
             window.add(frozenRowsCells);
 

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -62,7 +62,7 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
     /**
      * Creates a {@link SpreadsheetCellRangeReference} combining this row range and the given column range.
      */
-    public SpreadsheetCellRangeReference setColumnRangeReference(final SpreadsheetColumnRangeReference columnRangeReference) {
+    public SpreadsheetCellRangeReference setColumnRange(final SpreadsheetColumnRangeReference columnRangeReference) {
         checkColumnRangeReference(columnRangeReference);
 
         return columnRangeReference.setRowRange(this);

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVisitor.java
@@ -82,7 +82,7 @@ final class SpreadsheetSelectionToCellRangeResolvingLabelsSpreadsheetSelectionVi
 
     @Override
     protected void visit(final SpreadsheetRowRangeReference rows) {
-        this.cellRange = rows.setColumnRangeReference(SpreadsheetSelection.ALL_COLUMNS);
+        this.cellRange = rows.setColumnRange(SpreadsheetSelection.ALL_COLUMNS);
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -416,35 +416,54 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
         );
     }
 
-    // setColumnRangeReference............................................................................................
+    // setColumnRange...................................................................................................
 
     @Test
-    public void testSetColumnRangeReferenceNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createSelection().setColumnRangeReference(null));
+    public void testSetColumnRangeNullFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createSelection()
+                        .setColumnRange(null)
+        );
     }
 
     @Test
-    public void testSetColumnRangeReference() {
-        this.setColumnRangeReferenceAndCheck("2:4", "B:D", "B2:D4");
+    public void testSetColumnRange() {
+        this.setColumnRangeAndCheck(
+                "2:4",
+                "B:D",
+                "B2:D4"
+        );
     }
 
     @Test
-    public void testSetColumnRangeReference2() {
-        this.setColumnRangeReferenceAndCheck("2", "B", "B2");
+    public void testSetColumnRange2() {
+        this.setColumnRangeAndCheck(
+                "2",
+                "B",
+                "B2"
+        );
     }
 
     @Test
-    public void testSetColumnRangeReference3() {
-        this.setColumnRangeReferenceAndCheck("2", "B:D", "B2:D2");
+    public void testSetColumnRange3() {
+        this.setColumnRangeAndCheck(
+                "2",
+                "B:D",
+                "B2:D2"
+        );
     }
 
-    private void setColumnRangeReferenceAndCheck(final String row,
-                                                 final String column,
-                                                 final String range) {
+    private void setColumnRangeAndCheck(final String row,
+                                        final String column,
+                                        final String expected) {
         this.checkEquals(
-                SpreadsheetSelection.parseCellRange(range),
-                SpreadsheetSelection.parseColumnRange(column).setRowRange(SpreadsheetSelection.parseRowRange(row)),
-                () -> column + " setRowRange " + row
+                SpreadsheetSelection.parseCellRange(expected),
+                SpreadsheetSelection.parseColumnRange(column)
+                        .setRowRange(
+                                SpreadsheetSelection.parseRowRange(row)
+                        ),
+                () -> column + " setColumnRange " + row
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4009
- rename SpreadsheetRowRangeReference.setColumnRangeReference to setColumnRange