### PR TITLE
SpreadsheetComparatorInfo force json register FIX2

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorInfo.java
@@ -115,8 +115,8 @@ public final class SpreadsheetComparatorInfo implements PluginInfoLike<Spreadshe
     }
 
     static {
-        Url.HOST_PORT_SEPARATOR.character();
-        SpreadsheetComparatorName.CASE_SENSITIVITY.comparator(); // force json registry
+        Url.parseAbsoluteOrRelative("/");
+        SpreadsheetComparatorName.with("Hello"); // force json registry
 
         JsonNodeContext.register(
                 JsonNodeContext.computeTypeName(SpreadsheetComparatorInfo.class),


### PR DESCRIPTION
- Not sure why but reference static fields (constants) doesnt seem to always trigger static initializers.