### PR TITLE
SpreadsheetSelection.comparatorNamesBoundsCheck was comparatorNamesCheck

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellRange.java
@@ -217,7 +217,7 @@ public final class SpreadsheetCellRange implements Value<Set<SpreadsheetCell>>,
                 .columnOrRowReferenceKind();
 
         final SpreadsheetCellRangeReference cellRange = this.range();
-        cellRange.comparatorNamesCheck(
+        cellRange.comparatorNamesBoundsCheck(
                 SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.with(
                         comparators.stream()
                                 .map(SpreadsheetColumnOrRowSpreadsheetComparators::toSpreadsheetColumnOrRowSpreadsheetComparatorNames)

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -718,19 +718,19 @@ public abstract class SpreadsheetSelection implements HasText,
 
     abstract Optional<Function<SpreadsheetCellReference, Optional<SpreadsheetCellReference>>> replaceReferencesMapper0(final SpreadsheetSelection movedTo);
 
-    // comparatorNameCheck..............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     /**
      * Verifies all the column/rows for each {@link SpreadsheetColumnOrRowSpreadsheetComparatorNames} are the same type,
      * not overlapping and within this {@link SpreadsheetSelection}. The last check is skipped for {@link SpreadsheetLabelName}.
      */
-    public void comparatorNamesCheck(final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorNames) {
-        this.comparatorNamesCheck0(
+    public void comparatorNamesBoundsCheck(final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorNames) {
+        this.comparatorNamesBoundsCheck0(
                 SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.with(comparatorNames)
         );
     }
 
-    private void comparatorNamesCheck0(final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorNames) {
+    private void comparatorNamesBoundsCheck0(final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorNames) {
         if (false == this.isLabelName()) {
             final SpreadsheetCellRangeReference cellRange = this.toCellRange();
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReferenceTest.java
@@ -747,11 +747,11 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
         return SpreadsheetCellRangeReference.parseCellRange("B2:C3");
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A1:B2",
                 "B=TEXT;C=TEXT;ZZ=TEXT",
                 "Invalid column(s) C, ZZ are not within A1:B2"
@@ -759,8 +759,8 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
     }
 
     @Test
-    public void testComparatorNamesCheckWithRowComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithRowComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A1:B2",
                 "2=TEXT;3=TEXT;99=TEXT",
                 "Invalid row(s) 3, 99 are not within A1:B2"
@@ -768,16 +768,16 @@ public final class SpreadsheetCellRangeReferenceTest extends SpreadsheetCellRefe
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A1:C3",
                 "A=text UP;B=text DOWN"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A1:C3",
                 "2=text UP;3=text DOWN"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -197,11 +197,11 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         );
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A1",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
                 "Invalid column(s) B, ZZ are not within A1"
@@ -209,8 +209,8 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testComparatorNamesCheckWithRowComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithRowComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A1",
                 "1=TEXT;2=TEXT;99=TEXT",
                 "Invalid row(s) 2, 99 are not within A1"
@@ -218,16 +218,16 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A1",
                 "A=text UP"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A1",
                 "1=text UP"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -311,11 +311,11 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
         );
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A:C",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
                 "Invalid column(s) ZZ are not within A:C"
@@ -323,16 +323,16 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A:C",
                 "A=text UP;B=text DOWN;C=text UP"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A:C",
                 "1=text;2=text"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -144,11 +144,11 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
         );
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "A",
                 "A=TEXT;B=TEXT;ZZ=TEXT",
                 "Invalid column(s) B, ZZ are not within A"
@@ -156,16 +156,16 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A",
                 "A=text UP"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "A",
                 "1=text;2=text"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -590,11 +590,11 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
         );
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "1:3",
                 "1=TEXT;2=TEXT;33=TEXT",
                 "Invalid row(s) 33 are not within 1:3"
@@ -602,16 +602,16 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "1:3",
                 "A=text UP;B=text DOWN;C=text UP;D=text DOWN"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "1:3",
                 "1=text;2=text;3=text"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -234,11 +234,11 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
         );
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public void testComparatorNamesCheckWithColumnComparatorsOutOfBoundsFails() {
-        this.comparatorNamesCheckAndCheckFails(
+    public void testComparatorNamesBoundsCheckWithColumnComparatorsOutOfBoundsFails() {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 "1",
                 "1=TEXT;2=TEXT;33=TEXT",
                 "Invalid row(s) 2, 33 are not within 1"
@@ -246,16 +246,16 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     }
 
     @Test
-    public void testComparatorNamesCheckWithColumns() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithColumns() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "1",
                 "A=text UP;B=text DOWN;C=text UP;D=text DOWN"
         );
     }
 
     @Test
-    public void testComparatorNamesCheckWithRows() {
-        this.comparatorNamesCheckAndCheck(
+    public void testComparatorNamesBoundsCheckWithRows() {
+        this.comparatorNamesBoundsCheckAndCheck(
                 "1",
                 "1=text"
         );

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -511,52 +511,52 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         }
     }
 
-    // comparatorNamesCheck.............................................................................................
+    // comparatorNamesBoundsCheck.......................................................................................
 
     @Test
-    public final void testComparatorNamesCheckWithNullComparatorsFails() {
+    public final void testComparatorNamesBoundsCheckWithNullComparatorsFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> this.createSelection()
-                        .comparatorNamesCheck(null)
+                        .comparatorNamesBoundsCheck(null)
         );
     }
 
-    void comparatorNamesCheckAndCheck(final String selection,
-                                      final String comparatorsNameList) {
-        this.comparatorNamesCheckAndCheck(
+    void comparatorNamesBoundsCheckAndCheck(final String selection,
+                                            final String comparatorsNameList) {
+        this.comparatorNamesBoundsCheckAndCheck(
                 this.parseString(selection),
                 SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parse(comparatorsNameList)
         );
     }
 
-    void comparatorNamesCheckAndCheck(final SpreadsheetSelection selection,
-                                      final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorsNameList) {
-        selection.comparatorNamesCheck(comparatorsNameList);
+    void comparatorNamesBoundsCheckAndCheck(final SpreadsheetSelection selection,
+                                            final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorsNameList) {
+        selection.comparatorNamesBoundsCheck(comparatorsNameList);
     }
 
-    void comparatorNamesCheckAndCheckFails(final String selection,
-                                           final String comparatorsNameList,
-                                           final String expected) {
-        this.comparatorNamesCheckAndCheckFails(
+    void comparatorNamesBoundsCheckAndCheckFails(final String selection,
+                                                 final String comparatorsNameList,
+                                                 final String expected) {
+        this.comparatorNamesBoundsCheckAndCheckFails(
                 this.parseString(selection),
                 SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.parse(comparatorsNameList),
                 expected
         );
     }
 
-    void comparatorNamesCheckAndCheckFails(final SpreadsheetSelection selection,
-                                           final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorsNameList,
-                                           final String expected) {
+    void comparatorNamesBoundsCheckAndCheckFails(final SpreadsheetSelection selection,
+                                                 final SpreadsheetColumnOrRowSpreadsheetComparatorNamesList comparatorsNameList,
+                                                 final String expected) {
         final IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class,
-                () -> selection.comparatorNamesCheck(comparatorsNameList)
+                () -> selection.comparatorNamesBoundsCheck(comparatorsNameList)
         );
 
         this.checkEquals(
                 expected,
                 thrown.getMessage(),
-                () -> selection + " comparatorNamesCheck " + comparatorsNameList
+                () -> selection + " comparatorNamesBoundsCheck " + comparatorsNameList
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/4772
- SpreadsheetSelection.comparatorNamesBoundsCheck was comparatorNamesCheck