### PR TITLE
SpreadsheetSelection.parseXXX include original text when value is out…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.spreadsheet.reference;
 
-import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.Range;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.compare.Comparators;
@@ -25,14 +24,7 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetFormula;
 import walkingkooka.spreadsheet.SpreadsheetViewportRectangle;
 import walkingkooka.spreadsheet.parser.SpreadsheetCellReferenceParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserContexts;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserToken;
-import walkingkooka.spreadsheet.parser.SpreadsheetParsers;
-import walkingkooka.text.cursor.MaxPositionTextCursor;
-import walkingkooka.text.cursor.TextCursors;
-import walkingkooka.text.cursor.parser.Parser;
-import walkingkooka.text.cursor.parser.ParserException;
 import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.Comparator;
@@ -60,35 +52,6 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
     public static Comparator<SpreadsheetCell> cellComparator(final Comparator<SpreadsheetCellReference> comparator) {
         return SpreadsheetCellReferenceComparator.with(comparator);
     }
-
-    /**
-     * Parsers the text expecting a valid {@link SpreadsheetCellReference} or fails.
-     */
-    static SpreadsheetCellReference parseCell0(final String text) {
-        try {
-            final MaxPositionTextCursor textCursor = TextCursors.maxPosition(
-                    TextCursors.charSequence(text)
-            );
-            final Optional<ParserToken> token = PARSER.parse(
-                    textCursor,
-                    SpreadsheetParserContexts.fake()
-            );
-            if (false == token.isPresent() || false == textCursor.isEmpty()) {
-                throw new InvalidCharacterException(
-                        text,
-                        textCursor.max()
-                );
-            }
-            return token.get()
-                    .cast(SpreadsheetCellReferenceParserToken.class)
-                    .cell();
-        } catch (final ParserException cause) {
-            throw new IllegalArgumentException(cause.getMessage(), cause);
-        }
-    }
-
-    // Used by SpreadsheetSelection
-    static final Parser<SpreadsheetParserContext> PARSER = SpreadsheetParsers.cell();
 
     /**
      * Factory that creates a {@link SpreadsheetCellReference} with the given column and row.

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
@@ -529,7 +529,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringFails(
                 text,
-                new IllegalArgumentException("Invalid column value 1252505392 expected between 0 and 16384")
+                new IllegalArgumentException("Invalid column value 1252505392 expected between 0 and 16384 in \"ABCDEFGHIJKLM text\"")
         );
     }
 
@@ -549,7 +549,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringFails(
                 text,
-                new IllegalArgumentException("Invalid row value 1912276170 expected between 0 and 1048576")
+                new IllegalArgumentException("Invalid row value 1912276170 expected between 0 and 1048576 in \"1234567890123 text\"")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -1325,15 +1325,35 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testParseInvalidCellReferenceLastColumnPlus1Fails() {
-        this.parseStringFails("XFE2",
-                IllegalArgumentException.class);
+    public void testParseInvalidColumnFails() {
+        this.parseStringFails(
+                "XFE2",
+                new IllegalColumnArgumentException("Invalid column value 16384 expected between 0 and 16384 in \"XFE2\"")
+        );
     }
 
     @Test
-    public void testParseInvalidCellReferenceLastRowPlus1Fails() {
-        this.parseStringFails("B1048577",
-                IllegalArgumentException.class);
+    public void testParseInvalidColumnFails2() {
+        this.parseStringFails(
+                "ABCDEF1",
+                new IllegalColumnArgumentException("Invalid column value 12850895 expected between 0 and 16384 in \"ABCDEF1\"")
+        );
+    }
+
+    @Test
+    public void testParseInvalidRowFails() {
+        this.parseStringFails(
+                "B1048577",
+                new IllegalRowArgumentException("Invalid row value 1048576 expected between 0 and 1048576 in \"B1048577\"")
+        );
+    }
+
+    @Test
+    public void testParseInvalidRowFails2() {
+        this.parseStringFails(
+                "B12345678",
+                new IllegalRowArgumentException("Invalid row value 12345677 expected between 0 and 1048576 in \"B12345678\"")
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceKindTest.java
@@ -273,7 +273,7 @@ public final class SpreadsheetColumnOrRowReferenceKindTest implements ClassTesti
         this.parseFails(
                 SpreadsheetColumnOrRowReferenceKind.COLUMN,
                 "Label123",
-                "Invalid column value 5502781 expected between 0 and 16384"
+                "Invalid column value 5502781 expected between 0 and 16384 in \"Label123\""
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -454,6 +454,14 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     }
 
     @Test
+    public void testParseColumnMoreThanMaxFails() {
+        this.parseStringFails(
+                "ABCDEFGHIJKL",
+                new IllegalColumnArgumentException("Invalid column value 2030465881 expected between 0 and 16384 in \"ABCDEFGHIJKL\"")
+        );
+    }
+
+    @Test
     public void testParseColumnUpperCased() {
         this.parseStringAndCheck("A", SpreadsheetColumnReference.with(0, SpreadsheetReferenceKind.RELATIVE));
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -327,6 +327,14 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     }
 
     @Test
+    public void testParseValueMoreThanMaxFails() {
+        this.parseStringFails(
+                "12345678",
+                new IllegalRowArgumentException("Invalid row value 12345677 expected between 0 and 1048576 in \"12345678\"")
+        );
+    }
+
+    @Test
     public void testParseAbsolute() {
         this.parseStringAndCheck("$1", SpreadsheetReferenceKind.ABSOLUTE.row(0));
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -1194,7 +1194,7 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
         );
 
         this.checkEquals(
-                "Invalid column value 3752126 expected between 0 and 16384",
+                "Invalid column value 3752126 expected between 0 and 16384 in \"hello\"",
                 thrown.getMessage(),
                 "message"
         );


### PR DESCRIPTION
… of range.

- eg a column in text form with "ABCDEFGHIJ" will include that text after the original invalid value message.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4277
- SpreadsheetColumnOrRowSpreadsheetComparatorNames.parseXXX gives confusing message when column/row value is greater than max

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4070
- SpreadsheetSelection.parseCell("AAAA") gives poor error message about out of bounds column