### PR TITLE
SpreadsheetSelection.equals simplified

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellRangeReference.java
@@ -920,13 +920,8 @@ public final class SpreadsheetCellRangeReference extends SpreadsheetCellReferenc
     }
 
     @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetCellRangeReference;
-    }
-
-    @Override
-    boolean equals0(final Object other,
-                    final boolean includeKind) {
+    boolean equalsNotSameAndNotNull(final Object other,
+                                    final boolean includeKind) {
         return this.equals1(
                 (SpreadsheetCellRangeReference) other,
                 includeKind
@@ -935,8 +930,8 @@ public final class SpreadsheetCellRangeReference extends SpreadsheetCellReferenc
 
     private boolean equals1(final SpreadsheetCellRangeReference other,
                             final boolean includeKind) {
-        return this.begin().equals0(other.begin(), includeKind) &&
-                this.end().equals0(other.end(), includeKind);
+        return this.begin().equalsNotSameAndNotNull(other.begin(), includeKind) &&
+                this.end().equalsNotSameAndNotNull(other.end(), includeKind);
     }
 
     // toString........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReference.java
@@ -696,13 +696,8 @@ public final class SpreadsheetCellReference extends SpreadsheetCellReferenceOrRa
     }
 
     @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetCellReference;
-    }
-
-    @Override
-    boolean equals0(final Object other,
-                    final boolean includeKind) {
+    boolean equalsNotSameAndNotNull(final Object other,
+                                    final boolean includeKind) {
         return this.equals1(
                 (SpreadsheetCellReference) other,
                 includeKind

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
@@ -220,8 +220,8 @@ abstract class SpreadsheetColumnOrRowRangeReference<T extends SpreadsheetColumnO
     }
 
     @Override
-    boolean equals0(final Object other,
-                    final boolean includeKind) {
+    boolean equalsNotSameAndNotNull(final Object other,
+                                    final boolean includeKind) {
         return this.equals1(
                 (SpreadsheetColumnOrRowRangeReference<?>) other,
                 includeKind
@@ -230,8 +230,8 @@ abstract class SpreadsheetColumnOrRowRangeReference<T extends SpreadsheetColumnO
 
     private boolean equals1(final SpreadsheetColumnOrRowRangeReference<?> other,
                             final boolean includeKind) {
-        return this.begin().equals0(other.begin(), includeKind) &&
-                this.end().equals0(other.end(), includeKind);
+        return this.begin().equalsNotSameAndNotNull(other.begin(), includeKind) &&
+                this.end().equalsNotSameAndNotNull(other.end(), includeKind);
     }
 
     // toString........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
@@ -181,8 +181,8 @@ abstract public class SpreadsheetColumnOrRowReference extends SpreadsheetSelecti
     }
 
     @Override
-    boolean equals0(final Object other,
-                    final boolean includeKind) {
+    boolean equalsNotSameAndNotNull(final Object other,
+                                    final boolean includeKind) {
         return this.equals1(
                 (SpreadsheetColumnOrRowReference) other,
                 includeKind

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
@@ -478,11 +478,6 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnOrRo
 
     // Object...........................................................................................................
 
-    @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetColumnRangeReference;
-    }
-
     // Comparable.......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -572,11 +572,6 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnOrRowRefe
     // Object...........................................................................................................
 
     @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetColumnReference;
-    }
-
-    @Override
     public String toString() {
         return toString0(this.value, this.referenceKind());
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelName.java
@@ -443,13 +443,8 @@ final public class SpreadsheetLabelName extends SpreadsheetExpressionReference
     }
 
     @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetLabelName;
-    }
-
-    @Override
-    boolean equals0(final Object other,
-                    final boolean includeKind) {
+    boolean equalsNotSameAndNotNull(final Object other,
+                                    final boolean includeKind) {
         return this.equals1(
                 (SpreadsheetLabelName) other
         );

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -489,11 +489,6 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
 
     // Object...........................................................................................................
 
-    @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetRowRangeReference;
-    }
-
     // Comparable.......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -560,11 +560,6 @@ public final class SpreadsheetRowReference extends SpreadsheetColumnOrRowReferen
     // Object...........................................................................................................
 
     @Override
-    boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetRowReference;
-    }
-
-    @Override
     public String toString() {
         // in text form columns start at 1 but internally are zero based.
         return this.referenceKind().prefix() + (this.value + 1);

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -1422,30 +1422,39 @@ public abstract class SpreadsheetSelection implements HasText,
     @Override
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public final boolean equals(final Object other) {
-        return this == other ||
-                this.canBeEqual(other) &&
-                        this.equals0(
-                                other,
-                                true
-                        );
+        return this.equalsWithReferenceKind(
+                other,
+                true // includeKind = true
+        );
     }
 
     /**
      * Tests if two {@link SpreadsheetSelection} are equal ignoring the {@link SpreadsheetReferenceKind} if one is present.
      */
     public final boolean equalsIgnoreReferenceKind(final Object other) {
+        return this.equalsWithReferenceKind(
+                other,
+                false // includeKind = false
+        );
+    }
+
+    private boolean equalsWithReferenceKind(final Object other,
+                                            final boolean includeKind) {
         return this == other ||
-                this.canBeEqual(other) &&
-                        this.equals0(
+                null != other &&
+                        this.getClass() == other.getClass() &&
+                        this.equalsNotSameAndNotNull(
                                 other,
-                                false
+                                includeKind
                         );
     }
 
-    abstract boolean canBeEqual(final Object other);
-
-    abstract boolean equals0(final Object other,
-                             final boolean includeKind);
+    /**
+     * Sub-classes should test their important individual properties for equality, assuming the other parameter is
+     * not the same instance and the same class type.
+     */
+    abstract boolean equalsNotSameAndNotNull(final Object other,
+                                             final boolean includeKind);
 
     // Object...........................................................................................................
 


### PR DESCRIPTION
- removed abstract SpreadsheetSelection.canBeEmpty
- First step in reducing soo many abstract SpreadsheetSelection methods