### PR TITLE
SpreadsheetMetadataPropertyNameFormatterTestCase.testPatternKindNonNull

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatterTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatterTestCase.java
@@ -17,12 +17,22 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 
 public abstract class SpreadsheetMetadataPropertyNameFormatterTestCase<N extends SpreadsheetMetadataPropertyName<SpreadsheetFormatterSelector>> extends SpreadsheetMetadataPropertyNameTestCase<N, SpreadsheetFormatterSelector> {
 
     SpreadsheetMetadataPropertyNameFormatterTestCase() {
         super();
+    }
+
+    @Test
+    public final void testPatternKindNonNull() {
+        this.checkNotEquals(
+                null,
+                this.createName()
+                        .patternKind()
+        );
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4360
- SpreadsheetMetadataPropertyNameFormatterTestCase needs a testPatternKindNonNull