### PR TITLE
BasicSpreadsheetEngineContextTest.testFormatValue *FIX*

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -580,10 +580,10 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
     @Test
     public void testFormatValue() {
         this.formatValueAndCheck(
-                BigDecimal.valueOf(-123.45),
+                BigDecimal.valueOf(-125.25),
                 SpreadsheetPattern.parseNumberFormatPattern("#.#\"Abc123\"").formatter(),
                 SpreadsheetText.with(
-                        MINUS + "123" + DECIMAL + "5Abc123"
+                        MINUS + "125" + DECIMAL + "3Abc123"
                 )
         );
     }


### PR DESCRIPTION
- Test was failing due to changes in behaviour in how BigDecimal are converted to double resulting in slightly different numerical value result in ConverterNumberNumber failing to convert BigDecimal -> double