### PR TITLE
SpreadsheetSelection.parseColumn invalid column text not number in me…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceSpreadsheetParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceSpreadsheetParser.java
@@ -17,8 +17,10 @@
 
 package walkingkooka.spreadsheet.parser;
 
+import walkingkooka.spreadsheet.reference.IllegalColumnArgumentException;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserToken;
 
@@ -52,8 +54,20 @@ final class SpreadsheetColumnReferenceSpreadsheetParser extends SpreadsheetColum
     final static int RADIX = 26;
 
     @Override
-    ParserToken token1(final SpreadsheetReferenceKind absoluteOrRelative, final int value, final String text) {
-        return SpreadsheetColumnReferenceParserToken.columnReference(absoluteOrRelative.column(value), text);
+    ParserToken token1(final SpreadsheetReferenceKind absoluteOrRelative,
+                       final int value,
+                       final String text) {
+        try {
+            return SpreadsheetColumnReferenceParserToken.columnReference(
+                    absoluteOrRelative.column(value),
+                    text
+            );
+        } catch (final IllegalColumnArgumentException cause) {
+            // Invalid column ABCDE not between \"A\" and \"$MAX\"
+            throw new IllegalColumnArgumentException(
+                    "Invalid column " + CharSequences.quoteAndEscape(text) + " not between \"A\" and \"" + SpreadsheetColumnReference.MAX_VALUE_STRING + "\""
+            );
+        }
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest.java
@@ -529,7 +529,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesTest implemen
 
         this.parseStringFails(
                 text,
-                new IllegalArgumentException("Invalid column value 1252505392 expected between 0 and 16384 in \"ABCDEFGHIJKLM text\"")
+                new IllegalArgumentException("Invalid column \"ABCDEFGHIJKLM\" not between \"A\" and \"XFE\" in \"ABCDEFGHIJKLM text\"")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceSpreadsheetParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetColumnReferenceSpreadsheetParserTest.java
@@ -113,12 +113,18 @@ public final class SpreadsheetColumnReferenceSpreadsheetParserTest extends Sprea
 
     @Test
     public void testParseRelativeReferenceInvalid() {
-        this.parseThrows("" + INVALID, "Invalid column value 16384 expected between 0 and 16384");
+        this.parseThrows(
+                "" + INVALID,
+                "Invalid column \"XFE\" not between \"A\" and \"XFE\""
+        );
     }
 
     @Test
     public void testParseAbsoluteReferenceInvalid() {
-        this.parseThrows("$" + INVALID, "Invalid column value 16384 expected between 0 and 16384");
+        this.parseThrows(
+                "$" + INVALID,
+                "Invalid column \"$XFE\" not between \"A\" and \"XFE\""
+        );
     }
 
     private void parseAndCheck2(final String text, final SpreadsheetReferenceKind referenceKind, final int column) {

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -1327,16 +1327,16 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     @Test
     public void testParseInvalidColumnFails() {
         this.parseStringFails(
-                "XFE2",
-                new IllegalColumnArgumentException("Invalid column value 16384 expected between 0 and 16384 in \"XFE2\"")
+                "XFEA",
+                new IllegalColumnArgumentException("Invalid column \"XFEA\" not between \"A\" and \"XFE\" in \"XFEA\"")
         );
     }
 
     @Test
     public void testParseInvalidColumnFails2() {
         this.parseStringFails(
-                "ABCDEF1",
-                new IllegalColumnArgumentException("Invalid column value 12850895 expected between 0 and 16384 in \"ABCDEF1\"")
+                "ABCDEFG",
+                new IllegalColumnArgumentException("Invalid column \"ABCDEFG\" not between \"A\" and \"XFE\" in \"ABCDEFG\"")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceKindTest.java
@@ -273,7 +273,7 @@ public final class SpreadsheetColumnOrRowReferenceKindTest implements ClassTesti
         this.parseFails(
                 SpreadsheetColumnOrRowReferenceKind.COLUMN,
                 "Label123",
-                "Invalid column value 5502781 expected between 0 and 16384 in \"Label123\""
+                "Invalid column \"Label\" not between \"A\" and \"XFE\" in \"Label123\""
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -473,7 +473,7 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     public void testParseColumnMoreThanMaxFails() {
         this.parseStringFails(
                 "ABCDEFGHIJKL",
-                new IllegalColumnArgumentException("Invalid column value 2030465881 expected between 0 and 16384 in \"ABCDEFGHIJKL\"")
+                new IllegalColumnArgumentException("Invalid column \"ABCDEFGHIJKL\" not between \"A\" and \"XFE\" in \"ABCDEFGHIJKL\"")
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -1194,7 +1194,7 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
         );
 
         this.checkEquals(
-                "Invalid column value 3752126 expected between 0 and 16384 in \"hello\"",
+                "Invalid column \"hello\" not between \"A\" and \"XFE\" in \"hello\"",
                 thrown.getMessage(),
                 "message"
         );


### PR DESCRIPTION
…ssage

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5428
- SpreadsheetSelection.parseColumn -> Invalid column value -1338306651 expected between 0 and 16384 in \"Invalid123!\"\n"