### PR TITLE
SpreadsheetXXXParserPattern.parse calls Parser.parseText

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateParsePattern.java
@@ -22,8 +22,6 @@ import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.parser.SpreadsheetDateParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
-import walkingkooka.text.cursor.TextCursors;
-import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 
@@ -74,10 +72,10 @@ public final class SpreadsheetDateParsePattern extends SpreadsheetNonNumberParse
     public LocalDate parse(final String text,
                            final SpreadsheetParserContext context) {
         return this.parser()
-                .orFailIfCursorNotEmpty(ParserReporters.basic())
-                .parse(TextCursors.charSequence(text), context)
-                .get()
-                .cast(SpreadsheetDateParserToken.class)
+                .parseText(
+                        text,
+                        context
+                ).cast(SpreadsheetDateParserToken.class)
                 .toLocalDate(context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetDateTimeParsePattern.java
@@ -22,8 +22,6 @@ import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.parser.SpreadsheetDateTimeParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
-import walkingkooka.text.cursor.TextCursors;
-import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 
@@ -74,10 +72,10 @@ public final class SpreadsheetDateTimeParsePattern extends SpreadsheetNonNumberP
     public LocalDateTime parse(final String text,
                                final SpreadsheetParserContext context) {
         return this.parser()
-                .orFailIfCursorNotEmpty(ParserReporters.basic())
-                .parse(TextCursors.charSequence(text), context)
-                .get()
-                .cast(SpreadsheetDateTimeParserToken.class)
+                .parseText(
+                        text,
+                        context
+                ).cast(SpreadsheetDateTimeParserToken.class)
                 .toLocalDateTime(context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePattern.java
@@ -23,9 +23,7 @@ import walkingkooka.convert.Converters;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.parser.SpreadsheetNumberParserToken;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
-import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.Parser;
-import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
@@ -65,10 +63,10 @@ public final class SpreadsheetNumberParsePattern extends SpreadsheetParsePattern
     public ExpressionNumber parse(final String text,
                                   final SpreadsheetParserContext context) {
         return this.parser()
-                .orFailIfCursorNotEmpty(ParserReporters.basic())
-                .parse(TextCursors.charSequence(text), context)
-                .get()
-                .cast(SpreadsheetNumberParserToken.class)
+                .parseText(
+                        text,
+                        context
+                ).cast(SpreadsheetNumberParserToken.class)
                 .toNumber(context);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePattern.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetTimeParsePattern.java
@@ -22,8 +22,6 @@ import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetTimeParserToken;
-import walkingkooka.text.cursor.TextCursors;
-import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 
@@ -74,10 +72,10 @@ public final class SpreadsheetTimeParsePattern extends SpreadsheetNonNumberParse
     public LocalTime parse(final String text,
                            final SpreadsheetParserContext context) {
         return this.parser()
-                .orFailIfCursorNotEmpty(ParserReporters.basic())
-                .parse(TextCursors.charSequence(text), context)
-                .get()
-                .cast(SpreadsheetTimeParserToken.class)
+                .parseText(
+                        text,
+                        context
+                ).cast(SpreadsheetTimeParserToken.class)
                 .toLocalTime();
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
@@ -57,7 +57,6 @@ import walkingkooka.spreadsheet.parser.SpreadsheetYearParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.Parser;
-import walkingkooka.text.cursor.parser.ParserReporterException;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokens;
@@ -308,7 +307,7 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
     @Test
     public final void testParseInvalidTextFails() {
         assertThrows(
-                ParserReporterException.class,
+                InvalidCharacterException.class,
                 () -> this.createPattern()
                         .parse(
                                 "!invalid",


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4350
- SpreadsheetTimeParsePattern.parse should be able to use parser.parseTextOrFail

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4349
- SpreadsheetDateParsePattern.parse should be able to use parser.parseTextOrFail

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4348
- SpreadsheetDateTimeParsePattern.parse should be able to use parser.parseTextOrFail