### PR TITLE
SpreadsheetColumnOrRowReference.addXXX0 pulled into subclasses

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReference.java
@@ -119,32 +119,6 @@ abstract class SpreadsheetColumnOrRowRangeReference<T extends SpreadsheetColumnO
 
     abstract SpreadsheetColumnOrRowRangeReference<?> replace(final Range<T> range);
 
-    // add..............................................................................................................
-
-    final SpreadsheetColumnOrRowRangeReference<?> add0(final int value) {
-        return 0 == value ?
-                this :
-                this.addNonZero(value);
-    }
-
-    abstract SpreadsheetColumnOrRowRangeReference<?> addNonZero(final int value);
-
-    // addSaturated.....................................................................................................
-
-    /**
-     * Adds a delta to the value and returns an instance with the result.
-     */
-    @Override
-    public abstract SpreadsheetColumnOrRowRangeReference<?> addSaturated(final int value);
-
-    final SpreadsheetColumnOrRowRangeReference<?> addSaturated0(final int value) {
-        return 0 == value ?
-                this :
-                this.addSaturatedNonZero(value);
-    }
-
-    abstract SpreadsheetColumnOrRowRangeReference<?> addSaturatedNonZero(final int value);
-
     // addIfRelative....................................................................................................
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
@@ -90,12 +90,12 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnOrRo
 
     @Override
     public SpreadsheetColumnRangeReference add(final int value) {
-        return this.add0(value)
-                .toColumnRange();
+        return 0 == value ?
+                this :
+                this.addNonZero(value);
     }
 
-    @Override
-    SpreadsheetColumnRangeReference addNonZero(final int value) {
+    private SpreadsheetColumnRangeReference addNonZero(final int value) {
         return this.setRange(
                 Range.with(
                         RangeBound.inclusive(
@@ -112,12 +112,12 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnOrRo
 
     @Override
     public SpreadsheetColumnRangeReference addSaturated(final int value) {
-        return this.addSaturated0(value)
-                .toColumnRange();
+        return 0 == value ?
+                this :
+                this.addSaturatedNonZero(value);
     }
 
-    @Override
-    SpreadsheetColumnRangeReference addSaturatedNonZero(final int value) {
+    private SpreadsheetColumnRangeReference addSaturatedNonZero(final int value) {
         return this.setRange(
                 Range.with(
                         RangeBound.inclusive(

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -82,12 +82,12 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
 
     @Override
     public SpreadsheetRowRangeReference add(final int value) {
-        return this.add0(value)
-                .toRowRange();
+        return 0 == value ?
+                this :
+                this.addNonZero(value);
     }
 
-    @Override
-    SpreadsheetRowRangeReference addNonZero(final int value) {
+    private SpreadsheetRowRangeReference addNonZero(final int value) {
         return this.setRange(
                 Range.with(
                         RangeBound.inclusive(
@@ -104,12 +104,12 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetColumnOrRowRa
 
     @Override
     public SpreadsheetRowRangeReference addSaturated(final int value) {
-        return this.addSaturated0(value)
-                .toRowRange();
+        return 0 == value ?
+                this :
+                this.addSaturatedNonZero(value);
     }
 
-    @Override
-    SpreadsheetRowRangeReference addSaturatedNonZero(final int value) {
+    private SpreadsheetRowRangeReference addSaturatedNonZero(final int value) {
         return this.setRange(
                 Range.with(
                         RangeBound.inclusive(


### PR DESCRIPTION
- Part of work to remove common base class SpreadsheetColumnOrRowRangeReference.