### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorNames.parseXXX calls Sprea…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
@@ -900,10 +900,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringListFails(
                 text,
-                new InvalidCharacterException(
-                        text,
-                        text.indexOf('1')
-                )
+                new IllegalArgumentException("Got Row 1 expected Column")
         );
     }
 
@@ -913,10 +910,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringListFails(
                 text,
-                new InvalidCharacterException(
-                        text,
-                        text.indexOf('A')
-                )
+                new IllegalArgumentException("Got Column A expected Row")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsTest.java
@@ -496,10 +496,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorsTest implements C
 
         this.parseStringFails(
                 text,
-                new InvalidCharacterException(
-                        text,
-                        text.indexOf('1')
-                )
+                new IllegalArgumentException("Got Row 1 expected Column")
         );
     }
 
@@ -509,10 +506,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorsTest implements C
 
         this.parseStringFails(
                 text,
-                new InvalidCharacterException(
-                        text,
-                        text.indexOf('A')
-                )
+                new IllegalArgumentException("Got Column A expected Row")
         );
     }
 


### PR DESCRIPTION
…dsheetColumnOrRowReference.ifDifferentReferenceTypeFail

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4057
- SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parseList should report got column|row expected other