### PR TITLE
SpreadsheetMetadataPropertyName.compareToName() removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -711,11 +711,28 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
 
     @Override
     public int compareTo(final SpreadsheetMetadataPropertyName<?> other) {
-        return this.caseSensitivity().comparator().compare(this.compareToName(), other.compareToName());
+        return this.caseSensitivity()
+                .comparator()
+                .compare(
+                        this.compareToValue(),
+                        other.compareToValue()
+                );
     }
 
-    abstract String compareToName();
+    private String compareToValue() {
+        String value = this.value();
 
+        if (this instanceof SpreadsheetMetadataPropertyNameSpreadsheetId) {
+            value = ""; // make ids sort first
+        } else {
+            if (this instanceof SpreadsheetMetadataPropertyNameNumberedColor) {
+                final SpreadsheetMetadataPropertyNameNumberedColor numberedColor = (SpreadsheetMetadataPropertyNameNumberedColor) this;
+                value = numberedColor.compareToValue;
+            }
+        }
+
+        return value;
+    }
 
     abstract Class<T> type();
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
@@ -52,11 +52,6 @@ abstract class SpreadsheetMetadataPropertyNameBoolean extends SpreadsheetMetadat
         return Boolean.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
@@ -64,11 +64,6 @@ abstract class SpreadsheetMetadataPropertyNameCharacter extends SpreadsheetMetad
         return Character.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameClipboardExporter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameClipboardExporter.java
@@ -66,11 +66,6 @@ final class SpreadsheetMetadataPropertyNameClipboardExporter extends Spreadsheet
         return SpreadsheetExporterSelector.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameClipboardImporter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameClipboardImporter.java
@@ -66,11 +66,6 @@ final class SpreadsheetMetadataPropertyNameClipboardImporter extends Spreadsheet
         return SpreadsheetImporterSelector.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverter.java
@@ -57,11 +57,6 @@ abstract class SpreadsheetMetadataPropertyNameConverter extends SpreadsheetMetad
         return ConverterSelector.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
@@ -63,11 +63,6 @@ final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMet
         return Long.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameEmailAddress.java
@@ -52,11 +52,6 @@ abstract class SpreadsheetMetadataPropertyNameEmailAddress extends SpreadsheetMe
         return EmailAddress.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunction.java
@@ -57,11 +57,6 @@ abstract class SpreadsheetMetadataPropertyNameExpressionFunction extends Spreads
         return ExpressionFunctionAliases.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
@@ -65,11 +65,6 @@ final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends Spreadsh
         return ExpressionNumberKind.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormatter.java
@@ -71,11 +71,6 @@ abstract class SpreadsheetMetadataPropertyNameFormatter extends SpreadsheetMetad
         return SpreadsheetFormatterSelector.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
@@ -75,11 +75,6 @@ final class SpreadsheetMetadataPropertyNameFrozenColumns extends SpreadsheetMeta
         visitor.visitFrozenColumns(value);
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
@@ -76,11 +76,6 @@ final class SpreadsheetMetadataPropertyNameFrozenRows extends SpreadsheetMetadat
         visitor.visitFrozenRows(value);
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
@@ -48,11 +48,6 @@ abstract class SpreadsheetMetadataPropertyNameInteger extends SpreadsheetMetadat
         return Integer.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocalDateTime.java
@@ -51,11 +51,6 @@ abstract class SpreadsheetMetadataPropertyNameLocalDateTime extends SpreadsheetM
         return LocalDateTime.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
@@ -63,11 +63,6 @@ final class SpreadsheetMetadataPropertyNameLocale extends SpreadsheetMetadataPro
         return Locale.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
@@ -71,7 +71,7 @@ final class SpreadsheetMetadataPropertyNameNumberedColor extends SpreadsheetMeta
     private SpreadsheetMetadataPropertyNameNumberedColor(final int number) {
         super(COLOR_PREFIX + number);
         this.number = number;
-        this.compareToName = COLOR_PREFIX + CharSequences.padLeft(String.valueOf(number), 5, '0');
+        this.compareToValue = COLOR_PREFIX + CharSequences.padLeft(String.valueOf(number), 5, '0');
     }
 
     final int number;
@@ -114,10 +114,5 @@ final class SpreadsheetMetadataPropertyNameNumberedColor extends SpreadsheetMeta
         visitor.visitNumberedColor(this.number, value);
     }
 
-    @Override
-    String compareToName() {
-        return this.compareToName;
-    }
-
-    private final String compareToName;
+    final String compareToValue;
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameParser.java
@@ -71,11 +71,6 @@ abstract class SpreadsheetMetadataPropertyNameParser extends SpreadsheetMetadata
         return SpreadsheetParserSelector.class;
     }
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePlugin.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePlugin.java
@@ -47,11 +47,6 @@ abstract class SpreadsheetMetadataPropertyNamePlugin<S extends PluginInfoSetLike
     }
 
     @Override
-    final String compareToName() {
-        return this.value();
-    }
-
-    @Override
     final Optional<S> extractLocaleAwareValue(final Locale locale) {
         return Optional.empty();
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
@@ -64,11 +64,6 @@ final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetad
         return RoundingMode.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
@@ -71,11 +71,6 @@ final class SpreadsheetMetadataPropertyNameSortComparators extends SpreadsheetMe
         return SpreadsheetComparatorNameList.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
@@ -66,11 +66,6 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMeta
         return SpreadsheetId.class;
     }
 
-    @Override
-    String compareToName() {
-        return ""; // ensure id always appears first.
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
@@ -66,11 +66,6 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMe
         return SpreadsheetName.class;
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
@@ -57,11 +57,6 @@ abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadata
 
     abstract String extractLocaleValueString(final DecimalFormatSymbols symbols);
 
-    @Override
-    final String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
@@ -67,11 +67,6 @@ final class SpreadsheetMetadataPropertyNameStyle extends SpreadsheetMetadataProp
         visitor.visitStyle(value);
     }
 
-    @Override
-    String compareToName() {
-        return this.value();
-    }
-
     // parseUrlFragmentSaveValue........................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewport.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewport.java
@@ -68,11 +68,6 @@ final class SpreadsheetMetadataPropertyNameViewport extends SpreadsheetMetadataP
     }
 
     @Override
-    String compareToName() {
-        return this.value();
-    }
-
-    @Override
     void accept(final SpreadsheetViewport value,
                 final SpreadsheetMetadataVisitor visitor) {
         visitor.visitViewport(value);


### PR DESCRIPTION
- Updated SpreadsheetMetadataPropertyName.compareTo to special case id & numbered-color

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5186
- SpreadsheetMetadataPropertyName.compareToName should be able to remove and inline