### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorNames.parse improved messages

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNames.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNames.java
@@ -354,8 +354,26 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNames implements H
                         )
                 );
                 break;
+            case MODE_COLUMN_OR_ROW_START:
+                throw new IllegalArgumentException("Missing column/row");
             case MODE_COLUMN_OR_ROW:
-                throw new IllegalArgumentException("Expected column/row");
+                if (length != tokenStart) {
+                    // could be a column/row missing '=' or could be an invalid character within a column/row
+                    try {
+                        columnOrRowParser.apply(
+                                text.substring(
+                                        tokenStart,
+                                        length
+                                )
+                        );
+                    } catch (final InvalidCharacterException invalid) {
+                        throw invalid.setTextAndPosition(
+                                text,
+                                tokenStart + invalid.position()
+                        );
+                    }
+                }
+                throw new IllegalArgumentException("Missing " + CharSequences.quoteIfChars(COLUMN_ROW_AND_COMPARATOR_NAME_SEPARATOR_CHAR));
             case MODE_NAME_START:
                 throw new IllegalArgumentException("Missing comparator name");
             case MODE_UP_OR_DOWN_START:

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
@@ -412,7 +412,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringFails(
                 text,
-                new IllegalArgumentException("Expected column/row")
+                new InvalidCharacterException(text, 0)
         );
     }
 
@@ -422,7 +422,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringFails(
                 text,
-                new IllegalArgumentException("Expected column/row")
+                new IllegalArgumentException("Missing '='")
         );
     }
 


### PR DESCRIPTION
- Previously would give a poor message when text only contained a valid column/row but was missing '=' and when text had a bad character when column/row was expected.