### PR TITLE
XXXInfo force XXXName init

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorInfo.java
@@ -101,7 +101,7 @@ public final class SpreadsheetComparatorInfo implements PluginInfoLike<Spreadshe
     // Json.............................................................................................................
 
     static void register() {
-
+        SpreadsheetComparatorName.CASE_SENSITIVITY.toString();
     }
 
     static SpreadsheetComparatorInfo unmarshall(final JsonNode node,

--- a/src/main/java/walkingkooka/spreadsheet/export/SpreadsheetExporterInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/export/SpreadsheetExporterInfo.java
@@ -103,6 +103,7 @@ public final class SpreadsheetExporterInfo implements PluginInfoLike<Spreadsheet
 
     static void register() {
         // required to FORCE json register
+        SpreadsheetExporterName.CASE_SENSITIVITY.toString();
     }
 
     static SpreadsheetExporterInfo unmarshall(final JsonNode node,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterInfo.java
@@ -103,6 +103,7 @@ public final class SpreadsheetFormatterInfo implements PluginInfoLike<Spreadshee
 
     static void register() {
         // required to FORCE json register
+        SpreadsheetFormatterName.CASE_SENSITIVITY.toString();
     }
 
     static SpreadsheetFormatterInfo unmarshall(final JsonNode node,

--- a/src/main/java/walkingkooka/spreadsheet/importer/SpreadsheetImporterInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/importer/SpreadsheetImporterInfo.java
@@ -103,6 +103,7 @@ public final class SpreadsheetImporterInfo implements PluginInfoLike<Spreadsheet
 
     static void register() {
         // required to FORCE json register
+        SpreadsheetImporterName.CASE_SENSITIVITY.toString();
     }
 
     static SpreadsheetImporterInfo unmarshall(final JsonNode node,

--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserInfo.java
@@ -104,6 +104,7 @@ public final class SpreadsheetParserInfo implements PluginInfoLike<SpreadsheetPa
 
     static void register() {
         // required to FORCE json register
+        SpreadsheetParserName.CASE_SENSITIVITY.toString();
     }
 
     static SpreadsheetParserInfo unmarshall(final JsonNode node,


### PR DESCRIPTION
- Hopefully solves problems such as being unable to unmarshall SpreadsheetExporterName when GET SpreadsheetExporterInfoSets.