### PR TITLE
SpreadsheetFormatParserTokenKind order color alternatives

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKind.java
@@ -267,7 +267,7 @@ public enum SpreadsheetFormatParserTokenKind {
                             .flatMap(k -> k.patterns.stream())
                             .collect(
                                     Collectors.toCollection(
-                                            Sets::sorted
+                                            this.isColor() ? Sets::ordered : Sets::sorted
                                     )
                             )
             );

--- a/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/parser/SpreadsheetFormatParserTokenKindTest.java
@@ -436,17 +436,6 @@ public final class SpreadsheetFormatParserTokenKindTest implements ClassTesting<
     }
 
     @Test
-    public void testAlternativesDayWithoutLeadingZeroDifferentCase() {
-        this.alternativeAndCheck(
-                SpreadsheetFormatParserTokenKind.DAY_WITHOUT_LEADING_ZERO,
-                "d",
-                "dd",
-                "ddd",
-                "dddd"
-        );
-    }
-
-    @Test
     public void testAlternativesDayWithLeadingZero() {
         this.alternativeAndCheck(
                 SpreadsheetFormatParserTokenKind.DAY_WITH_LEADING_ZERO,
@@ -483,7 +472,7 @@ public final class SpreadsheetFormatParserTokenKindTest implements ClassTesting<
 
     private void alternativeAndCheck(final SpreadsheetFormatParserTokenKind kind,
                                      final SpreadsheetFormatParserTokenKind... expected) {
-        final Set<String> patterns = Sets.sorted();
+        final Set<String> patterns = Sets.ordered();
         patterns.addAll(kind.patterns());
 
         for (final SpreadsheetFormatParserTokenKind e : expected) {


### PR DESCRIPTION
- All other alternatives are sorted, but color are ordered, because this keeps SpreadsheetColorName.DEFAULTS in their original order, and keeps color numbers in numeric order.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4585
- SpreadsheetFormatParserTokenKind.COLOR_NUMBER.alternatives should only return numbers and they should be in number order

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4584
- SpreadsheetFormatParserTokenKind.COLOR_NAME.alternatives badly sorted