### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorNames trailing separator FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNames.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNames.java
@@ -357,7 +357,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNames implements H
                 );
                 break;
             case MODE_COLUMN_OR_ROW_START:
-                throw new IllegalArgumentException("Missing column/row");
+                break;
             case MODE_COLUMN_OR_ROW:
                 if (length != tokenStart) {
                     // could be a column/row missing '=' or could be an invalid character within a column/row

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
@@ -297,6 +297,29 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest impl
     }
 
     @Test
+    public void testParseColumnsTrailingSeparator() {
+        this.parseStringAndCheck(
+                "A=text;B=text-case-insensitive;",
+                SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.with(
+                        Lists.of(
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseColumn("A"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text")
+                                        )
+                                ),
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseColumn("B"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text-case-insensitive")
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+
+    @Test
     public void testParseRows() {
         this.parseStringAndCheck(
                 "1=text;23=text-case-insensitive",

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
@@ -682,6 +682,21 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
     }
 
     @Test
+    public void testParseListRowSpreadsheetComparatorNameSeparator() {
+        this.parseStringListAndCheck(
+                "2=day-of-month;",
+                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                        SpreadsheetSelection.parseRow("2"),
+                        Lists.of(
+                                SpreadsheetComparators.dayOfMonth()
+                                        .name()
+                                        .setDirection(SpreadsheetComparatorDirection.DEFAULT)
+                        )
+                )
+        );
+    }
+
+    @Test
     public void testParseListSpreadsheetComparatorNameSpaceFails() {
         this.parseStringListFails(
                 "A=day-of-month ",


### PR DESCRIPTION
- Previously parsing "A=text;" would fail with a "Missing column/row", its now parsed successfully.