### PR TITLE
BasicSpreadsheetEngine support empty formula parse & evaluate formatt…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetFormula.java
@@ -319,15 +319,23 @@ public final class SpreadsheetFormula implements CanBeEmpty,
                 );
     }
 
-    // clear ....................................................................................................
+    // clear ...........................................................................................................
 
     /**
      * Clears the expression, value or error if any are present. The {@link SpreadsheetFormula} returned will only
      * have text and possibly a token (if one already was presented)
      */
     public SpreadsheetFormula clear() {
-        return this.expression().isPresent() || this.value().isPresent() ?
-                new SpreadsheetFormula(this.text, this.token, NO_EXPRESSION, NO_VALUE) :
+        final String text = this.text;
+
+        // text will be cleared when token is present
+        return (null == text || false == text.isEmpty()) && (this.expression().isPresent() || this.value().isPresent()) ?
+                new SpreadsheetFormula(
+                        text,
+                        this.token,
+                        NO_EXPRESSION,
+                        NO_VALUE
+                ) :
                 this;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaTest.java
@@ -420,7 +420,7 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     // clear............................................................................................................
 
     @Test
-    public void testClearText() {
+    public void testClearNonEmptyText() {
         final SpreadsheetFormula formula = formula("1+99");
         final SpreadsheetFormula cleared = formula.clear();
         assertSame(
@@ -431,7 +431,7 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     @Test
-    public void testClearTextAndToken() {
+    public void testClearNonEmptyTextAndToken() {
         final SpreadsheetFormula formula = formula("1+99")
                 .setToken(this.token());
         final SpreadsheetFormula cleared = formula.clear();
@@ -443,7 +443,7 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     @Test
-    public void testClearTextTokenExpression() {
+    public void testClearNonEmptyTextTokenExpression() {
         final SpreadsheetFormula formula = formula("1+99")
                 .setToken(this.token())
                 .setExpression(this.expression());
@@ -457,7 +457,7 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     @Test
-    public void testClearTextTokenExpressionValue() {
+    public void testClearNonEmptyTextTokenExpressionValue() {
         final SpreadsheetFormula formula = formula("1+99")
                 .setToken(this.token())
                 .setExpression(this.expression())
@@ -475,6 +475,19 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
         this.expressionAndCheck(formula);
         this.valueAndCheck(formula);
         this.errorAndCheck(formula);
+    }
+
+    @Test
+    public void testClearEmptyTextAndValue() {
+        final SpreadsheetFormula formula = SpreadsheetFormula.EMPTY.setValue(
+                Optional.of(123)
+        );
+
+        final SpreadsheetFormula cleared = formula.clear();
+        assertSame(
+                formula,
+                cleared
+        );
     }
 
     // parse............................................................................................................


### PR DESCRIPTION
…ing value

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/5950
- SpreadsheetEngine should skip parsing and evaluating when value is present and text | token are empty

- SpreadsheetFormula.clear updated to not clear value if text is empty(missing).