### PR TITLE
ConverterSpreadsheetExpressionEvaluationContext.loadCellOrFail removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
@@ -173,11 +173,6 @@ final class ConverterSpreadsheetExpressionEvaluationContext implements Spreadshe
     }
 
     @Override
-    public SpreadsheetCell cellOrFail() {
-        return this.context.cellOrFail();
-    }
-
-    @Override
     public Converter<SpreadsheetConverterContext> converter() {
         return this.context.converter();
     }


### PR DESCRIPTION
- Unnecessary delegate removed, letting shadowed default method thru.