### PR TITLE
TreeMapSpreadsheetCellStore save/delete watcher loadCells FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStore.java
@@ -80,22 +80,23 @@ final class TreeMapSpreadsheetCellStore implements SpreadsheetCellStore {
     }
 
     @Override
-    public SpreadsheetCell save(final SpreadsheetCell spreadsheetCell) {
-        final SpreadsheetCell saved = this.store.save(spreadsheetCell);
+    public SpreadsheetCell save(final SpreadsheetCell cell) {
+        Objects.requireNonNull(cell, "cell");
 
-        this.lrtd.addOrReplace(saved);
-        this.rltd.addOrReplace(saved);
+        this.lrtd.addOrReplace(cell);
+        this.rltd.addOrReplace(cell);
 
-        this.lrbu.addOrReplace(saved);
-        this.rlbu.addOrReplace(saved);
+        this.lrbu.addOrReplace(cell);
+        this.rlbu.addOrReplace(cell);
 
-        this.tdlr.addOrReplace(saved);
-        this.tdrl.addOrReplace(saved);
+        this.tdlr.addOrReplace(cell);
+        this.tdrl.addOrReplace(cell);
 
-        this.bulr.addOrReplace(saved);
-        this.burl.addOrReplace(saved);
+        this.bulr.addOrReplace(cell);
+        this.burl.addOrReplace(cell);
 
-        return saved;
+        // must be last so any SaveWatchers that try and loadCells after the #maps like #lrtd have already saved $cell
+        return this.store.save(cell);
     }
 
     @Override
@@ -105,7 +106,7 @@ final class TreeMapSpreadsheetCellStore implements SpreadsheetCellStore {
 
     @Override
     public void delete(final SpreadsheetCellReference id) {
-        this.store.delete(id);
+        Objects.requireNonNull(id, "id");
 
         this.lrtd.remove(id);
         this.rltd.remove(id);
@@ -118,6 +119,9 @@ final class TreeMapSpreadsheetCellStore implements SpreadsheetCellStore {
 
         this.bulr.remove(id);
         this.burl.remove(id);
+
+        // must be last so any DeleteWatchers that try and loadCells after the #maps like #lrtd have already deleted $id
+        this.store.delete(id);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetCellStoreTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.store;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.collect.set.SortedSets;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetExpressionFunctionNames;
 import walkingkooka.spreadsheet.SpreadsheetValueType;
@@ -527,6 +528,32 @@ final class TreeMapSpreadsheetCellStoreTest extends SpreadsheetCellStoreTestCase
         );
     }
 
+    // save.............................................................................................................
+
+    @Test
+    public void testLoadCellsWithinSaveCellWithSaveWatcher() {
+        final SpreadsheetCell a1 = SpreadsheetSelection.A1.setFormula(
+                SpreadsheetFormula.EMPTY.setText("'Hello")
+        );
+
+        final Set<SpreadsheetCell> loaded = SortedSets.tree();
+
+        final TreeMapSpreadsheetCellStore store = this.createStore();
+
+        store.addSaveWatcher(
+                (s) -> loaded.addAll(
+                            store.loadCells(
+                                    SpreadsheetSelection.A1.toCellRange()
+                            )
+                    )
+        );
+        store.save(a1);
+
+        this.checkEquals(
+                Sets.of(a1),
+                loaded
+        );
+    }
 
     // deleteCells.....................................................................................................
 
@@ -565,6 +592,33 @@ final class TreeMapSpreadsheetCellStoreTest extends SpreadsheetCellStoreTestCase
 
         this.loadFailCheck(store, b2);
         this.loadFailCheck(store, c3);
+    }
+
+    @Test
+    public void testLoadCellsWithinDeleteCellWithDeleteWatcher() {
+        final SpreadsheetCell a1 = SpreadsheetSelection.A1.setFormula(
+                SpreadsheetFormula.EMPTY.setText("'Hello")
+        );
+
+        final TreeMapSpreadsheetCellStore store = this.createStore();
+        store.save(a1);
+
+        final Set<SpreadsheetCell> loaded = SortedSets.tree();
+
+        store.addDeleteWatcher(
+                (s) -> loaded.addAll(
+                        store.loadCells(
+                                SpreadsheetSelection.A1.toCellRange()
+                        )
+                )
+        );
+
+        store.delete(a1.reference());
+
+        this.checkEquals(
+                Sets.empty(),
+                loaded
+        );
     }
 
     // clearParsedFormulaExpressions..............................................................................................


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5645
- TreeMapSpreadsheetCellStore.save/delete firing events before ALL internal maps are updated, meaning loadCells will be broken