### PR TITLE
SpreadsheetMetadataPropertyNameFormatter.compareToName missing final FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatter.java
@@ -72,7 +72,7 @@ abstract class SpreadsheetMetadataPropertyNameFormatter extends SpreadsheetMetad
     }
 
     @Override
-    String compareToName() {
+    final String compareToName() {
         return this.value();
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4357
- SpreadsheetMetadataPropertyNameFormatter.compareToName missing final modifier