### PR TITLE
BasicSpreadsheetEngineChanges rewrite

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -140,7 +140,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                         evaluation,
                         context
                 );
-                changes.onLoad(evaluated); // might have just loaded a cell without any updates but want to record cell.
+                changes.onCellLoad(evaluated); // might have just loaded a cell without any updates but want to record cell.
 
                 loaded.add(evaluated);
             }
@@ -208,7 +208,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                         final Optional<SpreadsheetCell> loaded = store.load(reference);
                                         if (loaded.isPresent()) {
                                             final SpreadsheetCell evaluated = this.parseFormulaEvaluateFormatStyleAndSave(loaded.get(), evaluation, context);
-                                            changes.onLoad(evaluated); // might have just loaded a cell without any updates but want to record cell.
+                                            changes.onCellLoad(evaluated); // might have just loaded a cell without any updates but want to record cell.
                                         }
                                     }
                                 }
@@ -432,7 +432,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                     if (filterPredicate.test(loadedAndEval)) {
                         if (skipOffset >= offset) {
                             found.add(loadedAndEval);
-                            changes.onLoad(loadedAndEval);
+                            changes.onCellLoad(loadedAndEval);
                         }
                         skipOffset++;
                     }
@@ -572,7 +572,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                 } else {
                     target = cellReference.setFormula(SpreadsheetFormula.EMPTY);
                 }
-                changes.onLoad(target);
+                changes.onCellLoad(target);
 
                 loadedCount++;
             }
@@ -865,15 +865,16 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
      */
     private SpreadsheetDelta prepareResponse(final BasicSpreadsheetEngineChanges changes,
                                              final SpreadsheetEngineContext context) {
-        changes.refreshUpdated();
+        changes.commit();
 
         return this.prepareResponse(
                 changes,
-                changes.deletedAndUpdatedCellRange().map(
-                        r -> SpreadsheetViewportWindows.with(
-                                Sets.of(r)
-                        )
-                ).orElse(SpreadsheetViewportWindows.EMPTY),
+                changes.changesCellRange()
+                        .map(
+                                r -> SpreadsheetViewportWindows.with(
+                                        Sets.of(r)
+                                )
+                        ).orElse(SpreadsheetViewportWindows.EMPTY),
                 context
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChanges.java
@@ -38,14 +38,16 @@ import walkingkooka.spreadsheet.store.TargetAndSpreadsheetCellReference;
 import walkingkooka.spreadsheet.store.repo.SpreadsheetStoreRepository;
 import walkingkooka.watch.Watchers;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 
 /**
  * Aggregates all the updated cells that result parse an operation by {@link BasicSpreadsheetEngine}.
+ * <br>
+ * Note that cell reference save events are not watched.
  */
 final class BasicSpreadsheetEngineChanges implements AutoCloseable {
 
@@ -72,8 +74,6 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
 
         this.engine = engine;
         this.context = context;
-
-        // test $deltaProperties for each watcher registration.
 
         final SpreadsheetStoreRepository repository = context.storeRepository();
 
@@ -119,69 +119,494 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
         this.repository = repository;
     }
 
-    // dispatch using mode to the final target.
+    // double dispatch using mode to the final target method............................................................
 
     private void onCellSaved(final SpreadsheetCell cell) {
-        this.mode.onCellSaved(cell, this);
+        this.mode.onCellSaved(
+                cell,
+                this
+        );
     }
 
     private void onCellDeleted(final SpreadsheetCellReference cell) {
-        this.mode.onCellDeleted(cell, this);
+        this.mode.onCellDeleted(
+                cell,
+                this
+        );
     }
 
     private void onCellReferenceDeleted(final TargetAndSpreadsheetCellReference<SpreadsheetCellReference> targetAndReference) {
-        this.mode.onCellReferenceDeleted(targetAndReference, this);
+        this.mode.onCellReferenceDeleted(
+                targetAndReference,
+                this
+        );
     }
 
     private void onColumnSaved(final SpreadsheetColumn column) {
-        this.mode.onColumnSaved(column, this);
+        this.mode.onColumnSaved(
+                column,
+                this
+        );
     }
 
     private void onColumnDeleted(final SpreadsheetColumnReference column) {
-        this.mode.onColumnDeleted(column, this);
+        this.mode.onColumnDeleted(
+                column,
+                this
+        );
     }
 
     private void onLabelSaved(final SpreadsheetLabelMapping mapping) {
-        this.mode.onLabelSaved(mapping, this);
+        this.mode.onLabelSaved(
+                mapping,
+                this
+        );
     }
 
     private void onLabelDeleted(final SpreadsheetLabelName label) {
-        this.mode.onLabelDeleted(label, this);
+        this.mode.onLabelDeleted(
+                label,
+                this
+        );
     }
 
     private void onRowSaved(final SpreadsheetRow row) {
-        this.mode.onRowSaved(row, this);
+        this.mode.onRowSaved(
+                row,
+                this
+        );
     }
 
     private void onRowDeleted(final SpreadsheetRowReference row) {
-        this.mode.onRowDeleted(row, this);
+        this.mode.onRowDeleted(
+                row,
+                this
+        );
     }
 
-    // IMMEDIATE.......................................................................................................
+    /**
+     * The current mode, which never changes.
+     */
+    private final BasicSpreadsheetEngineChangesMode mode;
+
+    // COLUMN SAVE......................................................................................................
+
+    void onColumnSavedImmediate(final SpreadsheetColumn column) {
+        this.savedColumn(column);
+    }
+
+    void onColumnSavedBatch(final SpreadsheetColumn column) {
+        this.savedColumn(column);
+    }
+
+    private void savedColumn(final SpreadsheetColumn column) {
+        this.getOrCreateColumnCache(column)
+                .save();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetColumnReference, SpreadsheetColumn> getOrCreateColumnCache(final SpreadsheetColumn column) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                column.reference(),
+                column,
+                this.columns
+        );
+    }
+
+    // COLUMN DELETE....................................................................................................
+
+    void onColumnDeletedImmediate(final SpreadsheetColumnReference column) {
+        this.deletedColumn(column);
+    }
+
+    void onColumnDeletedBatch(final SpreadsheetColumnReference column) {
+        this.deletedColumn(column);
+    }
+
+    private void deletedColumn(final SpreadsheetColumnReference column) {
+        this.getOrCreateColumnCache(column)
+                .delete();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetColumnReference, SpreadsheetColumn> getOrCreateColumnCache(final SpreadsheetColumnReference column) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                column,
+                null,
+                this.columns
+        );
+    }
+
+    final Map<SpreadsheetColumnReference, BasicSpreadsheetEngineChangesCache<SpreadsheetColumnReference, SpreadsheetColumn>> columns = Maps.sorted();
+
+    // ROW SAVE.........................................................................................................
+
+    void onRowSavedImmediate(final SpreadsheetRow row) {
+        this.savedRow(row);
+    }
+
+    void onRowSavedBatch(final SpreadsheetRow row) {
+        this.savedRow(row);
+    }
+
+    private void savedRow(final SpreadsheetRow row) {
+        this.getOrCreateRowCache(row)
+                .save();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetRowReference, SpreadsheetRow> getOrCreateRowCache(final SpreadsheetRow row) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                row.reference(),
+                row,
+                this.rows
+        );
+    }
+
+    // ROW DELETE.......................................................................................................
+
+    void onRowDeletedImmediate(final SpreadsheetRowReference row) {
+        this.deletedRow(row);
+    }
+
+    void onRowDeletedBatch(final SpreadsheetRowReference row) {
+        this.deletedRow(row);
+    }
+
+    private void deletedRow(final SpreadsheetRowReference row) {
+        this.getOrCreateRowCache(row)
+                .delete();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetRowReference, SpreadsheetRow> getOrCreateRowCache(final SpreadsheetRowReference row) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                row,
+                null,
+                this.rows
+        );
+    }
+
+    final Map<SpreadsheetRowReference, BasicSpreadsheetEngineChangesCache<SpreadsheetRowReference, SpreadsheetRow>> rows = Maps.sorted();
+
+    // CELL SAVE........................................................................................................
 
     /**
      * Accepts a just saved cell, parsing the formula adding external references and then batching references to this cell.
      */
     void onCellSavedImmediate(final SpreadsheetCell cell) {
-        final SpreadsheetCellReference reference = cell.reference();
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache = this.getOrCreateCellCache(cell)
+                .save();
 
-        final Map<SpreadsheetCellReference, SpreadsheetCell> updatedAndDeleted = this.updatedAndDeletedCells;
-        final SpreadsheetCell previous = updatedAndDeleted.get(reference);
-
-        // save replaces deletes
-        if (null == previous) {
-            updatedAndDeleted.put(reference, cell);
-
-            this.removePreviousExpressionReferences(reference);
-            this.addReferences(cell);
-            this.batchReferrers(reference);
+        if (false == cache.committed) {
+            this.refreshSavedCell(
+                    cell.reference(),
+                    cache
+            );
         }
+    }
+
+    void onCellSavedBatch(final SpreadsheetCell cell) {
+        this.getOrCreateCellCache(cell)
+                .save();
+    }
+
+    private void forceRefreshSavedCell(final SpreadsheetCellReference cell) {
+        this.getOrCreateCellCache(cell)
+                .save()
+                .setCommitted(false);
+    }
+
+    private void refreshSavedCell(final SpreadsheetCellReference cell) {
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache = this.getOrCreateCellCache(cell)
+                .save();
+
+        if (false == cache.committed) {
+            this.refreshSavedCell(
+                    cell,
+                    cache
+            );
+        }
+    }
+
+    private void refreshSavedCell(final SpreadsheetCellReference reference,
+                                  final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache) {
+        SpreadsheetCell cell = null;
+        if (cache.save) {
+            cell = this.repository.cells()
+                    .load(reference)
+                    .orElse(null);
+            if (null != cell) {
+                cell = this.engine.parseFormulaEvaluateFormatStyleAndSave(
+                        cell,
+                        SpreadsheetEngineEvaluation.FORCE_RECOMPUTE,
+                        this.context
+                );
+            }
+            cache.value = cell;
+
+            if (null != cell) {
+                this.onCellLoad(cell);
+            }
+        }
+
+        this.removeReferences(reference);
+        if (null != cell) {
+            this.addFormulaReferences(cell);
+        }
+        this.refreshCellExternalReferences(reference);
+
+        // must be set last because #removeReferences will perform deletes which will clear cache.committed.
+        cache.committed = true;
+    }
+
+    /**
+     * Commits a loaded cell. but records it so any references are updated.
+     */
+    void onCellLoad(final SpreadsheetCell cell) {
+        this.getOrCreateCellCache(cell)
+                .setCommitted(true); // assume SpreadsheetEngineEngine.loadCell "load"
+    }
+
+    /**
+     * Tests if the given {@link SpreadsheetCellReference} has been already been loaded in this request.
+     */
+    boolean isLoaded(final SpreadsheetCellReference cell) {
+        return this.cells.containsKey(cell);
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> getOrCreateCellCache(final SpreadsheetCell cell) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                cell.reference(),
+                cell,
+                this.cells
+        );
+    }
+
+    // CELL DELETE .....................................................................................................
+
+    void onCellDeletedImmediate(final SpreadsheetCellReference cell) {
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache = this.getOrCreateCellCache(cell)
+                .delete();
+
+        if (false == cache.committed) {
+            this.refreshDeletedCell(
+                    cell,
+                    cache
+            );
+        }
+    }
+
+    void onCellDeletedBatch(final SpreadsheetCellReference cell) {
+        this.getOrCreateCellCache(cell)
+                .delete();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> getOrCreateCellCache(final SpreadsheetCellReference cell) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                cell,
+                null,
+
+                this.cells
+        );
+    }
+
+    private void refreshDeletedCell(final SpreadsheetCellReference cell,
+                                    final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache) {
+        this.removeReferences(cell);
+        this.refreshCellExternalReferences(cell);
+
+        cache.setCommitted(true); // previous #removeReferences will clear committed
+    }
+
+    private void refreshRange(final SpreadsheetCellRangeReference range) {
+        this.repository.rangeToCells()
+                .load(range)
+                .ifPresent(c -> c.forEach(this::refreshSavedCell));
+    }
+
+    /**
+     * Returns a {@link SpreadsheetCellRangeReference} that includes all saved & deleted {@link SpreadsheetCellReference} and {@link SpreadsheetLabelName}.
+     */
+    Optional<SpreadsheetCellRangeReference> changesCellRange() {
+        final Set<SpreadsheetCellReference> cells = SortedSets.tree();
+
+        cells.addAll(
+                this.cells.keySet()
+        );
+
+        for (final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache : this.labels.values()) {
+            if (cache.save) {
+                final SpreadsheetLabelMapping labelMapping = cache.value;
+                if (null != labelMapping) {
+                    final SpreadsheetCellRangeReference range = labelMapping.target()
+                            .toCellRangeResolvingLabels(
+                                    l -> this.context.storeRepository()
+                                            .labels()
+                                            .load(l)
+                                            .map(m -> m.target()
+                                                    .toCellRange()
+                                            )
+                            ).orElse(null);
+                    if (null != range) {
+                        cells.add(range.toCell());
+                    }
+                }
+            }
+        }
+
+        return SpreadsheetSelection.boundingRange(cells);
+    }
+
+    /**
+     * Records all updated which includes deleted cells. This can then be returned by the {@link BasicSpreadsheetEngine} method.
+     * A null value indicates the cell was deleted.
+     */
+    final Map<SpreadsheetCellReference, BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell>> cells = Maps.sorted();
+
+    // LABELS...........................................................................................................
+
+    /**
+     * Holds a queue of labels that need to be updated.
+     */
+    void onLabelSavedImmediate(final SpreadsheetLabelMapping mapping) {
+        BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache = this.getOrCreateLabelCache(mapping)
+                .save();
+        if (false == cache.committed) {
+            this.refreshSavedLabel(
+                    mapping.label(),
+                    cache
+            );
+        }
+    }
+
+    void onLabelSavedBatch(final SpreadsheetLabelMapping mapping) {
+        this.getOrCreateLabelCache(mapping)
+                .save();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> getOrCreateLabelCache(final SpreadsheetLabelMapping mapping) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                mapping.label(),
+                mapping,
+                this.labels
+        );
+    }
+
+    private void refreshSavedLabel(final SpreadsheetLabelName label) {
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache = this.getOrCreateLabelCache(label);
+        if (false == cache.committed) {
+            this.refreshSavedLabel(
+                    label,
+                    cache
+            );
+        }
+    }
+
+    // delete label references
+    private void refreshSavedLabel(final SpreadsheetLabelName label,
+                                   final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache) {
+        this.repository.labelReferences()
+                .load(label)
+                .ifPresent(r -> r.forEach(this::forceRefreshSavedCell));
+
+        cache.setCommitted(true);
+    }
+
+    // LABEL DELETE ....................................................................................................
+
+    void onLabelDeletedImmediate(final SpreadsheetLabelName label) {
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache = this.getOrCreateLabelCache(label)
+                .delete();
+
+        if (false == cache.committed) {
+            this.refreshDeletedLabel(
+                    label,
+                    cache
+            );
+        }
+    }
+
+    void onLabelDeletedBatch(final SpreadsheetLabelName label) {
+        this.getOrCreateLabelCache(label)
+                .delete();
+    }
+
+    private BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> getOrCreateLabelCache(final SpreadsheetLabelName label) {
+        return BasicSpreadsheetEngineChangesCache.getOrCreate(
+                label,
+                null,
+                this.labels
+        );
+    }
+
+    /**
+     * Records all updated and deleted labels. This can then be returned by the {@link BasicSpreadsheetEngine} method.
+     * A null value indicates the label was deleted.
+     */
+    final Map<SpreadsheetLabelName, BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping>> labels = Maps.sorted();
+
+    // unused
+    private void refreshDeletedLabel(final SpreadsheetLabelName label) {
+        final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache = this.getOrCreateLabelCache(label);
+        if (false == cache.committed) {
+            this.refreshDeletedLabel(
+                    label,
+                    cache
+            );
+        }
+    }
+
+    // delete label references
+    private void refreshDeletedLabel(final SpreadsheetLabelName label,
+                                     final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache) {
+        this.repository.labelReferences()
+                .load(label)
+                .ifPresent(r -> r.forEach(this::refreshSavedCell));
+
+        cache.committed = true;
+    }
+
+    // CELL REFERENCES DELETE...........................................................................................
+
+    void onCellReferenceDeletedImmediate(final TargetAndSpreadsheetCellReference<SpreadsheetCellReference> targetAndReference) {
+        this.refreshCellExternalReferences(
+                targetAndReference.target()
+        );
+    }
+
+    @SuppressWarnings("unused")
+    void onCellReferenceDeletedBatch(final TargetAndSpreadsheetCellReference<SpreadsheetCellReference> targetAndReference) {
+        this.getOrCreateCellCache(targetAndReference.target())
+                .setCommitted(false); // force refreshing formula & external references
+    }
+
+    private void removeReferences(final SpreadsheetCellReference cell) {
+        final SpreadsheetStoreRepository repository = this.repository;
+
+        repository.cellReferences()
+                .delete(cell);
+
+        repository.labelReferences()
+                .loadTargets(cell)
+                .forEach(l -> this.repository.labelReferences()
+                        .removeReference(
+                                TargetAndSpreadsheetCellReference.with(
+                                        l,
+                                        cell
+                                )
+                        )
+                );
+        repository.rangeToCells()
+                .rangesWithValue(cell)
+                .forEach(r -> this.repository.rangeToCells()
+                        .removeValue(
+                                r,
+                                cell
+                        )
+                );
     }
 
     /**
      * Records any {@link walkingkooka.tree.expression.ExpressionReference} within the given {@link SpreadsheetFormula}.
      */
-    private void addReferences(final SpreadsheetCell cell) {
+    private void addFormulaReferences(final SpreadsheetCell cell) {
         cell.formula()
                 .consumeSpreadsheetExpressionReferences(
                         BasicSpreadsheetEngineChangesAddReferencesSpreadsheetSelectionVisitor.with(
@@ -191,334 +616,85 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
                 );
     }
 
-    /**
-     * Invoked whenever a cell is deleted.
-     */
-    void onCellDeletedImmediate(final SpreadsheetCellReference cell) {
-        this.deletedCellImmediate(cell);
-    }
-
-    private void deletedCellImmediate(final SpreadsheetCellReference cell) {
-        final Map<SpreadsheetCellReference, SpreadsheetCell> updatedAndDeleted = this.updatedAndDeletedCells;
-        final SpreadsheetCell previous = updatedAndDeleted.get(cell);
-
-        // delete does not overwrite save/updated
-        if (null == previous) {
-            updatedAndDeleted.put(cell, null);
-            this.removePreviousExpressionReferences(cell);
-            this.batchReferrers(cell);
-        }
-    }
-
-    private void removePreviousExpressionReferences(final SpreadsheetCellReference cell) {
-        final SpreadsheetStoreRepository repository = this.repository;
-
-        repository.cellReferences()
-                .delete(cell);
-        repository.labelReferences()
-                .loadTargets(cell)
-                .forEach(l -> repository.labelReferences().removeReference(TargetAndSpreadsheetCellReference.with(l, cell)));
-        repository.rangeToCells()
-                .rangesWithValue(cell)
-                .forEach(r -> repository.rangeToCells().removeValue(r, cell));
-    }
-
-    void onCellReferenceDeletedImmediate(final TargetAndSpreadsheetCellReference<SpreadsheetCellReference> targetAndReference) {
-        this.batchReferrers(targetAndReference.target());
-    }
-
-    void onColumnSavedImmediate(final SpreadsheetColumn column) {
-        this.onColumnSave(column);
-    }
-
-    void onColumnDeletedImmediate(final SpreadsheetColumnReference column) {
-        this.deletedColumnImmediate(column);
-    }
-
-    private void deletedColumnImmediate(final SpreadsheetColumnReference column) {
-        final Map<SpreadsheetColumnReference, SpreadsheetColumn> updatedAndDeleted = this.updatedAndDeletedColumns;
-        final SpreadsheetColumn previous = updatedAndDeleted.get(column);
-
-        // delete does not overwrite save/updated
-        if (null == previous) {
-            updatedAndDeleted.put(column, null);
-        }
-    }
-
-    void onLabelSavedImmediate(final SpreadsheetLabelMapping mapping) {
-        final SpreadsheetLabelName label = mapping.label();
-
-        final Map<SpreadsheetLabelName, SpreadsheetLabelMapping> updatedAndDeleted = this.updatedAndDeletedLabels;
-        final SpreadsheetLabelMapping previous = updatedAndDeleted.get(label);
-
-        // save replaces deletes
-        if (null == previous) {
-            updatedAndDeleted.put(
-                    label,
-                    mapping
-            );
-        }
-
-        this.batchReferences(label);
-    }
-
-    void onLabelDeletedImmediate(final SpreadsheetLabelName label) {
-        this.updatedAndDeletedLabels.put(
-                label,
-                null
-        );
-        this.batchLabel(label);
-    }
-
-    void onRowSavedImmediate(final SpreadsheetRow row) {
-        this.onRowSave(row);
-    }
-
-    void onRowDeletedImmediate(final SpreadsheetRowReference row) {
-        this.deletedRowImmediate(row);
-    }
-
-    private void deletedRowImmediate(final SpreadsheetRowReference row) {
-        final Map<SpreadsheetRowReference, SpreadsheetRow> updatedAndDeleted = this.updatedAndDeletedRows;
-        final SpreadsheetRow previous = updatedAndDeleted.get(row);
-
-        // delete does not overwrite save/updated
-        if (null == previous) {
-            updatedAndDeleted.put(row, null);
-        }
-    }
-
-    // BATCH MODE....................................................................................................
-
-    void onCellSavedBatch(final SpreadsheetCell cell) {
-        final SpreadsheetCellReference reference = cell.reference();
-        this.unsavedCells.add(reference);
-
-        this.removePreviousExpressionReferences(reference);
-        this.addReferences(cell);
-        this.batchReferrers(reference);
-    }
-
-    void onCellDeletedBatch(final SpreadsheetCellReference cell) {
-        this.deletedCellImmediate(cell);
-    }
-
-    @SuppressWarnings("unused")
-    void onCellReferenceDeletedBatch(final TargetAndSpreadsheetCellReference<SpreadsheetCellReference> targetAndReference) {
-        this.batchReferrers(targetAndReference.target());
-    }
-
-    void onColumnSavedBatch(final SpreadsheetColumn column) {
-        this.onColumnSaved(column);
-    }
-
-    private void onColumnSave(final SpreadsheetColumn column) {
-        final SpreadsheetColumnReference reference = column.reference();
-
-        final Map<SpreadsheetColumnReference, SpreadsheetColumn> updatedAndDeleted = this.updatedAndDeletedColumns;
-        final SpreadsheetColumn previous = updatedAndDeleted.get(reference);
-
-        // save replaces deletes
-        if (null == previous) {
-            updatedAndDeleted.put(reference, column);
-        }
-    }
-
-    void onColumnDeletedBatch(final SpreadsheetColumnReference column) {
-        this.deletedColumnImmediate(column);
-    }
-
-    void onLabelSavedBatch(final SpreadsheetLabelMapping mapping) {
-        this.batchLabel(mapping.label());
-    }
-
-    void onLabelDeletedBatch(final SpreadsheetLabelName label) {
-        this.batchLabel(label);
-    }
-
-    void onRowSavedBatch(final SpreadsheetRow row) {
-        this.onRowSave(row);
-    }
-
-    private void onRowSave(final SpreadsheetRow row) {
-        final SpreadsheetRowReference reference = row.reference();
-
-        final Map<SpreadsheetRowReference, SpreadsheetRow> updatedAndDeleted = this.updatedAndDeletedRows;
-        final SpreadsheetRow previous = updatedAndDeleted.get(reference);
-
-        // save replaces deletes
-        if (null == previous) {
-            updatedAndDeleted.put(reference, row);
-        }
-    }
-
-    void onRowDeletedBatch(final SpreadsheetRowReference row) {
-        this.deletedRowImmediate(row);
-    }
-
-    // REFRESH UPDATED ................................................................................................
-
-    /**
-     * Completes any outstanding refreshes.
-     */
-    void refreshUpdated() {
-        this.mode = BasicSpreadsheetEngineChangesMode.IMMEDIATE;
-
-        for (; ; ) {
-            final SpreadsheetCellReference potential = this.unsavedCells.poll();
-            if (null == potential) {
-                break;
-            }
-            // saves will have a value of null for the given $potential (reference).
-            if (null != this.updatedAndDeletedCells.get(potential)) {
-                continue;
-            }
-
-            this.context.storeRepository()
-                    .cells()
-                    .load(potential)
-                    .ifPresent(
-                            c -> {
-                                final SpreadsheetCell evaluated = this.engine.parseFormulaEvaluateFormatStyleAndSave(
-                                        c,
-                                        SpreadsheetEngineEvaluation.FORCE_RECOMPUTE,
-                                        this.context
-                                );
-                                onLoad(evaluated); // might have just loaded a cell without any updates but want to record cell.
-                            }
-                    );
-        }
-    }
-
-    /**
-     * Unconditionally adds the {@link SpreadsheetCell} to the updated cells. This is used to add a cell that was loaded
-     * but not changed.
-     */
-    void onLoad(final SpreadsheetCell cell) {
-        this.updatedAndDeletedCells.put(cell.reference(), cell);
-    }
-
-    /**
-     * Tests if the given {@link SpreadsheetCellReference} has been already been loaded in this request.
-     */
-    boolean isLoaded(final SpreadsheetCellReference reference) {
-        return this.updatedAndDeletedCells.containsKey(reference);
-    }
-
-    // cells............................................................................................................
-
-    /**
-     * Returns a {@link SpreadsheetCellRangeReference} that includes all deleted and updated cells.
-     */
-    Optional<SpreadsheetCellRangeReference> deletedAndUpdatedCellRange() {
-        final Set<SpreadsheetCellReference> cells = SortedSets.tree();
-
-        cells.addAll(this.updatedAndDeletedCells.keySet());
-
-        for (final SpreadsheetLabelMapping labelMapping : this.updatedAndDeletedLabels.values()) {
-            if (null != labelMapping) {
-                final SpreadsheetCellRangeReference range = labelMapping.target()
-                        .toCellRangeResolvingLabels(
-                                l -> this.context.storeRepository()
-                                        .labels()
-                                        .load(l)
-                                        .map(m -> m.target()
-                                                .toCellRange()
-                                        )
-                        ).orElse(null);
-                if (null != range) {
-                    cells.add(range.toCell());
-                }
-            }
-        }
-
-        return SpreadsheetSelection.boundingRange(cells);
-    }
-
-    // batch...........................................................................................................
-
-    private void batchCell(final SpreadsheetCellReference reference) {
-        // saves replace delete, but dont replace a previous save
-        if (null == this.updatedAndDeletedCells.get(reference)) {
-            this.unsavedCells.add(reference);
-            this.batchReferrers(reference);
-        }
-    }
-
-    private void batchLabel(final SpreadsheetLabelName label) {
-        // saves replace delete, but dont replace a previous save
-        if (null == this.updatedAndDeletedLabels.get(label)) {
-            this.unsavedLabels.add(label);
-            this.batchReferences(label);
-        }
-    }
-
-    private void batchRange(final SpreadsheetCellRangeReference range) {
-        this.repository.rangeToCells()
-                .load(range)
-                .ifPresent(c -> c.forEach(this::batchCell));
-    }
-
-    private void batchReferences(final SpreadsheetLabelName label) {
-        this.repository.labelReferences()
-                .load(label)
-                .ifPresent(r -> r.forEach(this::batchCell));
-    }
-
-    private void batchReferrers(final SpreadsheetCellReference reference) {
+    private void refreshCellExternalReferences(final SpreadsheetCellReference reference) {
         final SpreadsheetStoreRepository repository = this.repository;
 
         repository.cellReferences()
                 .loadTargets(reference)
-                .forEach(this::batchCell);
+                .forEach(this::forceRefreshSavedCell);
 
         repository.labels()
                 .labels(reference)
-                .forEach(m -> this.batchLabel(m.label()));
+                .forEach(m -> this.refreshSavedLabel(m.label()));
 
         repository.rangeToCells()
                 .loadCellRangeReferences(reference)
-                .forEach(this::batchRange);
+                .forEach(this::refreshRange);
     }
 
-    /**
-     * The current mode.
-     */
-    private volatile BasicSpreadsheetEngineChangesMode mode;
+    // COMMIT...........................................................................................................
 
     /**
-     * Holds a queue of cell references that need to be updated.
+     * Commits any outstanding cell, label, reference type operations.
      */
-    private final Queue<SpreadsheetCellReference> unsavedCells = new ConcurrentLinkedQueue<>();
+    void commit() {
+        boolean changed;
 
-    /**
-     * Records all updated which includes deleted cells. This can then be returned by the {@link BasicSpreadsheetEngine} method.
-     * A null value indicates the cell was deleted.
-     */
-    final Map<SpreadsheetCellReference, SpreadsheetCell> updatedAndDeletedCells = Maps.sorted();
+        do {
+            changed = false;
 
-    /**
-     * Records all updated which includes deleted columns. This can then be returned by the {@link BasicSpreadsheetEngine} method.
-     * A null value indicates the column was deleted.
-     */
-    final Map<SpreadsheetColumnReference, SpreadsheetColumn> updatedAndDeletedColumns = Maps.sorted();
+            {
+                final Collection<BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell>> workCells = this.cells.values()
+                        .stream()
+                        .filter(c -> false == c.committed)
+                        .collect(Collectors.toList());
 
-    /**
-     * Records all updated which includes deleted rows. This can then be returned by the {@link BasicSpreadsheetEngine} method.
-     * A null value indicates the row was deleted.
-     */
-    final Map<SpreadsheetRowReference, SpreadsheetRow> updatedAndDeletedRows = Maps.sorted();
+                for (final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> cache : workCells) {
+                    changed = true;
 
-    /**
-     * Holds a queue of labels that need to be updated.
-     */
-    private final Queue<SpreadsheetLabelName> unsavedLabels = new ConcurrentLinkedQueue<>();
+                    final SpreadsheetCellReference reference = cache.reference;
+                    if (cache.save) {
+                        this.refreshSavedCell(
+                                reference,
+                                cache
+                        );
+                    } else {
+                        this.refreshDeletedCell(
+                                reference,
+                                cache
+                        );
+                    }
+                }
+            }
 
-    /**
-     * Records all updated and deleted labels. This can then be returned by the {@link BasicSpreadsheetEngine} method.
-     * A null value indicates the label was deleted.
-     */
-    final Map<SpreadsheetLabelName, SpreadsheetLabelMapping> updatedAndDeletedLabels = Maps.sorted();
+            {
+                final Collection<BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping>> workLabels = this.labels.values()
+                        .stream()
+                        .filter(c -> false == c.committed)
+                        .collect(Collectors.toList());
+
+                for (final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> cache : workLabels) {
+                    changed = true;
+
+                    final SpreadsheetLabelName labelName = cache.reference;
+                    if (cache.save) {
+                        this.refreshSavedLabel(
+                                labelName,
+                                cache
+                        );
+
+                    } else {
+                        this.refreshDeletedLabel(
+                                labelName,
+                                cache
+                        );
+                    }
+                }
+            }
+        } while (changed);
+    }
+
+    // MISC.............................................................................................................
 
     // VisibleFor BasicSpreadsheetEngine
     final Set<SpreadsheetDeltaProperties> deltaProperties;
@@ -561,6 +737,12 @@ final class BasicSpreadsheetEngineChanges implements AutoCloseable {
 
     @Override
     public String toString() {
-        return this.updatedAndDeletedCells + " " + this.updatedAndDeletedColumns + " " + this.updatedAndDeletedRows;
+        return this.cells +
+                " " +
+                this.labels +
+                " " +
+                this.columns +
+                " " +
+                this.rows;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChangesCache.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChangesCache.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.ToStringBuilder;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A cache of an SAVE/UPDATE or DELETE operation upon a reference and value. A save flag is used rather than testing the
+ * value for null to avoid mistakes like a SAVE without the actual value.
+ */
+final class BasicSpreadsheetEngineChangesCache<S extends SpreadsheetSelection, V> {
+
+    static <S extends SpreadsheetSelection, V> BasicSpreadsheetEngineChangesCache<S, V> getOrCreate(
+            final S reference,
+            final V value,
+            final Map<S, BasicSpreadsheetEngineChangesCache<S, V>> referenceToValue) {
+        Objects.requireNonNull(reference, "reference");
+
+        BasicSpreadsheetEngineChangesCache<S, V> cache = referenceToValue.get(reference);
+        if (null == cache) {
+            cache = new BasicSpreadsheetEngineChangesCache<>(
+                    reference,
+                    value
+            );
+            referenceToValue.put(
+                    reference,
+                    cache
+            );
+        } else {
+            // if extra save with the DIFFERENT cell clear $committed
+            if(null != value) {
+                //cache.committed = false == value.equals(cache.value);
+
+                // clear committed if new save value happens
+                if(false == value.equals(cache.value)) {
+                    cache.committed = false;
+                }
+            }
+        }
+
+        if(null != value) {
+            cache.save = true; // must be save when value provided.
+        }
+
+        return cache;
+    }
+
+    private BasicSpreadsheetEngineChangesCache(final S reference,
+                                               final V value) {
+        this.reference = reference;
+        this.value = value;
+    }
+
+    /**
+     * The {@link walkingkooka.spreadsheet.reference.SpreadsheetCellReference} or {@link walkingkooka.spreadsheet.reference.SpreadsheetLabelName}.
+     */
+    final S reference;
+
+    BasicSpreadsheetEngineChangesCache<S, V> save() {
+        this.save = true;
+        return this;
+    }
+
+    BasicSpreadsheetEngineChangesCache<S, V> delete() {
+        this.save = false;
+        return this;
+    }
+
+    /**
+     * Only true for SAVE/UPDATES will be false for DELETES.
+     */
+    boolean save;
+
+    /**
+     * When {@link #save is true, could be null if an existing cell hasnt been loaded such as when iterating over
+     * {@link walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping}.
+     */
+    V value;
+
+    /**
+     * Setter supporting fluent setter.
+     */
+    BasicSpreadsheetEngineChangesCache<S, V> setCommitted(final boolean committed) {
+        this.committed = committed;
+        return this;
+    }
+
+    /**
+     * Indicates an unsaved or undeleted entity.
+     */
+    boolean committed = false;
+
+    // Object...........................................................................................................
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.empty()
+                .value(this.reference)
+                .labelSeparator("=")
+                .value(this.value)
+                .label("save")
+                .value(this.save)
+                .label("committed")
+                .value(this.committed)
+                .build();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEnginePrepareResponse.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEnginePrepareResponse.java
@@ -84,25 +84,25 @@ final class BasicSpreadsheetEnginePrepareResponse {
     }
 
     SpreadsheetDelta go() {
-        this.changes.refreshUpdated();
+        this.changes.commit();
 
         // columns......................................................................................................
         if (this.shouldSaveUpdateColumns || this.shouldDeleteColumns) {
-            for (final Map.Entry<SpreadsheetColumnReference, SpreadsheetColumn> referenceToColumn : this.changes.updatedAndDeletedColumns.entrySet()) {
-                final SpreadsheetColumnReference reference = referenceToColumn.getKey();
-                final SpreadsheetColumn column = referenceToColumn.getValue();
+            for (final BasicSpreadsheetEngineChangesCache<SpreadsheetColumnReference, SpreadsheetColumn> referenceAndColumn : this.changes.columns.values()) {
+                final SpreadsheetColumnReference columnReference = referenceAndColumn.reference;
+                final SpreadsheetColumn column = referenceAndColumn.value;
 
                 if (null != column) {
                     if (this.shouldSaveUpdateColumns) {
                         this.columns.put(
-                                reference,
+                                columnReference,
                                 column
                         );
                     }
                 } else {
                     if (this.shouldDeleteColumns) {
                         this.columns.put(
-                                reference,
+                                columnReference,
                                 null
                         );
                     }
@@ -113,21 +113,21 @@ final class BasicSpreadsheetEnginePrepareResponse {
         // rows.........................................................................................................
 
         if (this.shouldSaveUpdateRows || this.shouldDeleteRows) {
-            for (final Map.Entry<SpreadsheetRowReference, SpreadsheetRow> referenceToRow : this.changes.updatedAndDeletedRows.entrySet()) {
-                final SpreadsheetRowReference reference = referenceToRow.getKey();
-                final SpreadsheetRow row = referenceToRow.getValue();
+            for (final BasicSpreadsheetEngineChangesCache<SpreadsheetRowReference, SpreadsheetRow> referenceAndRow : this.changes.rows.values()) {
+                final SpreadsheetRowReference rowReference = referenceAndRow.reference;
+                final SpreadsheetRow row = referenceAndRow.value;
 
                 if (null != row) {
                     if (this.shouldSaveUpdateRows) {
                         this.rows.put(
-                                reference,
+                                rowReference,
                                 row
                         );
                     }
                 } else {
                     if (this.shouldDeleteRows) {
                         this.rows.put(
-                                reference,
+                                rowReference,
                                 null
                         );
                     }
@@ -138,10 +138,10 @@ final class BasicSpreadsheetEnginePrepareResponse {
         // labels.......................................................................................................
 
         if (this.shouldSaveUpdateLabels || this.shouldDeleteLabels || this.shouldSaveUpdateCells) {
-            for (final Map.Entry<SpreadsheetLabelName, SpreadsheetLabelMapping> labelNameAndMapping : this.changes.updatedAndDeletedLabels.entrySet()) {
-                final SpreadsheetLabelName labelName = labelNameAndMapping.getKey();
-                final SpreadsheetLabelMapping labelMapping = labelNameAndMapping.getValue();
-
+            for (final BasicSpreadsheetEngineChangesCache<SpreadsheetLabelName, SpreadsheetLabelMapping> nameAndMapping : this.changes.labels.values()) {
+                final SpreadsheetLabelName labelName = nameAndMapping.reference;
+                final SpreadsheetLabelMapping labelMapping = nameAndMapping.value;
+                
                 if (null != labelMapping) {
                     if (this.shouldSaveUpdateLabels) {
                         this.labels.put(
@@ -164,9 +164,9 @@ final class BasicSpreadsheetEnginePrepareResponse {
         // cells........................................................................................................
 
         if (this.shouldSaveUpdateCells || this.shouldDeleteCells || this.shouldSaveUpdateLabels || this.shouldDeleteLabels || this.shouldSaveUpdateColumns || this.shouldDeleteColumns || this.shouldSaveUpdateRows || this.shouldDeleteRows) {
-            for (final Map.Entry<SpreadsheetCellReference, SpreadsheetCell> cellReferenceToCell : this.changes.updatedAndDeletedCells.entrySet()) {
-                final SpreadsheetCellReference cellReference = cellReferenceToCell.getKey();
-                final SpreadsheetCell cell = cellReferenceToCell.getValue();
+            for (final BasicSpreadsheetEngineChangesCache<SpreadsheetCellReference, SpreadsheetCell> referenceAndCell : this.changes.cells.values()) {
+                final SpreadsheetCellReference cellReference = referenceAndCell.reference;
+                final SpreadsheetCell cell = referenceAndCell.value;
 
                 if (null != cell) {
                     if (this.shouldSaveUpdateCells) {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChangesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineChangesTest.java
@@ -129,7 +129,7 @@ public final class BasicSpreadsheetEngineChangesTest extends BasicSpreadsheetEng
 
         this.toStringAndCheck(
                 changes,
-                "{A1=A1 1+2, B2=B2 3+4} {M=M, N=N hidden=true} {6=6, 7=7 hidden=true}"
+                "{A1=A1 save=true committed=true, B2=B2 save=true committed=true} {} {M=M M save=true, N=N N hidden=true save=true} {6=6 6 save=true, 7=7 7 hidden=true save=true}"
         );
     }
 


### PR DESCRIPTION
- Previous BATCH BasicSpreadsheetEngineChanges didnt batch all events, some were performed within the event handler.
- Detection of cycles between when resolving labels still outstanding TODO fix SpreadsheetLabelStoreCellReferenceOrRangeSpreadsheetSelectionVisitor.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5648
- Deleting column/row with label does not return deleted labels in SpreadsheetDelta response