### PR TITLE
SpreadsheetFormula.isEmpty NPE FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -641,7 +641,9 @@ public final class SpreadsheetFormula implements CanBeEmpty,
 
     @Override
     public boolean isEmpty() {
-        return this.text.isEmpty();
+        return this.text()
+                .trim()
+                .isEmpty();
     }
 }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -661,6 +661,56 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         );
     }
 
+    // CanBeEmpty.......................................................................................................
+
+    @Test
+    public void testIsEmpty() {
+        this.parseAndIsEmptyCheck(
+                "",
+                true
+        );
+    }
+
+    @Test
+    public void testIsEmptyWithOnlyWhitespace() {
+        this.parseAndIsEmptyCheck(
+                "  ",
+                true
+        );
+    }
+
+    @Test
+    public void testIsEmptyWithIncompleteExpression() {
+        this.parseAndIsEmptyCheck(
+                "1+",
+                false
+        );
+    }
+
+    @Test
+    public void testIsEmptyWithExpression() {
+        this.parseAndIsEmptyCheck(
+                "1+2",
+                false
+        );
+    }
+
+    @Test
+    public void testIsEmptyWithExpression2() {
+        this.parseAndIsEmptyCheck(
+                " 1 + 2 + hello()",
+                false
+        );
+    }
+
+    private void parseAndIsEmptyCheck(final String text,
+                                      final boolean expected) {
+        this.isEmptyAndCheck(
+                this.parseFormula(text),
+                expected
+        );
+    }
+
     // consumeSpreadsheetExpressionReferences...........................................................................
 
     @Test


### PR DESCRIPTION
- old code was performing SpreadsheetFormula.text.isEmpty() which was failing when text was null because SpreadsheetFormula.token is present.