### PR TITLE
SpreadsheetMetadataDefaultTextResource.json removed CONVERTERS/EXPRES…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -40,19 +40,23 @@ import walkingkooka.net.http.server.hateos.HateosResource;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparator;
+import walkingkooka.spreadsheet.compare.SpreadsheetComparatorInfoSet;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorProvider;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorProviders;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
+import walkingkooka.spreadsheet.convert.SpreadsheetConvertersConverterProviders;
 import walkingkooka.spreadsheet.format.SpreadsheetColorName;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContexts;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterInfoSet;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterProvider;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterProviders;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
+import walkingkooka.spreadsheet.format.SpreadsheetParserInfoSet;
 import walkingkooka.spreadsheet.format.SpreadsheetParserProvider;
 import walkingkooka.spreadsheet.format.SpreadsheetParserProviders;
 import walkingkooka.spreadsheet.format.SpreadsheetParserSelector;
@@ -72,6 +76,7 @@ import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.HasExpressionNumberKind;
+import walkingkooka.tree.expression.function.provider.ExpressionFunctionInfoSet;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionProvider;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionProviders;
 import walkingkooka.tree.json.JsonNode;
@@ -1139,6 +1144,38 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                                 .text()
                 ),
                 SpreadsheetMetadata.class
+        ).set(
+                SpreadsheetMetadataPropertyName.CONVERTERS,
+                ConverterInfoSet.with(
+                        SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                                SpreadsheetMetadata.EMPTY,
+                                SpreadsheetFormatterProviders.fake(),
+                                SpreadsheetParserProviders.fake()
+                        ).converterInfos()
+                )
+        ).set(
+                SpreadsheetMetadataPropertyName.EXPRESSION_FUNCTIONS,
+                ExpressionFunctionInfoSet.with(
+                        Sets.empty()
+                )
+        ).set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_COMPARATORS,
+                SpreadsheetComparatorInfoSet.with(
+                        SpreadsheetComparatorProviders.spreadsheetComparators()
+                                .spreadsheetComparatorInfos()
+                )
+        ).set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_FORMATTERS,
+                SpreadsheetFormatterInfoSet.with(
+                        SpreadsheetFormatterProviders.spreadsheetFormatPattern()
+                                .spreadsheetFormatterInfos()
+                )
+        ).set(
+                SpreadsheetMetadataPropertyName.SPREADSHEET_PARSERS,
+                SpreadsheetParserInfoSet.with(
+                        SpreadsheetParserProviders.spreadsheetParsePattern()
+                                .spreadsheetParserInfos()
+                )
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
@@ -64,123 +64,14 @@
   "color-Yellow": 6,
   "color-Magenta": 7,
   "color-Cyan": 8,
-  "converters": [
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/Converter/general",
-      "name": "general"
-    }
-  ],
   "date-time-offset": -25569,
   "default-year": 1900,
   "expression-converter": "general",
-  "expression-functions": [],
   "expression-number-kind": "BIG_DECIMAL",
   "general-number-format-digit-count": 9,
   "hide-zero-values": false,
   "precision": 10,
   "rounding-mode": "HALF_UP",
-  "spreadsheet-comparators": [
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/date",
-      "name": "date"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/date-time",
-      "name": "date-time"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/day-of-month",
-      "name": "day-of-month"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/day-of-week",
-      "name": "day-of-week"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/hour-of-am-pm",
-      "name": "hour-of-am-pm"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/hour-of-day",
-      "name": "hour-of-day"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/minute-of-hour",
-      "name": "minute-of-hour"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/month-of-year",
-      "name": "month-of-year"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/nano-of-second",
-      "name": "nano-of-second"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/number",
-      "name": "number"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/seconds-of-minute",
-      "name": "seconds-of-minute"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/text",
-      "name": "text"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/text-case-insensitive",
-      "name": "text-case-insensitive"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/time",
-      "name": "time"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetComparator/year",
-      "name": "year"
-    }
-  ],
-  "spreadsheet-formatters": [
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/date-format-pattern",
-      "name": "date-format-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/date-time-format-pattern",
-      "name": "date-time-format-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/number-format-pattern",
-      "name": "number-format-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/text-format-pattern",
-      "name": "text-format-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/time-format-pattern",
-      "name": "time-format-pattern"
-    }
-  ],
-  "spreadsheet-parsers": [
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/Parser/date-parse-pattern",
-      "name": "date-parse-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/Parser/date-time-parse-pattern",
-      "name": "date-time-parse-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/Parser/number-parse-pattern",
-      "name": "number-parse-pattern"
-    },
-    {
-      "url": "https://github.com/mP1/walkingkooka-spreadsheet/Parser/time-parse-pattern",
-      "name": "time-parse-pattern"
-    }
-  ],
   "style": {
     "background-color": "#ffffff",
     "border-left-color": "#000000",


### PR DESCRIPTION
…SION_FUNCTIONS/SPREADSHEET_COMPARTORS/SPREADSHEET_FORMATTERS/SPREADSHEET_PARSERS

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4457
- SpreadsheetMetadataDefaultTextResource.json shouldnt hardcode converter/functions/comparators/formatters/parser Infos

- Infos are retrieved from XXXProviders.xxxInfos() instead of hardcoding urls and names.