### PR TITLE
SpreadsheetError.referenceNotFound

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
@@ -24,10 +24,12 @@ import walkingkooka.Value;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
+import walkingkooka.store.HasNotFoundText;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonObject;
 import walkingkooka.tree.json.JsonPropertyName;
@@ -88,6 +90,35 @@ public final class SpreadsheetError implements Value<Optional<?>>,
         return SpreadsheetErrorKind.NAME.setMessageAndValue(
                 function.notFoundText(),
                 function
+        );
+    }
+
+    /**
+     * Creates a {@link SpreadsheetError} reporting that a {@link ExpressionReference} was not found.
+     * If the {@link ExpressionReference} is a {@link SpreadsheetExpressionReference} then {@link #selectionNotFound(SpreadsheetExpressionReference)}
+     * is returned.
+     */
+    public static SpreadsheetError referenceNotFound(final ExpressionReference reference) {
+        Objects.requireNonNull(reference, "reference");
+
+        return reference instanceof SpreadsheetExpressionReference ?
+                selectionNotFound((SpreadsheetExpressionReference) reference) :
+                referenceNotSpreadsheetExpressionReferenceNotFound(reference);
+    }
+
+    private static SpreadsheetError referenceNotSpreadsheetExpressionReferenceNotFound(final ExpressionReference reference) {
+        String text;
+
+        if (reference instanceof HasNotFoundText) {
+            final HasNotFoundText hasNotFoundText = (HasNotFoundText) reference;
+            text = hasNotFoundText.notFoundText();
+        } else {
+            text = "Missing " + CharSequences.quoteAndEscape(reference.toString());
+        }
+
+        return SpreadsheetErrorKind.NAME.setMessageAndValue(
+                text,
+                reference
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
@@ -27,6 +27,8 @@ import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.printer.TreePrintableTesting;
 import walkingkooka.tree.expression.ExpressionFunctionName;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.expression.FakeExpressionReference;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -161,6 +163,46 @@ public final class SpreadsheetErrorTest implements ClassTesting2<SpreadsheetErro
         this.checkValue(error, Optional.of(function));
     }
 
+    // referenceNotFound................................................................................................
+
+    @Test
+    public void testReferenceNotFoundWithCell() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("A99");
+
+        final SpreadsheetError error = SpreadsheetError.referenceNotFound(cell);
+        this.checkKind(error, SpreadsheetErrorKind.NAME);
+        this.checkMessage(error, "Cell not found: A99");
+        this.checkValue(error, Optional.of(cell));
+    }
+
+    @Test
+    public void testReferenceNotFoundWithLabel() {
+        final SpreadsheetLabelName label = SpreadsheetSelection.labelName("Label123");
+
+        final SpreadsheetError error = SpreadsheetError.referenceNotFound(label);
+        this.checkKind(error, SpreadsheetErrorKind.NAME);
+        this.checkMessage(error, "Label not found: Label123");
+        this.checkValue(error, Optional.of(label));
+    }
+
+    @Test
+    public void testReferenceNotFoundWithNonSpreadsheetExpressionReference() {
+        final ExpressionReference reference = new FakeExpressionReference() {
+            @Override
+            public String toString() {
+                return "123";
+            }
+        };
+
+        final SpreadsheetError error = SpreadsheetError.referenceNotFound(reference);
+        this.checkKind(error, SpreadsheetErrorKind.NAME);
+        this.checkMessage(error, "Missing \"123\"");
+        this.checkValue(
+                error,
+                Optional.of(reference)
+        );
+    }
+    
     // isMissingCell....................................................................................................
 
     @Test


### PR DESCRIPTION
- Required because SpreadsheetExpressionEvaluationContext.referenceOrFail assumes reference is a SpreadsheetExpressionReference meaning the fail case will throw a ClassCastException