### PR TITLE
TargetAndSpreadsheetCellReference allow self reference

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/store/TargetAndSpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TargetAndSpreadsheetCellReference.java
@@ -33,11 +33,11 @@ public final class TargetAndSpreadsheetCellReference<T extends SpreadsheetExpres
                                                                                                        final SpreadsheetCellReference reference) {
         Objects.requireNonNull(target, "target");
         Objects.requireNonNull(reference, "reference");
-        if (target.equals(reference)) {
-            throw new IllegalArgumentException("Target equals reference=" + target);
-        }
 
-        return new TargetAndSpreadsheetCellReference<>(target, reference);
+        return new TargetAndSpreadsheetCellReference<>(
+                target,
+                reference
+        );
     }
 
     private TargetAndSpreadsheetCellReference(final T target, final SpreadsheetCellReference reference) {

--- a/src/test/java/walkingkooka/spreadsheet/store/TargetAndSpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/TargetAndSpreadsheetCellReferenceTest.java
@@ -41,19 +41,32 @@ public final class TargetAndSpreadsheetCellReferenceTest implements HashCodeEqua
     }
 
     @Test
-    public void testWithRefererEqualCellReference() {
-        final SpreadsheetCellReference cell = this.reference();
-
-        assertThrows(IllegalArgumentException.class, () -> TargetAndSpreadsheetCellReference.with(cell, cell));
-    }
-
-    @Test
     public void testWith() {
         final SpreadsheetLabelName label = this.label();
         final SpreadsheetCellReference reference = this.reference();
         final TargetAndSpreadsheetCellReference<?> and = TargetAndSpreadsheetCellReference.with(label, reference);
         this.checkEquals(label, and.target(), "target");
         this.checkEquals(reference, and.reference(), "reference");
+    }
+
+    @Test
+    public void testWithSelfReference() {
+        final SpreadsheetCellReference reference = this.reference();
+        final TargetAndSpreadsheetCellReference<?> and = TargetAndSpreadsheetCellReference.with(
+                reference,
+                reference
+        );
+
+        this.checkEquals(
+                reference,
+                and.target(),
+                "target"
+        );
+        this.checkEquals(
+                reference,
+                and.reference(),
+                "reference"
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStoreTest.java
@@ -82,6 +82,33 @@ public class TreeMapSpreadsheetExpressionReferenceStoreTest extends SpreadsheetE
     }
 
     @Test
+    public void testSaveCellSelfReference() {
+        final TreeMapSpreadsheetExpressionReferenceStore<SpreadsheetCellReference> store = this.createStore();
+
+        final SpreadsheetCellReference a1 = SpreadsheetSelection.A1;
+
+        store.saveReferences(
+                a1,
+                Sets.of(a1)
+        );
+
+        this.checkTargetToReferences(
+                store,
+                Maps.of(
+                        a1,
+                        Sets.of(a1)
+                )
+        );
+        this.checkReferenceToTargets(
+                store,
+                Maps.of(
+                        a1,
+                        Sets.of(a1)
+                )
+        );
+    }
+
+    @Test
     public void testSave3Absolute() {
         final TreeMapSpreadsheetExpressionReferenceStore<SpreadsheetCellReference> store = this.createStore();
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5694
- TargetAndSpreadsheetCellReference.with should allow self references (currently fails in factory with)

- Removed TargetAndSpreadsheetCellReference.with self reference check.