### PR TITLE
SpreadsheetMetadataPropertyName.FIND_FUNCTIONS

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
@@ -169,6 +169,11 @@ public class FakeSpreadsheetMetadataVisitor extends SpreadsheetMetadataVisitor {
     }
 
     @Override
+    protected void visitFindFunctions(final ExpressionFunctionAliases aliases) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visitFormatters(final SpreadsheetFormatterInfoSet value) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
@@ -70,6 +70,7 @@
   "default-year": 1900,
   "exporters": "",
   "expression-number-kind": "BIG_DECIMAL",
+  "find-functions": "",
   "format-converter": "collection(error-to-number, error-to-string, string-to-selection, selection-to-selection, selection-to-string, general)",
   "formula-converter": "collection(error-to-number, error-throwing, string-to-selection, selection-to-selection, selection-to-string, general)",
   "formula-functions": "",

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -191,6 +191,11 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     public static final SpreadsheetMetadataPropertyName<ExpressionNumberKind> EXPRESSION_NUMBER_KIND = registerConstant(SpreadsheetMetadataPropertyNameExpressionNumberKind.instance());
 
     /**
+     * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link ExpressionFunctionAliases}</code> which will be used to pick available functions within find expressions.
+     */
+    public static final SpreadsheetMetadataPropertyName<ExpressionFunctionAliases> FIND_FUNCTIONS = registerConstant(SpreadsheetMetadataPropertyNameExpressionFunctionFind.instance());
+
+    /**
      * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link ConverterSelector}</code> which will be used to convert values during a formatting of values.
      */
     public static final SpreadsheetMetadataPropertyName<ConverterSelector> FORMAT_CONVERTER = registerConstant(SpreadsheetMetadataPropertyNameConverterFormat.instance());

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionFind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionFind.java
@@ -1,0 +1,50 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliases;
+
+/**
+ * This {@link SpreadsheetMetadataPropertyName} holds a {@link ExpressionFunctionAliases} used during
+ * expression evaluation.
+ */
+final class SpreadsheetMetadataPropertyNameExpressionFunctionFind extends SpreadsheetMetadataPropertyNameExpressionFunction {
+
+    /**
+     * Singleton
+     */
+    static SpreadsheetMetadataPropertyNameExpressionFunctionFind instance() {
+        return new SpreadsheetMetadataPropertyNameExpressionFunctionFind();
+    }
+
+    /**
+     * Private constructor use singleton.
+     */
+    private SpreadsheetMetadataPropertyNameExpressionFunctionFind() {
+        super(
+                "find-functions"
+        );
+    }
+
+    @Override
+    void accept(final ExpressionFunctionAliases aliases,
+                final SpreadsheetMetadataVisitor visitor) {
+        visitor.visitFindFunctions(aliases);
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -140,6 +140,7 @@ public interface SpreadsheetMetadataTesting extends Testing {
                     SpreadsheetMetadataPropertyName.EXPORTERS,
                     SPREADSHEET_EXPORTER_PROVIDER.spreadsheetExporterInfos()
             ).set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, EXPRESSION_NUMBER_KIND)
+            .set(SpreadsheetMetadataPropertyName.FIND_FUNCTIONS, ExpressionFunctionAliases.parse(""))
             .set(SpreadsheetMetadataPropertyName.FORMAT_CONVERTER, ConverterSelector.parse("collection (error-to-number, error-to-string, string-to-selection, selection-to-selection, selection-to-string, general)"))
             .set(
                     SpreadsheetMetadataPropertyName.FORMATTERS,

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
@@ -175,6 +175,10 @@ public abstract class SpreadsheetMetadataVisitor extends Visitor<SpreadsheetMeta
         // nop
     }
 
+    protected void visitFindFunctions(final ExpressionFunctionAliases aliases) {
+        // nop
+    }
+
     protected void visitFormatConverter(final ConverterSelector selector) {
         // nop
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -1039,6 +1039,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "    \"https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetExporter/json json\"\n" +
                         "  ],\n" +
                         "  \"expression-number-kind\": \"BIG_DECIMAL\",\n" +
+                        "  \"find-functions\": \"\",\n" +
                         "  \"format-converter\": \"collection(error-to-number, error-to-string, string-to-selection, selection-to-selection, selection-to-string, general)\",\n" +
                         "  \"formatters\": [\n" +
                         "    \"https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/automatic automatic\",\n" +
@@ -1252,6 +1253,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "    \"https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetExporter/json json\"\n" +
                         "  ],\n" +
                         "  \"expression-number-kind\": \"BIG_DECIMAL\",\n" +
+                        "  \"find-functions\": \"\",\n" +
                         "  \"format-converter\": \"collection(error-to-number, error-to-string, string-to-selection, selection-to-selection, selection-to-string, general)\",\n" +
                         "  \"formatters\": [\n" +
                         "    \"https://github.com/mP1/walkingkooka-spreadsheet/SpreadsheetFormatter/automatic automatic\",\n" +

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -2716,6 +2716,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         properties.put(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.BIG_DECIMAL);
         properties.put(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, EXPONENT_SYMBOL);
         properties.put(
+                SpreadsheetMetadataPropertyName.FIND_FUNCTIONS,
+                ConverterSelector.parse("find-something-something")
+        );
+        properties.put(
                 SpreadsheetMetadataPropertyName.FORMAT_CONVERTER,
                 ConverterSelector.parse("general")
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
@@ -278,6 +278,19 @@ public final class SpreadsheetMetadataVisitorTest implements SpreadsheetMetadata
     }
 
     @Test
+    public void testVisitFindFunctions() {
+        new TestSpreadsheetMetadataVisitor() {
+            @Override
+            protected void visitFindFunctions(final ExpressionFunctionAliases a) {
+                this.visited = a;
+            }
+        }.accept(
+                SpreadsheetMetadataPropertyName.FIND_FUNCTIONS,
+                ExpressionFunctionAliases.parse("abs")
+        );
+    }
+
+    @Test
     public void testVisitFormulaConverter() {
         new TestSpreadsheetMetadataVisitor() {
             @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5042
- SpreadsheetMetdataPropertyName.FIND_CELL_EXPRESSION_FUNCTIONS SpreadsheetEngine.findCells should have separate list of functions