### PR TITLE
EmptySpreadsheetFormatter was EmptyTextSpreadsheetFormatter

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
@@ -20,16 +20,16 @@ package walkingkooka.spreadsheet.format;
 import java.util.Optional;
 
 /**
- * A {@link SpreadsheetFormatter} that unconditionally always returns {@link SpreadsheetText#EMPTY}.
+ * A {@link SpreadsheetFormatter} that unconditionally always returns {@link Optional#empty()}.
  */
-final class EmptyTextSpreadsheetFormatter extends SpreadsheetFormatter2 {
+final class EmptySpreadsheetFormatter extends SpreadsheetFormatter2 {
 
     /**
      * Singleton
      */
-    final static EmptyTextSpreadsheetFormatter INSTANCE = new EmptyTextSpreadsheetFormatter();
+    final static EmptySpreadsheetFormatter INSTANCE = new EmptySpreadsheetFormatter();
 
-    private EmptyTextSpreadsheetFormatter() {
+    private EmptySpreadsheetFormatter() {
         super();
     }
 
@@ -42,10 +42,8 @@ final class EmptyTextSpreadsheetFormatter extends SpreadsheetFormatter2 {
     @Override
     Optional<SpreadsheetText> format0(final Object value,
                                       final SpreadsheetFormatterContext context) {
-        return RESULT;
+        return Optional.empty();
     }
-
-    private final static Optional<SpreadsheetText> RESULT = Optional.of(SpreadsheetText.EMPTY);
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatters.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatters.java
@@ -88,10 +88,10 @@ public final class SpreadsheetFormatters implements PublicStaticHelper {
     }
 
     /**
-     * {@see EmptyTextSpreadsheetFormatter}
+     * {@see EmptySpreadsheetFormatter}
      */
     public static SpreadsheetFormatter emptyText() {
-        return EmptyTextSpreadsheetFormatter.INSTANCE;
+        return EmptySpreadsheetFormatter.INSTANCE;
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterTest.java
@@ -19,7 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
 
-public final class EmptyTextSpreadsheetFormatterTest extends SpreadsheetFormatterTestCase<EmptyTextSpreadsheetFormatter> {
+public final class EmptySpreadsheetFormatterTest extends SpreadsheetFormatterTestCase<EmptySpreadsheetFormatter> {
 
     @Override
     public void testCanFormatFalse() {
@@ -33,15 +33,14 @@ public final class EmptyTextSpreadsheetFormatterTest extends SpreadsheetFormatte
 
     @Test
     public void testFormat() {
-        this.formatAndCheck(
-                "Hello2",
-                SpreadsheetText.EMPTY
+        this.formatFailAndCheck(
+                "Hello2"
         );
     }
 
     @Override
-    public EmptyTextSpreadsheetFormatter createFormatter() {
-        return EmptyTextSpreadsheetFormatter.INSTANCE;
+    public EmptySpreadsheetFormatter createFormatter() {
+        return EmptySpreadsheetFormatter.INSTANCE;
     }
 
     @Override
@@ -55,7 +54,7 @@ public final class EmptyTextSpreadsheetFormatterTest extends SpreadsheetFormatte
     }
 
     @Override
-    public Class<EmptyTextSpreadsheetFormatter> type() {
-        return EmptyTextSpreadsheetFormatter.class;
+    public Class<EmptySpreadsheetFormatter> type() {
+        return EmptySpreadsheetFormatter.class;
     }
 }


### PR DESCRIPTION
- now returns Optional#empty previously returned Optional.of(SpreadsheetText.EMPTY).