### PR TITLE
SpreadsheetPattern.parseXXX use Parser#parseText

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPattern.java
@@ -38,9 +38,7 @@ import walkingkooka.text.CaseKind;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.CharacterConstant;
 import walkingkooka.text.HasText;
-import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.Parser;
-import walkingkooka.text.cursor.parser.ParserException;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
@@ -689,16 +687,10 @@ abstract public class SpreadsheetPattern implements Value<ParserToken>,
      */
     private static ParserToken parsePatternOrFail(final String text,
                                                   final Parser<SpreadsheetFormatParserContext> parser) {
-        CharSequences.failIfNullOrEmpty(text, "text");
-
-        try {
-            return parser.parse(
-                    TextCursors.charSequence(text),
-                    SpreadsheetFormatParserContexts.basic()
-            ).get();
-        } catch (final ParserException cause) {
-            throw new IllegalArgumentException(cause.getMessage(), cause);
-        }
+        return parser.parseText(
+                text,
+                SpreadsheetFormatParserContexts.basic()
+        );
     }
 
     // ctor.............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.Either;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converter;
@@ -2092,6 +2093,18 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
         assertThrows(
                 thrown,
                 () -> parser.apply(text)
+        );
+    }
+
+    @Test
+    public void testParseInvalidCharacterThrowsInvalidCharacterException() {
+        final InvalidCharacterException thrown = assertThrows(
+                InvalidCharacterException.class,
+                () -> SpreadsheetPattern.parseNumberFormatPattern("!Hello")
+        );
+        this.checkEquals(
+                "Invalid character '!' at 0",
+                thrown.getShortMessage()
         );
     }
 


### PR DESCRIPTION
- Invalid issue, the actual changes is an improvement anyway.
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4052
- SpreadsheetPattern.parse should return InvalidCharacterException#getShortMessage