### PR TITLE
SpreadsheetEngineContext.evaluateAsBoolean made abstract

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -231,6 +231,25 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
         return result;
     }
 
+    @Override
+    public boolean evaluateAsBoolean(final Expression expression,
+                                     final Optional<SpreadsheetCell> cell) {
+        Objects.requireNonNull(expression, "expression");
+        Objects.requireNonNull(cell, "cell");
+
+        boolean result;
+
+        try {
+            result = expression.toBoolean(
+                    this.formulaExpressionEvaluationContext(cell)
+            );
+        } catch (final RuntimeException exception) {
+            result = false; // return false for any errors.
+        }
+
+        return result;
+    }
+
     /**
      * Creates a {@link SpreadsheetExpressionEvaluationContext} for both formulas and converting a token to an {@link Expression}.
      */

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -187,6 +187,14 @@ public class FakeSpreadsheetEngineContext extends FakeConverterContext implement
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean evaluateAsBoolean(final Expression node,
+                                     final Optional<SpreadsheetCell> cell) {
+        Objects.requireNonNull(node, "node");
+        Objects.requireNonNull(cell, "cell");
+        throw new UnsupportedOperationException();
+    }
+
     // formatting.......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -81,24 +81,12 @@ public interface SpreadsheetEngineContext extends Context,
                     final Optional<SpreadsheetCell> cell);
 
     /**
-     * Helper that converts the result of the {@link Expression} evaluation into a {@link Boolean} value.
+     * Helper that executes {@link #evaluate(Expression, Optional)} and converts the result into a {@link Boolean}.
+     * If executing the expression results in an error a false will be returned. This is intended for filter type operations,
+     * where only true/false results are desired, and errors should be considered as a non match.
      */
-    default boolean evaluateAsBoolean(final Expression node,
-                                      final Optional<SpreadsheetCell> cell) {
-        return this.spreadsheetMetadata()
-                .formulaSpreadsheetConverterContext(
-                        this::now,
-                        this, // SpreadsheetLabelNameResolver
-                        this, // ConverterProvider
-                        this // ProviderContext
-                ).convertOrFail(
-                        this.evaluate(
-                                node,
-                                cell
-                        ),
-                        Boolean.class
-                );
-    }
+    boolean evaluateAsBoolean(final Expression node,
+                              final Optional<SpreadsheetCell> cell);
 
     // Formatting & SpreadsheetFormatterProvider........................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
@@ -175,6 +175,30 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
 
     // evaluateAsBoolean................................................................................................
 
+    @Test
+    default void testEvaluateAsBooleanWithNullExpressionFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext()
+                        .evaluateAsBoolean(
+                                null,
+                                Optional.empty()
+                        )
+        );
+    }
+
+    @Test
+    default void testEvaluateAsBooleanWithNullCellFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext()
+                        .evaluateAsBoolean(
+                                Expression.value("required expression"),
+                                null
+                        )
+        );
+    }
+
     default void evaluateAsBooleanAndCheck(final SpreadsheetEngineContext context,
                                            final Expression expression,
                                            final boolean expected) {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -22,7 +22,6 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.color.Color;
-import walkingkooka.convert.ConversionException;
 import walkingkooka.datetime.DateTimeContext;
 import walkingkooka.datetime.FakeDateTimeContext;
 import walkingkooka.math.DecimalNumberContext;
@@ -811,18 +810,6 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
     }
 
     // evaluateAsBoolean................................................................................................
-
-    @Test
-    public void testEvaluateAsBooleanConvertFails() {
-        assertThrows(
-                ConversionException.class,
-                () -> this.createContext()
-                        .evaluateAsBoolean(
-                                Expression.value(this),
-                                Optional.empty()
-                        )
-        );
-    }
 
     @Test
     public void testEvaluateAsBooleanTrue() {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFilterPredicateTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineFilterPredicateTest.java
@@ -145,6 +145,12 @@ public final class BasicSpreadsheetEngineFilterPredicateTest implements Predicat
                     }
 
                     @Override
+                    public boolean evaluateAsBoolean(final Expression e,
+                                                     final Optional<SpreadsheetCell> cell) {
+                        return (Boolean)this.evaluate(e, cell);
+                    }
+
+                    @Override
                     public <C extends ConverterContext> Converter<C> converter(final ConverterName name,
                                                                                final List<?> values,
                                                                                final ProviderContext context) {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -13422,6 +13422,12 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
             }
 
             @Override
+            public boolean evaluateAsBoolean(final Expression node,
+                                             final Optional<SpreadsheetCell> cell) {
+                return (Boolean)this.evaluate(node, cell);
+            }
+
+            @Override
             public boolean isPure(final ExpressionFunctionName function) {
                 return this.expressionFunctionProvider()
                         .expressionFunction(


### PR DESCRIPTION
- Previously when a default method assumed a SpreadsheetMetadata.formulaSpreadsheetConverterContext when converting the actual value to a boolean. This will be a problem when the context is executing a find expression which should use a different context.