### PR TITLE
SpreadsheetMetadata defaults text-formatter FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1176,6 +1176,9 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                         SpreadsheetParserProviders.spreadsheetParsePattern()
                                 .spreadsheetParserInfos()
                 )
+        ).set(
+                SpreadsheetMetadataPropertyName.TEXT_FORMATTER,
+                SpreadsheetFormatters.defaultText().
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4462
- SpreadsheetMetadata defaults missing text-formatter=@