### PR TITLE
SpreadsheetExpressionReferenceStore.addSaveWatcher pulled

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/store/ReadOnlySpreadsheetExpressionReferenceStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/ReadOnlySpreadsheetExpressionReferenceStore.java
@@ -53,12 +53,6 @@ final class ReadOnlySpreadsheetExpressionReferenceStore<T extends SpreadsheetExp
     }
 
     @Override
-    public Runnable addSaveWatcher(final Consumer<Set<SpreadsheetCellReference>> saved) {
-        Objects.requireNonNull(saved, "saved");
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void delete(final T id) {
         checkId(id);
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetExpressionReferenceStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetExpressionReferenceStore.java
@@ -39,6 +39,12 @@ public interface SpreadsheetExpressionReferenceStore<T extends SpreadsheetExpres
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    default Runnable addSaveWatcher(final Consumer<Set<SpreadsheetCellReference>> saved) {
+        Objects.requireNonNull(saved, "saved");
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Saves many references to the given id. Note any {@link #addAddReferenceWatcher(Consumer)} and {@link #addRemoveReferenceWatcher(Consumer)}
      * will be fired for all targets.

--- a/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStore.java
@@ -58,12 +58,6 @@ final class TreeMapSpreadsheetExpressionReferenceStore<T extends SpreadsheetExpr
     }
 
     @Override
-    public Runnable addSaveWatcher(final Consumer<Set<SpreadsheetCellReference>> saved) {
-        Objects.requireNonNull(saved, "saved");
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void delete(final T id) {
         checkId(id);
         this.removeAllWithTargetAndFireDeleteWatchers(id);


### PR DESCRIPTION
- Default method added to interface, implementations no longer implement with a throw UOE.