### PR TITLE
SpreadsheetPatternSpreadsheetFormatter was SpreadsheetFormatParserTok…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatter.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 /**
  * Adds a {@link Color} to a value formatted by another {@link SpreadsheetFormatter}.
  */
-final class ColorSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatColorParserToken> {
+final class ColorSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatColorParserToken> {
 
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatter.java
@@ -26,7 +26,7 @@ import java.util.function.Predicate;
 /**
  * Tries to convert a value to a {@link BigDecimal} and then tests a condition and if it is true, executes the given {@link SpreadsheetFormatter}.
  */
-final class ConditionSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatConditionParserToken> {
+final class ConditionSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatConditionParserToken> {
 
     /**
      * Creates a {@link ConditionSpreadsheetFormatter}

--- a/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatter.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 /**
  * A {@link SpreadsheetFormatter} that formats any value after converting it to a {@link LocalDateTime}.
  */
-final class DateTimeSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatDateTimeParserToken> {
+final class DateTimeSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatDateTimeParserToken> {
 
     /**
      * Creates a {@link DateTimeSpreadsheetFormatter} parse a {@link SpreadsheetFormatDateTimeParserToken}

--- a/src/main/java/walkingkooka/spreadsheet/format/FractionSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FractionSpreadsheetFormatter.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
  * A {@link SpreadsheetFormatter} that unconditionally formats a {@link BigDecimal}, without a {@link Color} using a pattern
  * parsed into a {@link SpreadsheetFormatFractionParserToken}.
  */
-final class FractionSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatFractionParserToken> {
+final class FractionSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatFractionParserToken> {
 
     /**
      * Creates a {@link FractionSpreadsheetFormatter} parse a {@link SpreadsheetFormatNumberParserToken}.

--- a/src/main/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatter.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * A {@link SpreadsheetFormatter} that handles formatting the all {@link Number} values producing the text equivalent without a {@link Color}.
  * The pattern would have been a {@link String} but the factory accepts it represented as a {@link SpreadsheetFormatNumberParserToken}.
  */
-final class NumberSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatNumberParserToken> {
+final class NumberSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatNumberParserToken> {
 
     /**
      * Creates a {@link NumberSpreadsheetFormatter} parse a {@link SpreadsheetFormatNumberParserToken}.

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
@@ -22,9 +22,10 @@ import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserToken;
 import java.util.Objects;
 
 /**
- * Base class for all {@link SpreadsheetFormatter} implementations.
+ * Base class for all {@link SpreadsheetFormatter} implementations that use a {@link walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern}.
+ * This will become important when there are formatters that originate based on a pattern and others that are custom formatters with their own formatting logic.
  */
-abstract class SpreadsheetFormatParserTokenSpreadsheetFormatter<T extends SpreadsheetFormatParserToken> extends SpreadsheetFormatter2 {
+abstract class SpreadsheetPatternSpreadsheetFormatter<T extends SpreadsheetFormatParserToken> extends SpreadsheetFormatter2 {
 
     static SpreadsheetFormatter checkFormatter(final SpreadsheetFormatter formatter) {
         return Objects.requireNonNull(formatter, "formatter");
@@ -37,7 +38,7 @@ abstract class SpreadsheetFormatParserTokenSpreadsheetFormatter<T extends Spread
     /**
      * Package private to limit sub classing.
      */
-    SpreadsheetFormatParserTokenSpreadsheetFormatter(final T token) {
+    SpreadsheetPatternSpreadsheetFormatter(final T token) {
         super();
 
         this.token = token;

--- a/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatter.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 /**
  * A {@link SpreadsheetFormatter} that formats a {@link String}.
  */
-final class TextSpreadsheetFormatter extends SpreadsheetFormatParserTokenSpreadsheetFormatter<SpreadsheetFormatTextParserToken> {
+final class TextSpreadsheetFormatter extends SpreadsheetPatternSpreadsheetFormatter<SpreadsheetFormatTextParserToken> {
 
     /**
      * Creates a {@link TextSpreadsheetFormatter} parse a {@link SpreadsheetFormatTextParserToken}.

--- a/src/test/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ColorSpreadsheetFormatterTest.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ColorSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<ColorSpreadsheetFormatter,
+public final class ColorSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<ColorSpreadsheetFormatter,
         SpreadsheetFormatColorParserToken> {
 
     private final static String TEXT_PATTERN = "@@";

--- a/src/test/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ConditionSpreadsheetFormatterTest.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ConditionSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<ConditionSpreadsheetFormatter,
+public final class ConditionSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<ConditionSpreadsheetFormatter,
         SpreadsheetFormatConditionParserToken> {
 
     private final static String TEXT_PATTERN = "!@@";

--- a/src/test/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/DateTimeSpreadsheetFormatterTest.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class DateTimeSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<
+public final class DateTimeSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<
         DateTimeSpreadsheetFormatter,
         SpreadsheetFormatDateTimeParserToken> {
 

--- a/src/test/java/walkingkooka/spreadsheet/format/FractionSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/FractionSpreadsheetFormatterTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * In expectations all symbols are doubled, as a means to verify the context is supplying the values.
  */
-public final class FractionSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<FractionSpreadsheetFormatter,
+public final class FractionSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<FractionSpreadsheetFormatter,
         SpreadsheetFormatFractionParserToken> {
 
     //creation ..............................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/NumberSpreadsheetFormatterTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * In expectations all symbols are changed parse defaults to characters to verify the context is supplying such symbols.
  */
-public final class NumberSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<NumberSpreadsheetFormatter,
+public final class NumberSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<NumberSpreadsheetFormatter,
         SpreadsheetFormatNumberParserToken> {
 
     private final static Color RED = Color.parse("#FF0000");

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTest.java
@@ -21,10 +21,10 @@ import walkingkooka.Cast;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 
-public final class SpreadsheetFormatParserTokenSpreadsheetFormatterTest implements ClassTesting2<SpreadsheetFormatParserTokenSpreadsheetFormatter<?>> {
+public final class SpreadsheetPatternSpreadsheetFormatterTest implements ClassTesting2<SpreadsheetPatternSpreadsheetFormatter<?>> {
     @Override
-    public Class<SpreadsheetFormatParserTokenSpreadsheetFormatter<?>> type() {
-        return Cast.to(SpreadsheetFormatParserTokenSpreadsheetFormatter.class);
+    public Class<SpreadsheetPatternSpreadsheetFormatter<?>> type() {
+        return Cast.to(SpreadsheetPatternSpreadsheetFormatter.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTestCase.java
@@ -28,11 +28,11 @@ import walkingkooka.text.cursor.parser.ParserToken;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<F extends SpreadsheetFormatParserTokenSpreadsheetFormatter<T>,
+public abstract class SpreadsheetPatternSpreadsheetFormatterTestCase<F extends SpreadsheetPatternSpreadsheetFormatter<T>,
         T extends SpreadsheetFormatParserToken>
         extends SpreadsheetFormatterTestCase<F> {
 
-    SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase() {
+    SpreadsheetPatternSpreadsheetFormatterTestCase() {
         super();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/TextSpreadsheetFormatterTest.java
@@ -28,7 +28,7 @@ import walkingkooka.text.cursor.parser.SequenceParserToken;
 
 import java.util.Optional;
 
-public final class TextSpreadsheetFormatterTest extends SpreadsheetFormatParserTokenSpreadsheetFormatterTestCase<TextSpreadsheetFormatter, SpreadsheetFormatTextParserToken> {
+public final class TextSpreadsheetFormatterTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<TextSpreadsheetFormatter, SpreadsheetFormatTextParserToken> {
 
     private final static String TEXT = "Abc123";
 


### PR DESCRIPTION
…enSpreadsheetFormatter

- first step in making SPSF public. Next step will involve renaming sub classes to share a common prefix of `SpreadsheetPatternSpreadsheetFormatter` with the unique component of the name appear as the suffix.