### PR TITLE
SpreadsheetSelection.comparatorNamesCheck new Invalid message

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -740,7 +740,18 @@ public abstract class SpreadsheetSelection implements HasText,
                     .map(Object::toString)
                     .collect(Collectors.joining(", "));
             if (false == outOfBounds.isEmpty()) {
-                throw new IllegalArgumentException("Some sort columns/rows are not within " + this + " got " + outOfBounds);
+                final SpreadsheetColumnOrRowReference first = comparatorNames.get(0).columnOrRow();
+
+                // Invalid column(s) C are not within D1:E1
+                // Invalid column(s) C, D are not within D1:E1
+                throw new IllegalArgumentException(
+                        "Invalid " +
+                                first.textLabel().toLowerCase() +
+                                "(s) " +
+                                outOfBounds +
+                                " are not within " +
+                                this
+                );
             }
         }
     }

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellRangeTest.java
@@ -522,7 +522,7 @@ public final class SpreadsheetCellRangeTest implements ClassTesting<SpreadsheetC
         );
 
         this.checkEquals(
-                "Some sort columns/rows are not within A1:B2 got C, ZZ",
+                "Invalid column(s) C, ZZ are not within A1:B2",
                 thrown.getMessage()
         );
     }
@@ -559,7 +559,7 @@ public final class SpreadsheetCellRangeTest implements ClassTesting<SpreadsheetC
         );
 
         this.checkEquals(
-                "Some sort columns/rows are not within A1:B2 got 3, 99",
+                "Invalid row(s) 3, 99 are not within A1:B2",
                 thrown.getMessage()
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
@@ -754,7 +754,7 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
         this.comparatorNamesCheckAndCheckFails(
                 "A1:B2",
                 "B=TEXT;C=TEXT;ZZ=TEXT",
-                "Some sort columns/rows are not within A1:B2 got C, ZZ"
+                "Invalid column(s) C, ZZ are not within A1:B2"
         );
     }
 
@@ -763,7 +763,7 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
         this.comparatorNamesCheckAndCheckFails(
                 "A1:B2",
                 "2=TEXT;3=TEXT;99=TEXT",
-                "Some sort columns/rows are not within A1:B2 got 3, 99"
+                "Invalid row(s) 3, 99 are not within A1:B2"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -204,7 +204,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         this.comparatorNamesCheckAndCheckFails(
                 "A1",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
-                "Some sort columns/rows are not within A1 got B, ZZ"
+                "Invalid column(s) B, ZZ are not within A1"
         );
     }
 
@@ -213,7 +213,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         this.comparatorNamesCheckAndCheckFails(
                 "A1",
                 "1=TEXT;2=TEXT;99=TEXT",
-                "Some sort columns/rows are not within A1 got 2, 99"
+                "Invalid row(s) 2, 99 are not within A1"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -318,7 +318,7 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
         this.comparatorNamesCheckAndCheckFails(
                 "A:C",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
-                "Some sort columns/rows are not within A:C got ZZ"
+                "Invalid column(s) ZZ are not within A:C"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -151,7 +151,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
         this.comparatorNamesCheckAndCheckFails(
                 "A",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
-                "Some sort columns/rows are not within A got B, ZZ"
+                "Invalid column(s) B, ZZ are not within A"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -597,7 +597,7 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
         this.comparatorNamesCheckAndCheckFails(
                 "1:3",
                 "1=TEXT;2=TEXT;33=TEXT",
-                "Some sort columns/rows are not within 1:3 got 33"
+                "Invalid row(s) 33 are not within 1:3"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -241,7 +241,7 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
         this.comparatorNamesCheckAndCheckFails(
                 "1",
                 "1=TEXT;2=TEXT;33=TEXT",
-                "Some sort columns/rows are not within 1 got 2, 33"
+                "Invalid row(s) 2, 33 are not within 1"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4771
- SpreadsheetSelection "Some sort columns/rows are not within D1:E1 got B,C" change to "Invalid column(s) B,C is not within D1:E1"