### PR TITLE
SpreadsheetPatternSpreadsheetFormatterDateTime.hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
@@ -103,6 +103,25 @@ final class SpreadsheetPatternSpreadsheetFormatterDateTime implements Spreadshee
     // Object...........................................................................................................
 
     @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.valueType,
+                this.token
+        );
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof SpreadsheetPatternSpreadsheetFormatterDateTime && this.equals0((SpreadsheetPatternSpreadsheetFormatterDateTime) other);
+    }
+
+    private boolean equals0(final SpreadsheetPatternSpreadsheetFormatterDateTime other) {
+        return this.valueType == other.valueType &&
+                this.token.equals(other.token);
+    }
+
+    @Override
     public String toString() {
         return this.token.text();
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.color.Color;
 import walkingkooka.convert.ConversionException;
 import walkingkooka.convert.ConverterContexts;
@@ -42,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetPatternSpreadsheetFormatterDateTimeTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<
         SpreadsheetPatternSpreadsheetFormatterDateTime,
-        SpreadsheetFormatDateTimeParserToken> {
+        SpreadsheetFormatDateTimeParserToken>
+        implements HashCodeEqualsDefinedTesting2<SpreadsheetPatternSpreadsheetFormatterDateTime> {
 
     private final static Color RED = Color.parse("#FF0000");
 
@@ -969,5 +971,35 @@ public final class SpreadsheetPatternSpreadsheetFormatterDateTimeTest extends Sp
     @Override
     public Class<SpreadsheetPatternSpreadsheetFormatterDateTime> type() {
         return SpreadsheetPatternSpreadsheetFormatterDateTime.class;
+    }
+
+    // equals...........................................................................................................
+
+    @Test
+    public void testEqualsDifferentPattern() {
+        this.checkNotEquals(
+                this.createFormatter("dd/mm/yyyy")
+        );
+    }
+
+    @Test
+    public void testEqualsDifferentValueType() {
+        final SpreadsheetFormatDateTimeParserToken token = this.parsePatternOrFail("dd/mm/yyyy");
+
+        this.checkNotEquals(
+                SpreadsheetPatternSpreadsheetFormatterDateTime.with(
+                        token,
+                        LocalDate.class
+                ),
+                SpreadsheetPatternSpreadsheetFormatterDateTime.with(
+                        token,
+                        LocalDateTime.class
+                )
+        );
+    }
+
+    @Override
+    public SpreadsheetPatternSpreadsheetFormatterDateTime createObject() {
+        return this.createFormatter();
     }
 }


### PR DESCRIPTION
- Previously were not implemented using Object.hashCode/equals