### PR TITLE
SpreadsheetFormatter.format returns Optional<TextNode> was Optional<S…

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -266,15 +266,15 @@ public class TestGwtTest extends GWTTestCase {
                                         )
                                 ).map(
                                         f -> cell.style()
-                                                .replace(f.toTextNode())
+                                                .replace(f)
                                 ).orElse(TextNode.EMPTY_TEXT)
                         )
                 );
             }
 
             @Override
-            public Optional<SpreadsheetText> formatValue(final Object value,
-                                                         final SpreadsheetFormatter formatter) {
+            public Optional<TextNode> formatValue(final Object value,
+                                                  final SpreadsheetFormatter formatter) {
                 checkEquals(false, value instanceof Optional, "Value must not be optional" + value);
 
                 return formatter.format(

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -270,15 +270,15 @@ public class JunitTest {
                                         )
                                 ).map(
                                         f -> cell.style()
-                                                .replace(f.toTextNode())
+                                                .replace(f)
                                 ).orElse(TextNode.EMPTY_TEXT)
                         )
                 );
             }
 
             @Override
-            public Optional<SpreadsheetText> formatValue(final Object value,
-                                                         final SpreadsheetFormatter formatter) {
+            public Optional<TextNode> formatValue(final Object value,
+                                                  final SpreadsheetFormatter formatter) {
                 checkEquals(false, value instanceof Optional, "Value must not be optional" + value);
 
                 return formatter.format(

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -32,7 +32,6 @@ import walkingkooka.spreadsheet.conditionalformat.SpreadsheetConditionalFormatti
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
-import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
@@ -265,8 +264,8 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
     // formatValue......................................................................................................
 
     @Override
-    public Optional<SpreadsheetText> formatValue(final Object value,
-                                                 final SpreadsheetFormatter formatter) {
+    public Optional<TextNode> formatValue(final Object value,
+                                          final SpreadsheetFormatter formatter) {
         Objects.requireNonNull(formatter, "formatter");
 
         return formatter.format(
@@ -307,7 +306,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext {
                                                 )
                                                 .map(
                                                         f -> cell.style()
-                                                                .replace(f.toTextNode())
+                                                                .replace(f)
                                                 )
                                                 .orElse(TextNode.EMPTY_TEXT)
                                 )

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -23,7 +23,6 @@ import walkingkooka.spreadsheet.compare.SpreadsheetComparator;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorInfo;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorName;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
-import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
@@ -36,6 +35,7 @@ import walkingkooka.tree.expression.ExpressionEvaluationContext;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionInfo;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -102,8 +102,8 @@ public class FakeSpreadsheetEngineContext extends FakeConverterContext implement
     }
 
     @Override
-    public Optional<SpreadsheetText> formatValue(final Object value,
-                                                 final SpreadsheetFormatter formatter) {
+    public Optional<TextNode> formatValue(final Object value,
+                                          final SpreadsheetFormatter formatter) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -23,7 +23,6 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetErrorKind;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorProvider;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
-import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.meta.HasSpreadsheetMetadata;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
@@ -32,6 +31,7 @@ import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionPurityContext;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionProvider;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -86,8 +86,8 @@ public interface SpreadsheetEngineContext extends Context,
     /**
      * Formats the given value using the provided formatter.
      */
-    Optional<SpreadsheetText> formatValue(final Object value,
-                                          final SpreadsheetFormatter formatter);
+    Optional<TextNode> formatValue(final Object value,
+                                   final SpreadsheetFormatter formatter);
 
     /**
      * Combines formatting of any present value along with possibly applying conditional rules.

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
@@ -34,6 +34,7 @@ import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.ParserTesting;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionProviderTesting;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -223,7 +224,27 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
 
     default void formatValueAndCheck(final Object value,
                                      final SpreadsheetFormatter formatter,
-                                     final Optional<SpreadsheetText> expected) {
+                                     final SpreadsheetText expected) {
+        this.formatValueAndCheck(
+                value,
+                formatter,
+                expected.toTextNode()
+        );
+    }
+
+    default void formatValueAndCheck(final Object value,
+                                     final SpreadsheetFormatter formatter,
+                                     final TextNode expected) {
+        this.formatValueAndCheck(
+                value,
+                formatter,
+                Optional.of(expected)
+        );
+    }
+
+    default void formatValueAndCheck(final Object value,
+                                     final SpreadsheetFormatter formatter,
+                                     final Optional<TextNode> expected) {
         this.formatValueAndCheck(
                 this.createContext(),
                 value,
@@ -235,7 +256,19 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
     default void formatValueAndCheck(final SpreadsheetEngineContext context,
                                      final Object value,
                                      final SpreadsheetFormatter formatter,
-                                     final Optional<SpreadsheetText> expected) {
+                                     final TextNode expected) {
+        this.formatValueAndCheck(
+                context,
+                value,
+                formatter,
+                Optional.of(expected)
+        );
+    }
+
+    default void formatValueAndCheck(final SpreadsheetEngineContext context,
+                                     final Object value,
+                                     final SpreadsheetFormatter formatter,
+                                     final Optional<TextNode> expected) {
         this.checkEquals(
                 expected,
                 context.formatValue(value, formatter),

--- a/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
@@ -28,6 +28,7 @@ import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.text.TextNode;
 
 import java.math.MathContext;
 import java.time.LocalDateTime;
@@ -153,7 +154,7 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
     // format.................................................................................................
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value) {
+    public Optional<TextNode> format(final Object value) {
         return this.formatter.format(
                 value,
                 this

--- a/src/main/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatter.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.List;
 import java.util.Objects;
@@ -69,8 +70,8 @@ final class ChainSpreadsheetFormatter implements SpreadsheetFormatter {
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value,
-                                            final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Object value,
+                                     final SpreadsheetFormatterContext context) {
         return this.formatter(value, context)
                 .flatMap(f -> f.format(value, context));
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatter.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.tree.text.TextNode;
+
 import java.util.Optional;
 
 /**
@@ -43,7 +45,7 @@ final class ContextFormatTextSpreadsheetFormatter extends SpreadsheetFormatter2 
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context) {
+    Optional<TextNode> format0(final Object value, final SpreadsheetFormatterContext context) {
         return context.format(value);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatter.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -46,12 +47,14 @@ final class ConverterSpreadsheetFormatter implements SpreadsheetFormatter {
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value,
-                                            final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Object value,
+                                     final SpreadsheetFormatterContext context) {
         final Either<String, String> converted = this.converter.convert(value, String.class, context);
         return converted.isLeft() ?
                 Optional.of(
-                        SpreadsheetText.with(converted.leftValue())
+                        SpreadsheetText.with(
+                                converted.leftValue()
+                        ).toTextNode()
                 ) :
                 Optional.empty();
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.tree.text.TextNode;
+
 import java.util.Optional;
 
 /**
@@ -40,8 +42,8 @@ final class EmptySpreadsheetFormatter extends SpreadsheetFormatter2 {
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value,
-                                      final SpreadsheetFormatterContext context) {
+    Optional<TextNode> format0(final Object value,
+                               final SpreadsheetFormatterContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatter.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.format;
 
 import walkingkooka.test.Fake;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class FakeSpreadsheetFormatter implements SpreadsheetFormatter, Fake {
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Object value, final SpreadsheetFormatterContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.color.Color;
 import walkingkooka.spreadsheet.convert.FakeSpreadsheetConverterContext;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -40,7 +41,7 @@ public class FakeSpreadsheetFormatterContext extends FakeSpreadsheetConverterCon
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value) {
+    public Optional<TextNode> format(final Object value) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetPatternSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetPatternSpreadsheetFormatter.java
@@ -36,7 +36,8 @@ public class FakeSpreadsheetPatternSpreadsheetFormatter implements SpreadsheetPa
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.HasConverter;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -47,19 +48,20 @@ public interface SpreadsheetFormatter extends HasConverter<SpreadsheetConverterC
                       final SpreadsheetFormatterContext context);
 
     /**
-     * Accepts a value and returns a {@link SpreadsheetText}.
+     * Accepts a value and returns a {@link TextNode} if it could format the value.
      */
-    Optional<SpreadsheetText> format(final Object value, final SpreadsheetFormatterContext context);
+    Optional<TextNode> format(final Object value,
+                              final SpreadsheetFormatterContext context);
 
     /**
      * Formats the given {@link Object value} or returns {@link SpreadsheetText#EMPTY}.
      */
-    default SpreadsheetText formatOrEmptyText(final Object value,
-                                              final SpreadsheetFormatterContext context) {
+    default TextNode formatOrEmptyText(final Object value,
+                                       final SpreadsheetFormatterContext context) {
         return this.format(
                 value,
                 context
-        ).orElse(SpreadsheetText.EMPTY);
+        ).orElse(TextNode.EMPTY_TEXT);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter2.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.tree.text.TextNode;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -36,14 +38,17 @@ abstract class SpreadsheetFormatter2 implements SpreadsheetFormatter {
      * Accepts a value and uses the {@link SpreadsheetPatternSpreadsheetFormatterSpreadsheetFormatParserTokenVisitor} to produce the formatted text.
      */
     @Override
-    public final Optional<SpreadsheetText> format(final Object value, final SpreadsheetFormatterContext context) {
+    public final Optional<TextNode> format(final Object value, final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
-        return this.format0(value, context);
+        return this.format0(
+                value,
+                context
+        );
     }
 
-    abstract Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context);
+    abstract Optional<TextNode> format0(final Object value, final SpreadsheetFormatterContext context);
 
     @Override
     public abstract String toString();

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.Context;
 import walkingkooka.color.Color;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -47,14 +48,14 @@ public interface SpreadsheetFormatterContext extends SpreadsheetConverterContext
     /**
      * Provides a default format text.
      */
-    Optional<SpreadsheetText> format(final Object value);
+    Optional<TextNode> format(final Object value);
 
     /**
      * Formats the given {@link Object value} or if formatting fails returns {@link SpreadsheetText#EMPTY}.
      */
-    default SpreadsheetText formatOrEmptyText(final Object value) {
+    default TextNode formatOrEmptyText(final Object value) {
         return this.format(value)
-                .orElse(SpreadsheetText.EMPTY);
+                .orElse(TextNode.EMPTY_TEXT);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTesting.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import walkingkooka.color.Color;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumberConverterContextTesting;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -46,15 +47,33 @@ public interface SpreadsheetFormatterContextTesting<C extends SpreadsheetFormatt
     }
 
     default void formatAndCheck(final Object value,
-                                final Optional<SpreadsheetText> expected) {
-        this.formatAndCheck(this.createContext(),
+                                final SpreadsheetText expected) {
+        this.formatAndCheck(
                 value,
-                expected);
+                expected.toTextNode()
+        );
+    }
+
+    default void formatAndCheck(final Object value,
+                                final TextNode expected) {
+        this.formatAndCheck(
+                value,
+                Optional.of(expected)
+        );
+    }
+
+    default void formatAndCheck(final Object value,
+                                final Optional<TextNode> expected) {
+        this.formatAndCheck(
+                this.createContext(),
+                value,
+                expected
+        );
     }
 
     default void formatAndCheck(final SpreadsheetFormatterContext context,
                                 final Object value,
-                                final Optional<SpreadsheetText> expected) {
+                                final Optional<TextNode> expected) {
         this.checkEquals(expected,
                 context.format(value),
                 () -> context + " " + CharSequences.quoteIfChars(value));

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
@@ -24,6 +24,7 @@ import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.text.TextNode;
 
 import java.math.MathContext;
 import java.time.LocalDateTime;
@@ -92,7 +93,7 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value) {
+    public Optional<TextNode> format(final Object value) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.TreePrintableTesting;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -65,6 +66,18 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
                 formatter,
                 value,
                 context,
+                Optional.of(text.toTextNode())
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Object value,
+                                final SpreadsheetFormatterContext context,
+                                final TextNode text) {
+        this.formatAndCheck(
+                formatter,
+                value,
+                context,
                 Optional.of(text)
         );
     }
@@ -72,7 +85,7 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value,
                                 final SpreadsheetFormatterContext context,
-                                final Optional<SpreadsheetText> text) {
+                                final Optional<TextNode> text) {
         this.checkEquals(
                 text,
                 formatter.format(value, context),

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
@@ -22,6 +22,7 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.TypeNameTesting;
 import walkingkooka.text.CharSequences;
+import walkingkooka.tree.text.TextNode;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -159,6 +160,15 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
         this.formatAndCheck(
                 this.createFormatter(),
                 value,
+                text.toTextNode()
+        );
+    }
+
+    default void formatAndCheck(final Object value,
+                                final TextNode text) {
+        this.formatAndCheck(
+                this.createFormatter(),
+                value,
                 text
         );
     }
@@ -176,6 +186,16 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value,
                                 final SpreadsheetText text) {
+        this.formatAndCheck(
+                formatter,
+                value,
+                text.toTextNode()
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Object value,
+                                final TextNode text) {
         this.formatAndCheck(
                 formatter,
                 value,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
@@ -17,9 +17,25 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.tree.text.TextNode;
+
+import java.util.Optional;
+
 /**
  * A {@link SpreadsheetFormatter} for a {@link walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern}.
  */
 public interface SpreadsheetPatternSpreadsheetFormatter extends SpreadsheetFormatter {
+
+    @Override
+    default Optional<TextNode> format(final Object value,
+                                      final SpreadsheetFormatterContext context) {
+        return this.formatSpreadsheetText(
+                value,
+                context
+        ).map(SpreadsheetText::toTextNode);
+    }
+
+    Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                    final SpreadsheetFormatterContext context);
 }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterChain.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterChain.java
@@ -70,14 +70,18 @@ final class SpreadsheetPatternSpreadsheetFormatterChain implements SpreadsheetPa
     }
 
     @Override
-    public Optional<SpreadsheetText> format(final Object value,
-                                            final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
         return this.formatter(value, context)
-                .flatMap(f -> f.format(value, context));
+                .flatMap(f -> f.formatSpreadsheetText(
+                                value,
+                                context
+                        )
+                );
     }
 
-    Optional<SpreadsheetPatternSpreadsheetFormatter> formatter(final Object value,
-                                                               final SpreadsheetFormatterContext context) {
+    private Optional<SpreadsheetPatternSpreadsheetFormatter> formatter(final Object value,
+                                                                       final SpreadsheetFormatterContext context) {
         return this.formatters.stream()
                 .filter(f -> f.canFormat(value, context))
                 .findFirst();

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColor.java
@@ -27,8 +27,7 @@ import java.util.Optional;
 /**
  * Wraps another {@link SpreadsheetPatternSpreadsheetFormatter} and adds a {@link Color} to any formatted result.
  */
-final class SpreadsheetPatternSpreadsheetFormatterColor extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterColor implements SpreadsheetPatternSpreadsheetFormatter {
 
 
     /**
@@ -74,10 +73,15 @@ final class SpreadsheetPatternSpreadsheetFormatterColor extends SpreadsheetForma
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value,
-                                      final SpreadsheetFormatterContext context) {
-        return this.formatter.format(value, context)
-                .map(t -> t.setColor(this.color(context)));
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+
+        return this.formatter.formatSpreadsheetText(
+                value,
+                context
+        ).map(t -> t.setColor(this.color(context)));
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCondition.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCondition.java
@@ -27,8 +27,7 @@ import java.util.function.Predicate;
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that wraps another {@link SpreadsheetPatternSpreadsheetFormatter} which only formats if the condition is true.
  */
-final class SpreadsheetPatternSpreadsheetFormatterCondition extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterCondition implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Creates a {@link SpreadsheetPatternSpreadsheetFormatterCondition}
@@ -65,11 +64,15 @@ final class SpreadsheetPatternSpreadsheetFormatterCondition extends SpreadsheetF
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
         return context.convert(value, BigDecimal.class)
                 .mapLeft(this.predicate::test)
                 .orElseLeft(false) ?
-                this.formatter.format(value, context) :
+                this.formatter.formatSpreadsheetText(
+                        value,
+                        context
+                ) :
                 Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
@@ -28,8 +28,7 @@ import java.util.function.Predicate;
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that formats any value after converting it to a {@link LocalDateTime}.
  */
-final class SpreadsheetPatternSpreadsheetFormatterDateTime extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterDateTime implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Creates a {@link SpreadsheetPatternSpreadsheetFormatterDateTime} parse a {@link SpreadsheetFormatDateTimeParserToken}
@@ -69,9 +68,19 @@ final class SpreadsheetPatternSpreadsheetFormatterDateTime extends SpreadsheetFo
     private final Predicate<Object> typeTester;
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+
         return Optional.of(
-                this.formatLocalDateTime(context.convertOrFail(value, LocalDateTime.class), context)
+                this.formatLocalDateTime(
+                        context.convertOrFail(
+                                value,
+                                LocalDateTime.class
+                        ),
+                        context
+                )
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFraction.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFraction.java
@@ -32,8 +32,7 @@ import java.util.function.Function;
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that formats any number as a fraction.
  */
-final class SpreadsheetPatternSpreadsheetFormatterFraction extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterFraction implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Creates a {@link SpreadsheetPatternSpreadsheetFormatterFraction} parse a {@link SpreadsheetFormatNumberParserToken}.
@@ -74,10 +73,16 @@ final class SpreadsheetPatternSpreadsheetFormatterFraction extends SpreadsheetFo
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value, final SpreadsheetFormatterContext context) {
-        return Optional.ofNullable(context.convert(value, BigDecimal.class)
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+
+        return Optional.ofNullable(
+                context.convert(value, BigDecimal.class)
                 .mapLeft(v -> SpreadsheetText.with(this.format1(v, context)))
-                .orElseLeft(null));
+                        .orElseLeft(null)
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterGeneral.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterGeneral.java
@@ -31,8 +31,7 @@ import java.util.Optional;
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that converts any given value to a {@link ExpressionNumber} and then proceeds to format.
  * Formatting as a scientific number is controlled by {@link SpreadsheetFormatterContext#generalFormatNumberDigitCount}.
  */
-final class SpreadsheetPatternSpreadsheetFormatterGeneral extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterGeneral implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Singleton
@@ -59,8 +58,11 @@ final class SpreadsheetPatternSpreadsheetFormatterGeneral extends SpreadsheetFor
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value,
-                                      final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+
         return this.canFormat(
                 value,
                 context
@@ -81,9 +83,9 @@ final class SpreadsheetPatternSpreadsheetFormatterGeneral extends SpreadsheetFor
                 context
         ) ?
                 this.scientificFormatter(context)
-                        .format(number, context) :
+                        .formatSpreadsheetText(number, context) :
                 this.nonScientificFormatter(context)
-                        .format(number, context)
+                        .formatSpreadsheetText(number, context)
                         .map(t -> removeTrailingDecimalPlaceIfNecessary(t, context));
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
@@ -28,8 +28,7 @@ import java.util.Optional;
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that formats value after converting them to a number using the provided number pattern.
  */
-final class SpreadsheetPatternSpreadsheetFormatterNumber extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterNumber implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Creates a {@link SpreadsheetPatternSpreadsheetFormatterNumber} parse a {@link SpreadsheetFormatNumberParserToken}.
@@ -75,8 +74,11 @@ final class SpreadsheetPatternSpreadsheetFormatterNumber extends SpreadsheetForm
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value,
-                                      final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+
         return Optional.of(
                 SpreadsheetText.with(
                         this.format1(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterText.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterText.java
@@ -25,8 +25,7 @@ import java.util.Optional;
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that formats values after converting them to a {@link String}.
  */
-final class SpreadsheetPatternSpreadsheetFormatterText extends SpreadsheetFormatter2
-        implements SpreadsheetPatternSpreadsheetFormatter {
+final class SpreadsheetPatternSpreadsheetFormatterText implements SpreadsheetPatternSpreadsheetFormatter {
 
     /**
      * Creates a {@link SpreadsheetPatternSpreadsheetFormatterText} parse a {@link SpreadsheetFormatTextParserToken}.
@@ -53,8 +52,11 @@ final class SpreadsheetPatternSpreadsheetFormatterText extends SpreadsheetFormat
     }
 
     @Override
-    Optional<SpreadsheetText> format0(final Object value,
-                                      final SpreadsheetFormatterContext context) {
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                           final SpreadsheetFormatterContext context) {
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(context, "context");
+        
         return this.canFormat(value, context) ?
                 Optional.of(
                         SpreadsheetPatternSpreadsheetFormatterTextSpreadsheetFormatParserTokenVisitor.format(

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -521,10 +521,8 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
         this.formatValueAndCheck(
                 BigDecimal.valueOf(-123.45),
                 SpreadsheetPattern.parseNumberFormatPattern("#.#\"Abc123\"").formatter(),
-                Optional.of(
-                        SpreadsheetText.with(
-                                MINUS + "123" + DECIMAL + "5Abc123"
-                        )
+                SpreadsheetText.with(
+                        MINUS + "123" + DECIMAL + "5Abc123"
                 )
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -49,7 +49,6 @@ import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContex
 import walkingkooka.spreadsheet.format.FakeSpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
-import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
@@ -13540,8 +13539,8 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
             }
 
             @Override
-            public Optional<SpreadsheetText> formatValue(final Object value,
-                                                         final SpreadsheetFormatter formatter) {
+            public Optional<TextNode> formatValue(final Object value,
+                                                  final SpreadsheetFormatter formatter) {
                 assertFalse(
                         value instanceof Optional,
                         () -> "Value must not be optional" + value
@@ -13568,7 +13567,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                                         )
                                                 ).map(
                                                         f -> cell.style()
-                                                                .replace(f.toTextNode())
+                                                                .replace(f)
                                                 )
                                                 .orElse(TextNode.EMPTY_TEXT)
                                 )
@@ -13677,7 +13676,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         );
 
         if (value.isPresent()) {
-            final SpreadsheetText formattedText = this.metadata()
+            final TextNode formattedText = this.metadata()
                     .formatter()
                     .format(
                             value.get(),
@@ -13688,9 +13687,8 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
             result = result.setFormattedValue(
                     Optional.of(
-                            style.replace(
-                                    formattedText.toTextNode()
-                            ).root()
+                            style.replace(formattedText)
+                                    .root()
                     )
             );
         }

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -486,11 +486,11 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
             }
 
             @Override
-            public Optional<SpreadsheetText> formatValue(final Object value,
+            public Optional<TextNode> formatValue(final Object value,
                                                          final SpreadsheetFormatter formatter) {
                 checkEquals(FORMULA_VALUE, value, "formatValue");
                 return Optional.of(
-                        SpreadsheetText.with(FORMULA_VALUE)
+                        SpreadsheetText.with(FORMULA_VALUE).toTextNode()
                 );
             }
 
@@ -503,7 +503,7 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
                                 formatter.orElse(
                                         SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN.formatter()
                                 )
-                        ).map(SpreadsheetText::toTextNode)
+                        )
                 );
             }
         };

--- a/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
@@ -37,6 +37,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
+import walkingkooka.tree.text.TextNode;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -234,9 +235,7 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
     public void testFormat() {
         this.formatAndCheck(
                 BigDecimal.valueOf(12.5),
-                Optional.of(
-                        SpreadsheetText.with("012.500")
-                )
+                SpreadsheetText.with("012.500")
         );
     }
 
@@ -310,13 +309,13 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
             }
 
             @Override
-            public Optional<SpreadsheetText> format(final Object value,
-                                                    final SpreadsheetFormatterContext context) {
+            public Optional<TextNode> format(final Object value,
+                                             final SpreadsheetFormatterContext context) {
                 return Optional.of(
                         SpreadsheetText.with(
                                 new DecimalFormat("000.000")
                                         .format(value)
-                        )
+                        ).toTextNode()
                 );
             }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ChainSpreadsheetFormatterTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -110,12 +111,15 @@ public final class ChainSpreadsheetFormatterTest extends SpreadsheetFormatterTes
             }
 
             @Override
-            public Optional<SpreadsheetText> format(final Object value,
-                                                    final SpreadsheetFormatterContext context) {
+            public Optional<TextNode> format(final Object value,
+                                             final SpreadsheetFormatterContext context) {
                 Objects.requireNonNull(value, "value");
                 Objects.requireNonNull(context, "context");
 
-                return Optional.of(spreadsheetText(text));
+                return Optional.of(
+                        SpreadsheetText.with(text)
+                                .toTextNode()
+                );
             }
 
             @Override
@@ -123,10 +127,6 @@ public final class ChainSpreadsheetFormatterTest extends SpreadsheetFormatterTes
                 return String.valueOf(value);
             }
         };
-    }
-
-    private static SpreadsheetText spreadsheetText(final String text) {
-        return SpreadsheetText.with(text);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatterTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.format;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
 import walkingkooka.text.CharSequences;
+import walkingkooka.tree.text.TextNode;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -132,7 +133,7 @@ public final class ContextFormatTextSpreadsheetFormatterTest extends Spreadsheet
             }
 
             @Override
-            public Optional<SpreadsheetText> format(final Object value) {
+            public Optional<TextNode> format(final Object value) {
                 if (value instanceof String) {
                     return this.formattedText(value.toString());
                 }
@@ -145,9 +146,10 @@ public final class ContextFormatTextSpreadsheetFormatterTest extends Spreadsheet
                 return this.formattedText(value.toString());
             }
 
-            private Optional<SpreadsheetText> formattedText(final String text) {
+            private Optional<TextNode> formattedText(final String text) {
                 return Optional.of(
                         SpreadsheetText.with(text)
+                                .toTextNode()
                 );
             }
         };

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.color.Color;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -29,18 +30,18 @@ public final class SpreadsheetFormatterContextTest implements ClassTesting<Sprea
     @Test
     public void testFormatOrEmptyText() {
         final String value = "Abc123";
-        final SpreadsheetText expected = SpreadsheetText.EMPTY.setText(value + value + value)
+        final TextNode expected = SpreadsheetText.EMPTY.setText(value + value + value)
                 .setColor(
                         Optional.of(
                                 Color.parse("#234")
                         )
-                );
+                ).toTextNode();
 
         this.checkEquals(
                 expected,
                 new FakeSpreadsheetFormatterContext() {
                     @Override
-                    public Optional<SpreadsheetText> format(final Object v) {
+                    public Optional<TextNode> format(final Object v) {
                         checkEquals(value, v);
                         return Optional.of(expected);
                     }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.color.Color;
+import walkingkooka.tree.text.TextNode;
 
 import java.util.Optional;
 
@@ -34,17 +35,17 @@ public final class SpreadsheetFormatterTest implements SpreadsheetFormatterTesti
                         text + text + text
                 ).setColor(
                         Optional.of(red)
-                ),
+                ).toTextNode(),
                 new FakeSpreadsheetFormatter() {
                     @Override
-                    public Optional<SpreadsheetText> format(final Object value,
-                                                            final SpreadsheetFormatterContext context) {
+                    public Optional<TextNode> format(final Object value,
+                                                     final SpreadsheetFormatterContext context) {
                         return Optional.of(
                                 SpreadsheetText.EMPTY
                                         .setText(text + text + text)
                                         .setColor(
                                                 Optional.of(red)
-                                        )
+                                        ).toTextNode()
                         );
                     }
                 }.formatOrEmptyText(

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterChainTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterChainTest.java
@@ -145,8 +145,8 @@ public final class SpreadsheetPatternSpreadsheetFormatterChainTest extends Sprea
             }
 
             @Override
-            public Optional<SpreadsheetText> format(final Object value,
-                                                    final SpreadsheetFormatterContext context) {
+            public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+                                                                   final SpreadsheetFormatterContext context) {
                 Objects.requireNonNull(value, "value");
                 Objects.requireNonNull(context, "context");
 

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColorTest.java
@@ -213,7 +213,7 @@ public final class SpreadsheetPatternSpreadsheetFormatterColorTest extends Sprea
                 formatter,
                 value,
                 context,
-                Optional.of(formattedText)
+                formattedText.toTextNode()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
@@ -83,7 +83,8 @@ public final class SpreadsheetPatternSpreadsheetFormatterDateTimeTest extends Sp
 
         assertThrows(
                 ConversionException.class,
-                () -> this.createFormatter().format0(
+                () -> this.createFormatter()
+                        .formatSpreadsheetText(
                         time,
                         new FakeSpreadsheetFormatterContext() {
                             @Override

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -33,7 +33,6 @@ import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngines;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
-import walkingkooka.spreadsheet.format.SpreadsheetText;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
@@ -261,15 +260,15 @@ public final class Sample {
                                         )
                                 ).map(
                                         f -> cell.style()
-                                                .replace(f.toTextNode())
+                                                .replace(f)
                                 ).orElse(TextNode.EMPTY_TEXT)
                         )
                 );
             }
 
             @Override
-            public Optional<SpreadsheetText> formatValue(final Object value,
-                                                         final SpreadsheetFormatter formatter) {
+            public Optional<TextNode> formatValue(final Object value,
+                                                  final SpreadsheetFormatter formatter) {
                 checkEquals(false, value instanceof Optional, "Value must not be optional" + value);
 
                 return formatter.format(


### PR DESCRIPTION
…preadsheetText>

- SpreadsheetEngineContext.formatValue now returns Optional<Node> was Optional<SpreadsheetText>
- SpreadsheetFormatterContext.format now returns Optional<Node> was Optional<SpreadsheetText>

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4074
- SpreadsheetFormatter should return TextNode was SpreadsheetText