### PR TITLE
SpreadsheetPatternKind.patternPatch javadoc clarify two types of patch

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternKind.java
@@ -377,6 +377,9 @@ public enum SpreadsheetPatternKind implements HasUrlFragment {
 
     /**
      * Factory that creates a {@link JsonNode} patch for the given {@link SpreadsheetPattern}.
+     * Note because there are two types of {@link SpreadsheetPatternKind} one for formatting and other for parsing,
+     * there are also to types of json returned, one holding a {@link walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector}
+     * for formatting and a {@link walkingkooka.spreadsheet.format.SpreadsheetParserSelector} for parsing.
      */
     public JsonNode patternPatch(final Optional<? extends SpreadsheetPattern> pattern,
                                  final JsonNodeMarshallContext context) {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4355
- SpreadsheetPatternKind.patternPatch javadoc: clarify that two possible JSON patches could be returned.