### PR TITLE
SpreadsheetPatternSpreadsheetFormatterNumber hashCode/equals

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
@@ -152,6 +152,22 @@ final class SpreadsheetPatternSpreadsheetFormatterNumber implements SpreadsheetP
     // Object...........................................................................................................
 
     @Override
+    public int hashCode() {
+        return this.token.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof SpreadsheetPatternSpreadsheetFormatterNumber && this.equals0((SpreadsheetPatternSpreadsheetFormatterNumber) other);
+    }
+
+    // all other fields are derived from examining the token, so no need to include them in hashCode/equals
+    private boolean equals0(final SpreadsheetPatternSpreadsheetFormatterNumber other) {
+        return this.token.equals(other.token);
+    }
+
+    @Override
     public String toString() {
         return this.token.text();
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumberTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.color.Color;
 import walkingkooka.convert.ConversionException;
@@ -46,7 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * In expectations all symbols are changed parse defaults to characters to verify the context is supplying such symbols.
  */
 public final class SpreadsheetPatternSpreadsheetFormatterNumberTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<SpreadsheetPatternSpreadsheetFormatterNumber,
-        SpreadsheetFormatNumberParserToken> {
+        SpreadsheetFormatNumberParserToken>
+        implements HashCodeEqualsDefinedTesting2<SpreadsheetPatternSpreadsheetFormatterNumber> {
 
     private final static Color RED = Color.parse("#FF0000");
     
@@ -2531,5 +2533,20 @@ public final class SpreadsheetPatternSpreadsheetFormatterNumberTest extends Spre
     @Override
     public Class<SpreadsheetPatternSpreadsheetFormatterNumber> type() {
         return SpreadsheetPatternSpreadsheetFormatterNumber.class;
+    }
+
+    // equals...........................................................................................................
+
+    @Test
+    public void testEqualsDifferentToken() {
+        this.checkNotEquals(
+                this.createFormatter("$0.00"),
+                this.createFormatter("#.##")
+        );
+    }
+
+    @Override
+    public SpreadsheetPatternSpreadsheetFormatterNumber createObject() {
+        return this.createFormatter();
     }
 }


### PR DESCRIPTION
- Previously these methods were not implemented using the default provided by Object.