### PR TITLE
SpreadsheetFormatter.format null value support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/StringToFormatPatternConverterSpreadsheetValueVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/StringToFormatPatternConverterSpreadsheetValueVisitor.java
@@ -219,7 +219,7 @@ final class StringToFormatPatternConverterSpreadsheetValueVisitor extends Spread
         this.formatText(
                 pattern.formatter()
                         .formatOrEmptyText(
-                                value,
+                                Optional.of(value),
                                 SpreadsheetFormatterContexts.basic(
                                         this::numberToColor,
                                         this::nameToColor,

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -275,7 +275,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
     // formatValue......................................................................................................
 
     @Override
-    public Optional<TextNode> formatValue(final Object value,
+    public Optional<TextNode> formatValue(final Optional<Object> value,
                                           final SpreadsheetFormatter formatter) {
         Objects.requireNonNull(formatter, "formatter");
 
@@ -311,7 +311,7 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
                         cell.setFormattedValue(
                                 Optional.of(
                                         this.formatValue(
-                                                        value.get(),
+                                                        value,
                                                         formatter.orElse(
                                                                 this.spreadsheetMetadata()
                                                                         .spreadsheetFormatter(

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetEngineContext.java
@@ -100,7 +100,7 @@ final class BasicSpreadsheetEngineSpreadsheetEngineContext implements Spreadshee
     private final SpreadsheetExpressionEvaluationContext spreadsheetExpressionEvaluationContext;
 
     @Override
-    public Optional<TextNode> formatValue(final Object value,
+    public Optional<TextNode> formatValue(final Optional<Object> value,
                                           final SpreadsheetFormatter formatter) {
         return this.spreadsheetEngineContext.formatValue(
                 value,

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -108,7 +108,7 @@ public class FakeSpreadsheetEngineContext extends FakeSpreadsheetProvider implem
     }
 
     @Override
-    public Optional<TextNode> formatValue(final Object value,
+    public Optional<TextNode> formatValue(final Optional<Object> value,
                                           final SpreadsheetFormatter formatter) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -99,7 +99,7 @@ public interface SpreadsheetEngineContext extends Context,
     /**
      * Formats the given value using the provided formatter.
      */
-    Optional<TextNode> formatValue(final Object value,
+    Optional<TextNode> formatValue(final Optional<Object> value,
                                    final SpreadsheetFormatter formatter);
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegator.java
@@ -83,7 +83,7 @@ public interface SpreadsheetEngineContextDelegator extends SpreadsheetEngineCont
     }
 
     @Override
-    default Optional<TextNode> formatValue(final Object value,
+    default Optional<TextNode> formatValue(final Optional<Object> value,
                                            final SpreadsheetFormatter formatter) {
         return this.spreadsheetEngineContext()
                 .formatValue(

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
@@ -254,13 +254,23 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
                 NullPointerException.class,
                 () -> this.createContext()
                         .formatValue(
-                                "1",
+                                Optional.of("1"),
                                 null
                         )
         );
     }
 
     default void formatValueAndCheck(final Object value,
+                                     final SpreadsheetFormatter formatter,
+                                     final SpreadsheetText expected) {
+        this.formatValueAndCheck(
+                Optional.of(value),
+                formatter,
+                expected
+        );
+    }
+
+    default void formatValueAndCheck(final Optional<Object> value,
                                      final SpreadsheetFormatter formatter,
                                      final SpreadsheetText expected) {
         this.formatValueAndCheck(
@@ -274,6 +284,16 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
                                      final SpreadsheetFormatter formatter,
                                      final TextNode expected) {
         this.formatValueAndCheck(
+                Optional.of(value),
+                formatter,
+                expected
+        );
+    }
+
+    default void formatValueAndCheck(final Optional<Object> value,
+                                     final SpreadsheetFormatter formatter,
+                                     final TextNode expected) {
+        this.formatValueAndCheck(
                 value,
                 formatter,
                 Optional.of(expected)
@@ -281,6 +301,16 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
     }
 
     default void formatValueAndCheck(final Object value,
+                                     final SpreadsheetFormatter formatter,
+                                     final Optional<TextNode> expected) {
+        this.formatValueAndCheck(
+                Optional.of(value),
+                formatter,
+                expected
+        );
+    }
+
+    default void formatValueAndCheck(final Optional<Object> value,
                                      final SpreadsheetFormatter formatter,
                                      final Optional<TextNode> expected) {
         this.formatValueAndCheck(
@@ -297,6 +327,18 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
                                      final TextNode expected) {
         this.formatValueAndCheck(
                 context,
+                Optional.of(value),
+                formatter,
+                expected
+        );
+    }
+
+    default void formatValueAndCheck(final SpreadsheetEngineContext context,
+                                     final Optional<Object> value,
+                                     final SpreadsheetFormatter formatter,
+                                     final TextNode expected) {
+        this.formatValueAndCheck(
+                context,
                 value,
                 formatter,
                 Optional.of(expected)
@@ -304,12 +346,15 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
     }
 
     default void formatValueAndCheck(final SpreadsheetEngineContext context,
-                                     final Object value,
+                                     final Optional<Object> value,
                                      final SpreadsheetFormatter formatter,
                                      final Optional<TextNode> expected) {
         this.checkEquals(
                 expected,
-                context.formatValue(value, formatter),
+                context.formatValue(
+                        value,
+                        formatter
+                ),
                 () -> "formatValue " + CharSequences.quoteIfChars(value) + " " + formatter
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/AutomaticSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/AutomaticSpreadsheetFormatter.java
@@ -57,11 +57,11 @@ final class AutomaticSpreadsheetFormatter implements SpreadsheetFormatter {
     }
 
     @Override
-    public Optional<TextNode> format(final Object value,
+    public Optional<TextNode> format(final Optional<Object> value,
                                      final SpreadsheetFormatterContext context) {
         final SpreadsheetFormatter formatter = SpreadsheetMetadataFormattersSpreadsheetFormatterSpreadsheetValueVisitor.select(
                 this,
-                value
+                value.orElse(null)
         );
         // if the formatter didnt work format with text
         return or(
@@ -69,7 +69,10 @@ final class AutomaticSpreadsheetFormatter implements SpreadsheetFormatter {
                         value,
                         context
                 ),
-                () -> this.text.format(value, context)
+                () -> this.text.format(
+                        value,
+                        context
+                )
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContext.java
@@ -129,7 +129,7 @@ final class BasicSpreadsheetFormatterContext implements SpreadsheetFormatterCont
     // format...........................................................................................................
 
     @Override
-    public Optional<TextNode> format(final Object value) {
+    public Optional<TextNode> format(final Optional<Object> value) {
         return this.formatter.format(
                 value,
                 this

--- a/src/main/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatter.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A {@link SpreadsheetFormatter} that delegates formatting to {@link SpreadsheetFormatterContext#format(Object)}.
+ * A {@link SpreadsheetFormatter} that delegates formatting to {@link SpreadsheetFormatterContext#format(Optional)}.
  */
 final class ContextFormatTextSpreadsheetFormatter implements SpreadsheetFormatter {
 
@@ -41,7 +41,7 @@ final class ContextFormatTextSpreadsheetFormatter implements SpreadsheetFormatte
     }
 
     @Override
-    public Optional<TextNode> format(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Optional<Object> value, final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 

--- a/src/main/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatter.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.format;
 
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumberConverterContext;
 import walkingkooka.tree.text.TextNode;
 
@@ -42,16 +43,25 @@ final class ConverterSpreadsheetFormatter implements SpreadsheetFormatter {
     }
 
     @Override
-    public Optional<TextNode> format(final Object value,
+    public Optional<TextNode> format(final Optional<Object> value,
                                      final SpreadsheetFormatterContext context) {
-        final Either<String, String> converted = this.converter.convert(value, String.class, context);
-        return converted.isLeft() ?
-                Optional.of(
-                        SpreadsheetText.with(
-                                converted.leftValue()
-                        ).toTextNode()
-                ) :
-                Optional.empty();
+        final Either<String, String> converted = this.converter.convert(
+                value.orElse(null),
+                String.class,
+                context
+        );
+        return Optional.ofNullable(
+                converted.isLeft() ?
+                        toTextNode(converted.leftValue()) :
+                       null
+        );
+    }
+
+    private TextNode toTextNode(final String value) {
+        return CharSequences.isNullOrEmpty(value) ?
+                null :
+                SpreadsheetText.with(value)
+                        .toTextNode();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatter.java
@@ -38,7 +38,8 @@ final class EmptySpreadsheetFormatter implements SpreadsheetFormatter {
     }
 
     @Override
-    public Optional<TextNode> format(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Optional<Object> value,
+                                     final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatter.java
@@ -33,7 +33,8 @@ public class FakeSpreadsheetFormatter implements SpreadsheetFormatter, Fake {
     }
 
     @Override
-    public Optional<TextNode> format(final Object value, final SpreadsheetFormatterContext context) {
+    public Optional<TextNode> format(final Optional<Object> value,
+                                     final SpreadsheetFormatterContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterContext.java
@@ -41,7 +41,7 @@ public class FakeSpreadsheetFormatterContext extends FakeSpreadsheetConverterCon
     }
 
     @Override
-    public Optional<TextNode> format(final Object value) {
+    public Optional<TextNode> format(final Optional<Object> value) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetPatternSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetPatternSpreadsheetFormatter.java
@@ -31,7 +31,7 @@ public class FakeSpreadsheetPatternSpreadsheetFormatter extends FakeSpreadsheetF
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatPatternSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatPatternSpreadsheetFormatterProvider.java
@@ -531,7 +531,9 @@ final class SpreadsheetFormatPatternSpreadsheetFormatterProvider implements Spre
         return SpreadsheetFormatterSample.with(
                 "General",
                 SpreadsheetFormatterName.GENERAL.setValueText(""),
-                context.formatOrEmptyText(value)
+                context.formatOrEmptyText(
+                        Optional.ofNullable(value)
+                )
         );
     }
 
@@ -580,7 +582,7 @@ final class SpreadsheetFormatPatternSpreadsheetFormatterProvider implements Spre
                 formatPattern.spreadsheetFormatterSelector(),
                 formatPattern.formatter()
                         .formatOrEmptyText(
-                                value,
+                                Optional.of(value),
                                 context
                         )
         );

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatter.java
@@ -51,13 +51,13 @@ public interface SpreadsheetFormatter extends HasConverter<SpreadsheetConverterC
     /**
      * Accepts a value and returns a {@link TextNode} if it could format the value.
      */
-    Optional<TextNode> format(final Object value,
+    Optional<TextNode> format(final Optional<Object> value,
                               final SpreadsheetFormatterContext context);
 
     /**
      * Formats the given {@link Object value} or returns {@link SpreadsheetText#EMPTY}.
      */
-    default TextNode formatOrEmptyText(final Object value,
+    default TextNode formatOrEmptyText(final Optional<Object> value,
                                        final SpreadsheetFormatterContext context) {
         return this.format(
                 value,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterCollection.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterCollection.java
@@ -66,11 +66,16 @@ final class SpreadsheetFormatterCollection implements SpreadsheetFormatter {
     // SpreadsheetFormatter.............................................................................................
 
     @Override
-    public Optional<TextNode> format(final Object value,
+    public Optional<TextNode> format(final Optional<Object> value,
                                      final SpreadsheetFormatterContext context) {
         return this.formatters.stream()
-                .flatMap(f -> optionalStream(f.format(value, context)))
-                .findFirst();
+                .flatMap(f -> optionalStream(
+                                f.format(
+                                        value,
+                                        context
+                                )
+                        )
+                ).findFirst();
     }
 
     // TODO Missing GWT JRE Optional#stream

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContext.java
@@ -48,12 +48,12 @@ public interface SpreadsheetFormatterContext extends SpreadsheetConverterContext
     /**
      * Provides a default format text.
      */
-    Optional<TextNode> format(final Object value);
+    Optional<TextNode> format(final Optional<Object> value);
 
     /**
      * Formats the given {@link Object value} or if formatting fails returns {@link SpreadsheetText#EMPTY}.
      */
-    default TextNode formatOrEmptyText(final Object value) {
+    default TextNode formatOrEmptyText(final Optional<Object> value) {
         return this.format(value)
                 .orElse(TextNode.EMPTY_TEXT);
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextDelegator.java
@@ -54,13 +54,13 @@ public interface SpreadsheetFormatterContextDelegator extends SpreadsheetFormatt
     }
 
     @Override
-    default Optional<TextNode> format(final Object value) {
+    default Optional<TextNode> format(final Optional<Object> value) {
         return this.spreadsheetFormatterContext()
                 .format(value);
     }
 
     @Override
-    default TextNode formatOrEmptyText(final Object value) {
+    default TextNode formatOrEmptyText(final Optional<Object> value) {
         return this.spreadsheetFormatterContext()
                 .formatOrEmptyText(value);
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTesting.java
@@ -50,12 +50,20 @@ public interface SpreadsheetFormatterContextTesting<C extends SpreadsheetFormatt
     default void formatAndCheck(final Object value,
                                 final SpreadsheetText expected) {
         this.formatAndCheck(
+                Optional.of(value),
+                expected
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
+                                final SpreadsheetText expected) {
+        this.formatAndCheck(
                 value,
                 expected.toTextNode()
         );
     }
 
-    default void formatAndCheck(final Object value,
+    default void formatAndCheck(final Optional<Object> value,
                                 final TextNode expected) {
         this.formatAndCheck(
                 value,
@@ -63,7 +71,7 @@ public interface SpreadsheetFormatterContextTesting<C extends SpreadsheetFormatt
         );
     }
 
-    default void formatAndCheck(final Object value,
+    default void formatAndCheck(final Optional<Object> value,
                                 final Optional<TextNode> expected) {
         this.formatAndCheck(
                 this.createContext(),
@@ -73,7 +81,7 @@ public interface SpreadsheetFormatterContextTesting<C extends SpreadsheetFormatt
     }
 
     default void formatAndCheck(final SpreadsheetFormatterContext context,
-                                final Object value,
+                                final Optional<Object> value,
                                 final Optional<TextNode> expected) {
         this.checkEquals(expected,
                 context.format(value),

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverter.java
@@ -22,6 +22,8 @@ import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.text.CharSequences;
 
+import java.util.Optional;
+
 /**
  * A {@link Converter} which formats a value to {@link String text} using the given {@link SpreadsheetFormatter}.
  */
@@ -53,7 +55,7 @@ final class SpreadsheetFormatterConverter implements Converter<SpreadsheetConver
                                          final Class<T> type,
                                          final SpreadsheetConverterContext context) {
         return this.formatter.format(
-                        value,
+                        Optional.ofNullable(value),
                         SpreadsheetFormatterConverterSpreadsheetFormatterContext.with(context))
                 .map(
                         t -> this.successfulConversion(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
@@ -98,7 +98,7 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
     }
 
     @Override
-    public Optional<TextNode> format(final Object value) {
+    public Optional<TextNode> format(final Optional<Object> value) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting.java
@@ -37,6 +37,16 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
                                 final SpreadsheetFormatterContext context) {
         this.formatAndCheck(
                 formatter,
+                Optional.of(value),
+                context
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
+                                final SpreadsheetFormatterContext context) {
+        this.formatAndCheck(
+                formatter,
                 value,
                 context,
                 Optional.empty()
@@ -47,14 +57,40 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
                                 final Object value,
                                 final SpreadsheetFormatterContext context,
                                 final String text) {
-        this.formatAndCheck(formatter,
+        this.formatAndCheck(
+                formatter,
+                Optional.of(value),
+                context,
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
+                                final SpreadsheetFormatterContext context,
+                                final String text) {
+        this.formatAndCheck(
+                formatter,
                 value,
                 context,
-                SpreadsheetText.with(text));
+                SpreadsheetText.with(text)
+        );
     }
 
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value,
+                                final SpreadsheetFormatterContext context,
+                                final SpreadsheetText text) {
+        this.formatAndCheck(
+                formatter,
+                Optional.of(value),
+                context,
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
                                 final SpreadsheetFormatterContext context,
                                 final SpreadsheetText text) {
         this.formatAndCheck(
@@ -71,6 +107,18 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
                                 final TextNode text) {
         this.formatAndCheck(
                 formatter,
+                Optional.of(value),
+                context,
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
+                                final SpreadsheetFormatterContext context,
+                                final TextNode text) {
+        this.formatAndCheck(
+                formatter,
                 value,
                 context,
                 Optional.of(text)
@@ -79,6 +127,18 @@ public interface SpreadsheetFormatterTesting extends TreePrintableTesting {
 
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value,
+                                final SpreadsheetFormatterContext context,
+                                final Optional<TextNode> text) {
+        this.formatAndCheck(
+                formatter,
+                Optional.of(value),
+                context,
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
                                 final SpreadsheetFormatterContext context,
                                 final Optional<TextNode> text) {
         this.checkEquals(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTesting2.java
@@ -39,12 +39,26 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
     // format...........................................................................................................
 
     @Test
+    default void testFormatWithNullValueFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createFormatter()
+                        .format(
+                                null,
+                                this.createContext()
+                        )
+        );
+    }
+
+    @Test
     default void testFormatWithNullContextFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> this.createFormatter()
                         .format(
-                                this.value(),
+                                Optional.of(
+                                        this.value()
+                                ),
                                 null
                         )
         );
@@ -63,12 +77,28 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
     default void formatAndCheck(final Object value,
                                 final String text) {
         this.formatAndCheck(
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
+                                final String text) {
+        this.formatAndCheck(
                 value,
                 SpreadsheetText.with(text)
         );
     }
 
     default void formatAndCheck(final Object value,
+                                final SpreadsheetText text) {
+        this.formatAndCheck(
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
                                 final SpreadsheetText text) {
         this.formatAndCheck(
                 this.createFormatter(),
@@ -80,12 +110,28 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
     default void formatAndCheck(final Object value,
                                 final TextNode text) {
         this.formatAndCheck(
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
+                                final TextNode text) {
+        this.formatAndCheck(
                 value,
                 Optional.of(text)
         );
     }
 
     default void formatAndCheck(final Object value,
+                                final Optional<TextNode> text) {
+        this.formatAndCheck(
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
                                 final Optional<TextNode> text) {
         this.formatAndCheck(
                 this.createFormatter(),
@@ -99,6 +145,16 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
                                 final String text) {
         this.formatAndCheck(
                 formatter,
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
+                                final String text) {
+        this.formatAndCheck(
+                formatter,
                 value,
                 SpreadsheetText.with(text)
         );
@@ -106,6 +162,16 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
 
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value,
+                                final SpreadsheetText text) {
+        this.formatAndCheck(
+                formatter,
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
                                 final SpreadsheetText text) {
         this.formatAndCheck(
                 formatter,
@@ -119,13 +185,23 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
                                 final TextNode text) {
         this.formatAndCheck(
                 formatter,
+                Optional.of(value),
+                text
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value,
+                                final TextNode text) {
+        this.formatAndCheck(
+                formatter,
                 value,
                 Optional.of(text)
         );
     }
 
     default void formatAndCheck(final SpreadsheetFormatter formatter,
-                                final Object value,
+                                final Optional<Object> value,
                                 final Optional<TextNode> text) {
         this.formatAndCheck(
                 formatter,
@@ -139,12 +215,26 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
 
     default void formatAndCheck(final Object value) {
         this.formatAndCheck(
+                Optional.of(value)
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value) {
+        this.formatAndCheck(
                 value,
                 this.createContext()
         );
     }
 
     default void formatAndCheck(final Object value,
+                                final SpreadsheetFormatterContext context) {
+        this.formatAndCheck(
+                Optional.of(value),
+                context
+        );
+    }
+
+    default void formatAndCheck(final Optional<Object> value,
                                 final SpreadsheetFormatterContext context) {
         this.formatAndCheck(
                 this.createFormatter(),
@@ -155,6 +245,14 @@ public interface SpreadsheetFormatterTesting2<F extends SpreadsheetFormatter>
 
     default void formatAndCheck(final SpreadsheetFormatter formatter,
                                 final Object value) {
+        this.formatAndCheck(
+                formatter,
+                Optional.of(value)
+        );
+    }
+
+    default void formatAndCheck(final SpreadsheetFormatter formatter,
+                                final Optional<Object> value) {
         this.formatAndCheck(
                 formatter,
                 value,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatter.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 public interface SpreadsheetPatternSpreadsheetFormatter extends SpreadsheetFormatter {
 
     @Override
-    default Optional<TextNode> format(final Object value,
+    default Optional<TextNode> format(final Optional<Object> value,
                                       final SpreadsheetFormatterContext context) {
         return this.formatSpreadsheetText(
                 value,
@@ -40,7 +40,7 @@ public interface SpreadsheetPatternSpreadsheetFormatter extends SpreadsheetForma
      * Implementors should implement this method and only produce a {@link SpreadsheetText} rather than the richer
      * {@link TextNode}.
      */
-    Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                     final SpreadsheetFormatterContext context);
 }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCollection.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCollection.java
@@ -65,11 +65,14 @@ final class SpreadsheetPatternSpreadsheetFormatterCollection implements Spreadsh
     // SpreadsheetFormatter.............................................................................................
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         return this.formatters.stream()
                 .flatMap(f -> optionalStream(
-                                f.formatSpreadsheetText(value, context)
+                                f.formatSpreadsheetText(
+                                        value,
+                                        context
+                                )
                         )
                 ).findFirst();
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColor.java
@@ -68,7 +68,7 @@ final class SpreadsheetPatternSpreadsheetFormatterColor implements SpreadsheetPa
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         return this.formatter.formatSpreadsheetText(
                 value,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCondition.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCondition.java
@@ -57,10 +57,12 @@ final class SpreadsheetPatternSpreadsheetFormatterCondition implements Spreadshe
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
-        return context.convert(value, BigDecimal.class)
-                .mapLeft(this.predicate::test)
+        return context.convert(
+                        value.orElse(null),
+                        BigDecimal.class
+                ).mapLeft(v -> null != v && this.predicate.test(v))
                 .orElseLeft(false) ?
                 this.formatter.formatSpreadsheetText(
                         value,

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
@@ -63,14 +63,17 @@ final class SpreadsheetPatternSpreadsheetFormatterDateTime implements Spreadshee
     private final Class<? extends Temporal> valueType;
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
-        final Either<LocalDateTime, String> valueAsDateTime = value.getClass() == this.valueType ?
+        final Object valueOrNull = value.orElse(null);
+
+        final Either<LocalDateTime, String> valueAsDateTime = null != valueOrNull &&
+                valueOrNull.getClass() == this.valueType ?
                 context.convert(
-                        value,
+                        valueOrNull,
                         LocalDateTime.class
                 ) :
                 null;

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFraction.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFraction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.format;
 
+import walkingkooka.Either;
 import walkingkooka.math.Fraction;
 import walkingkooka.spreadsheet.format.parser.FractionSpreadsheetFormatParserToken;
 import walkingkooka.spreadsheet.format.parser.NumberSpreadsheetFormatParserToken;
@@ -67,15 +68,28 @@ final class SpreadsheetPatternSpreadsheetFormatterFraction implements Spreadshee
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
+        final Either<BigDecimal, String> converted = context.convert(
+                value.orElse(null),
+                BigDecimal.class
+        );
+        final BigDecimal bigDecimal = converted.isLeft() ?
+                converted.leftValue() :
+                null;
+
         return Optional.ofNullable(
-                context.convert(value, BigDecimal.class)
-                        .mapLeft(v -> SpreadsheetText.with(this.format1(v, context)))
-                        .orElseLeft(null)
+                null != bigDecimal ?
+                        SpreadsheetText.with(
+                                this.format1(
+                                        bigDecimal,
+                                        context
+                                )
+                        ) :
+                        null
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumber.java
@@ -65,23 +65,26 @@ final class SpreadsheetPatternSpreadsheetFormatterNumber implements SpreadsheetP
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
         final Either<ExpressionNumber, String> valueAsNumber = context.convert(
-                value,
+                value.orElse(null),
                 ExpressionNumber.class
         );
 
+        final ExpressionNumber expressionNumber = valueAsNumber.isLeft() ?
+                valueAsNumber.leftValue() :
+                null;
+
         return Optional.ofNullable(
-                valueAsNumber.isLeft() ?
+                null != expressionNumber ?
                         SpreadsheetText.with(
                                 this.format1(
                                         this.normalOrScientific.context(
-                                                valueAsNumber.leftValue()
-                                                        .bigDecimal(),
+                                                expressionNumber.bigDecimal(),
                                                 this,
                                                 context
                                         )

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTesting.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public interface SpreadsheetPatternSpreadsheetFormatterTesting extends SpreadsheetFormatterTesting {
 
     default void formatSpreadsheetTextAndCheck(final SpreadsheetPatternSpreadsheetFormatter formatter,
-                                               final Object value,
+                                               final Optional<Object> value,
                                                final SpreadsheetFormatterContext context) {
         this.formatSpreadsheetTextAndCheck(
                 formatter,
@@ -33,7 +33,7 @@ public interface SpreadsheetPatternSpreadsheetFormatterTesting extends Spreadshe
     }
 
     default void formatSpreadsheetTextAndCheck(final SpreadsheetPatternSpreadsheetFormatter formatter,
-                                               final Object value,
+                                               final Optional<Object> value,
                                                final SpreadsheetFormatterContext context,
                                                final SpreadsheetText expected) {
         this.formatSpreadsheetTextAndCheck(
@@ -45,7 +45,7 @@ public interface SpreadsheetPatternSpreadsheetFormatterTesting extends Spreadshe
     }
 
     default void formatSpreadsheetTextAndCheck(final SpreadsheetPatternSpreadsheetFormatter formatter,
-                                               final Object value,
+                                               final Optional<Object> value,
                                                final SpreadsheetFormatterContext context,
                                                final Optional<SpreadsheetText> expected) {
         this.checkEquals(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTesting2.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTesting2.java
@@ -44,13 +44,13 @@ public interface SpreadsheetPatternSpreadsheetFormatterTesting2<F extends Spread
                 NullPointerException.class,
                 () -> this.createFormatter()
                         .formatSpreadsheetText(
-                                "Value",
+                                Optional.of("Value"),
                                 null
                         )
         );
     }
 
-    default void formatSpreadsheetTextAndCheck(final Object value,
+    default void formatSpreadsheetTextAndCheck(final Optional<Object> value,
                                                final SpreadsheetFormatterContext context) {
         this.formatSpreadsheetTextAndCheck(
                 this.createFormatter(),
@@ -59,7 +59,7 @@ public interface SpreadsheetPatternSpreadsheetFormatterTesting2<F extends Spread
         );
     }
 
-    default void formatSpreadsheetTextAndCheck(final Object value,
+    default void formatSpreadsheetTextAndCheck(final Optional<Object> value,
                                                final SpreadsheetFormatterContext context,
                                                final SpreadsheetText expected) {
         this.formatSpreadsheetTextAndCheck(
@@ -70,7 +70,7 @@ public interface SpreadsheetPatternSpreadsheetFormatterTesting2<F extends Spread
         );
     }
 
-    default void formatSpreadsheetTextAndCheck(final Object value,
+    default void formatSpreadsheetTextAndCheck(final Optional<Object> value,
                                                final SpreadsheetFormatterContext context,
                                                final Optional<SpreadsheetText> expected) {
         this.formatSpreadsheetTextAndCheck(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterText.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterText.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 /**
  * A {@link SpreadsheetPatternSpreadsheetFormatter} that formats values after converting them to a {@link String}.
+ * Note that null {@link String} values are supported but any placeholders in the pattern will be skipped.
  */
 final class SpreadsheetPatternSpreadsheetFormatterText implements SpreadsheetPatternSpreadsheetFormatter {
 
@@ -47,16 +48,24 @@ final class SpreadsheetPatternSpreadsheetFormatterText implements SpreadsheetPat
     }
 
     @Override
-    public Optional<SpreadsheetText> formatSpreadsheetText(final Object value,
+    public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> value,
                                                            final SpreadsheetFormatterContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
+        final Object valueOrNull = value.orElse(null);
+
         return Optional.ofNullable(
-                context.canConvert(value, String.class) ?
+                context.canConvert(
+                        valueOrNull,
+                        String.class
+                ) ?
                         SpreadsheetPatternSpreadsheetFormatterTextSpreadsheetFormatParserTokenVisitor.format(
                                 this.token,
-                                context.convertOrFail(value, String.class),
+                                context.convertOrFail(
+                                        valueOrNull,
+                                        String.class
+                                ),
                                 context
                         ) :
                         null

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTextSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTextSpreadsheetFormatParserTokenVisitor.java
@@ -102,7 +102,10 @@ final class SpreadsheetPatternSpreadsheetFormatterTextSpreadsheetFormatParserTok
 
     @Override
     protected void visit(final TextPlaceholderSpreadsheetFormatParserToken token) {
-        this.append(this.value);
+        final String value = this.value;
+        if(null != value) {
+            this.append(value);
+        }
     }
 
     private final String value;

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -19340,7 +19340,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                     SPREADSHEET_FORMATTER_PROVIDER,
                     PROVIDER_CONTEXT
             ).format(
-                    value.get(),
+                    value,
                     SPREADSHEET_TEXT_FORMAT_CONTEXT
             ).orElseThrow(
                     () -> new AssertionError("Failed to format " + CharSequences.quoteIfChars(value.get()))

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -521,11 +521,16 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
             }
 
             @Override
-            public Optional<TextNode> formatValue(final Object value,
+            public Optional<TextNode> formatValue(final Optional<Object> value,
                                                   final SpreadsheetFormatter formatter) {
-                checkEquals(FORMULA_VALUE, value, "formatValue");
+                checkEquals(
+                        FORMULA_VALUE,
+                        value.orElse(null),
+                        "formatValue"
+                );
                 return Optional.of(
-                        SpreadsheetText.with(FORMULA_VALUE).toTextNode()
+                        SpreadsheetText.with(FORMULA_VALUE)
+                                .toTextNode()
                 );
             }
 
@@ -534,7 +539,8 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
                                                        final Optional<SpreadsheetFormatter> formatter) {
                 return cell.setFormattedValue(
                         this.formatValue(
-                                cell.formula().value().get(),
+                                cell.formula()
+                                        .value(),
                                 formatter.orElse(
                                         SpreadsheetPattern.DEFAULT_TEXT_FORMAT_PATTERN.formatter()
                                 )

--- a/src/test/java/walkingkooka/spreadsheet/format/AutomaticSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/AutomaticSpreadsheetFormatterTest.java
@@ -43,9 +43,13 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
 
     private final SpreadsheetFormatter DATE_FORMATTER = new FakeSpreadsheetFormatter() {
         @Override
-        public Optional<TextNode> format(final Object value,
+        public Optional<TextNode> format(final Optional<Object> value,
                                          final SpreadsheetFormatterContext context) {
-            checkEquals(DATE, value, "value");
+            checkEquals(
+                    DATE,
+                    value.orElse(null),
+                    "value"
+            );
             return DATE_FORMATTED;
         }
     };
@@ -58,19 +62,26 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
 
     private final SpreadsheetFormatter DATE_TIME_FORMATTER = new FakeSpreadsheetFormatter() {
         @Override
-        public Optional<TextNode> format(final Object value,
+        public Optional<TextNode> format(final Optional<Object> value,
                                          final SpreadsheetFormatterContext context) {
-            checkEquals(DATE_TIME, value, "value");
+            checkEquals(
+                    DATE_TIME,
+                    value.orElse(null),
+                    "value"
+            );
             return DATE_TIME_FORMATTED;
         }
     };
 
     private final SpreadsheetFormatter NUMBER_FORMATTER = new FakeSpreadsheetFormatter() {
         @Override
-        public Optional<TextNode> format(final Object value,
+        public Optional<TextNode> format(final Optional<Object> value,
                                          final SpreadsheetFormatterContext context) {
             return Optional.of(
-                    TextNode.text("number-formatted " + value.toString())
+                    TextNode.text(
+                            "number-formatted " +
+                                    value.orElse("")
+                    )
             );
         }
     };
@@ -83,7 +94,7 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
 
     private final SpreadsheetFormatter TEXT_FORMATTER = new FakeSpreadsheetFormatter() {
         @Override
-        public Optional<TextNode> format(final Object value,
+        public Optional<TextNode> format(final Optional<Object> value,
                                          final SpreadsheetFormatterContext context) {
             return TEXT_FORMATTED;
         }
@@ -97,9 +108,13 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
 
     private final SpreadsheetFormatter TIME_FORMATTER = new FakeSpreadsheetFormatter() {
         @Override
-        public Optional<TextNode> format(final Object value,
+        public Optional<TextNode> format(final Optional<Object> value,
                                          final SpreadsheetFormatterContext context) {
-            checkEquals(TIME, value, "value");
+            checkEquals(
+                    TIME,
+                    value.orElse(null),
+                    "value"
+            );
             return TIME_FORMATTED;
         }
     };
@@ -190,6 +205,8 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
         );
     }
 
+    // format...........................................................................................................
+
     @Test
     public void testFormatByte() {
         this.formatNumberAndCheck(
@@ -257,6 +274,14 @@ public final class AutomaticSpreadsheetFormatterTest implements SpreadsheetForma
         this.formatAndCheck(
                 number,
                 TextNode.text("number-formatted " + number)
+        );
+    }
+
+    @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                Optional.empty(),
+                TEXT_FORMATTED
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
@@ -305,12 +305,14 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
         return new FakeSpreadsheetFormatter() {
 
             @Override
-            public Optional<TextNode> format(final Object value,
+            public Optional<TextNode> format(final Optional<Object> value,
                                              final SpreadsheetFormatterContext context) {
                 return Optional.of(
                         SpreadsheetText.with(
                                 new DecimalFormat("000.000")
-                                        .format(value)
+                                        .format(
+                                                value.orElse(null)
+                                        )
                         ).toTextNode()
                 );
             }

--- a/src/test/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ContextFormatTextSpreadsheetFormatterTest.java
@@ -35,6 +35,14 @@ public final class ContextFormatTextSpreadsheetFormatterTest implements Spreadsh
     private final static String LOCAL_DATE_TIME_STRING = "999D00Text";
 
     @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                Optional.empty(),
+                ""
+        );
+    }
+
+    @Test
     public void testFormatText() {
         final String text = "abc123";
         this.formatAndCheck(text, text);
@@ -138,23 +146,30 @@ public final class ContextFormatTextSpreadsheetFormatterTest implements Spreadsh
             }
 
             @Override
-            public Optional<TextNode> format(final Object value) {
-                if (value instanceof String) {
-                    return this.formattedText(value.toString());
+            public Optional<TextNode> format(final Optional<Object> value) {
+                final Object valueOrNull = value.orElse(null);
+
+                if (valueOrNull instanceof String) {
+                    return this.formattedText(valueOrNull.toString());
                 }
-                if (BIG_DECIMAL.equals(value)) {
+                if (BIG_DECIMAL.equals(valueOrNull)) {
                     return this.formattedText(BIGDECIMAL_STRING);
                 }
-                if (LOCAL_DATE_TIME.equals(value)) {
+                if (LOCAL_DATE_TIME.equals(valueOrNull)) {
                     return this.formattedText(LOCAL_DATE_TIME_STRING);
                 }
-                return this.formattedText(value.toString());
+                return this.formattedText(
+                        (String)valueOrNull
+                );
             }
 
             private Optional<TextNode> formattedText(final String text) {
                 return Optional.of(
-                        SpreadsheetText.with(text)
-                                .toTextNode()
+                        SpreadsheetText.with(
+                                null == text ?
+                                        "" :
+                                        text
+                        ).toTextNode()
                 );
             }
         };

--- a/src/test/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ConverterSpreadsheetFormatterTest.java
@@ -23,8 +23,17 @@ import walkingkooka.convert.Converters;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.Optional;
 
 public final class ConverterSpreadsheetFormatterTest implements SpreadsheetFormatterTesting2<ConverterSpreadsheetFormatter> {
+
+    @Test
+    public void testFormatNullValue() {
+        this.formatAndCheck(
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
 
     @Test
     public void testFormatConvertedValue() {

--- a/src/test/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterTest.java
@@ -20,10 +20,20 @@ package walkingkooka.spreadsheet.format;
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 
+import java.util.Optional;
+
 public final class EmptySpreadsheetFormatterTest implements SpreadsheetFormatterTesting2<EmptySpreadsheetFormatter> {
 
     @Test
-    public void testFormat() {
+    public void testFormatNull() {
+        this.formatAndCheck(
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
+    @Test
+    public void testFormatNonNull() {
         this.formatAndCheck(
                 "Hello2"
         );

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterCollectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterCollectionTest.java
@@ -65,6 +65,14 @@ public final class SpreadsheetFormatterCollectionTest implements SpreadsheetForm
         this.formatAndCheck(VALUE2, TEXT2);
     }
 
+    @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
     @Override
     public SpreadsheetFormatterCollection createFormatter() {
         return Cast.to(SpreadsheetFormatterCollection.with(Lists.of(this.formatter1(), this.formatter2())));
@@ -78,17 +86,18 @@ public final class SpreadsheetFormatterCollectionTest implements SpreadsheetForm
         return this.formatter(VALUE2, TEXT2);
     }
 
-    private SpreadsheetFormatter formatter(final Object value, final String text) {
+    private SpreadsheetFormatter formatter(final Object value,
+                                           final String text) {
         return new FakeSpreadsheetFormatter() {
 
             @Override
-            public Optional<TextNode> format(final Object v,
+            public Optional<TextNode> format(final Optional<Object> v,
                                              final SpreadsheetFormatterContext context) {
                 Objects.requireNonNull(v, "value");
                 Objects.requireNonNull(context, "context");
 
                 return Optional.ofNullable(
-                        v.equals(value) ?
+                                value.equals(v.orElse(null)) ?
                                 SpreadsheetText.with(text)
                                         .toTextNode()
                                 :

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterContextTest.java
@@ -41,11 +41,16 @@ public final class SpreadsheetFormatterContextTest implements ClassTesting<Sprea
                 expected,
                 new FakeSpreadsheetFormatterContext() {
                     @Override
-                    public Optional<TextNode> format(final Object v) {
-                        checkEquals(value, v);
+                    public Optional<TextNode> format(final Optional<Object> v) {
+                        checkEquals(
+                                Optional.of(value),
+                                v
+                        );
                         return Optional.of(expected);
                     }
-                }.formatOrEmptyText(value)
+                }.formatOrEmptyText(
+                        Optional.of(value)
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterTest.java
@@ -38,7 +38,7 @@ public final class SpreadsheetFormatterTest implements SpreadsheetFormatterTesti
                 ).toTextNode(),
                 new FakeSpreadsheetFormatter() {
                     @Override
-                    public Optional<TextNode> format(final Object value,
+                    public Optional<TextNode> format(final Optional<Object> value,
                                                      final SpreadsheetFormatterContext context) {
                         return Optional.of(
                                 SpreadsheetText.EMPTY
@@ -49,7 +49,7 @@ public final class SpreadsheetFormatterTest implements SpreadsheetFormatterTesti
                         );
                     }
                 }.formatOrEmptyText(
-                        text,
+                        Optional.of(text),
                         SpreadsheetFormatterContexts.fake()
                 )
         );

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCollectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterCollectionTest.java
@@ -78,6 +78,14 @@ public final class SpreadsheetPatternSpreadsheetFormatterCollectionTest extends 
         this.formatAndCheck(VALUE2, TEXT2);
     }
 
+    @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                Optional.empty(),
+                Optional.empty()
+        );
+    }
+
     @Override
     String pattern() {
         return "General";
@@ -111,13 +119,13 @@ public final class SpreadsheetPatternSpreadsheetFormatterCollectionTest extends 
         return new FakeSpreadsheetPatternSpreadsheetFormatter() {
 
             @Override
-            public Optional<SpreadsheetText> formatSpreadsheetText(final Object v,
+            public Optional<SpreadsheetText> formatSpreadsheetText(final Optional<Object> v,
                                                                    final SpreadsheetFormatterContext context) {
                 Objects.requireNonNull(v, "value");
                 Objects.requireNonNull(context, "context");
 
                 return Optional.ofNullable(
-                        value.equals(v) ?
+                        value.equals(v.orElse(null)) ?
                                 spreadsheetText(text) :
                                 null
                 );
@@ -135,8 +143,8 @@ public final class SpreadsheetPatternSpreadsheetFormatterCollectionTest extends 
     }
 
     @Override
-    public Object value() {
-        return VALUE1;
+    public Optional<Object> value() {
+        return Optional.of(VALUE1);
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterColorTest.java
@@ -91,6 +91,28 @@ public final class SpreadsheetPatternSpreadsheetFormatterColorTest extends Sprea
     // format...........................................................................................................
 
     @Test
+    public void testFormatNullValue() {
+        final Optional<Color> color = Optional.of(Color.BLACK);
+
+        this.formatAndCheck(
+                this.createFormatter("[BLACK]"),
+                Optional.empty(), // value
+                new TestSpreadsheetFormatterContext() {
+                    @Override
+                    public Optional<Color> colorName(final SpreadsheetColorName name) {
+                        checkEquals(
+                                SpreadsheetColorName.with("BLACK"),
+                                name,
+                                "color name"
+                        );
+                        return color;
+                    }
+                },
+                Optional.empty()
+        );
+    }
+
+    @Test
     public void testFormatColorNameAndTextFormatted() {
         final String text = "abc123";
         final Optional<Color> color = Optional.of(Color.BLACK);

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterConditionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterConditionTest.java
@@ -39,6 +39,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,6 +54,15 @@ public final class SpreadsheetPatternSpreadsheetFormatterConditionTest extends S
     }
 
     // EQ...............................................................................................................
+
+    @Test
+    public void testFormatEQWithNullValue() {
+        this.formatAndCheck(
+                this.createFormatter("[=50]"),
+                Optional.empty(), // value
+                Optional.empty() // expected
+        ); // pass
+    }
 
     @Test
     public void testFormatEQ() {

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTimeTest.java
@@ -56,6 +56,15 @@ public final class SpreadsheetPatternSpreadsheetFormatterDateTimeTest extends Sp
     // tests.............................................................................................................
 
     @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                this.createFormatter("dd/mm/yyyy"),
+                Optional.empty(), // value,
+                Optional.empty() // expected
+        );
+    }
+
+    @Test
     public void testFormatDateFails() {
         this.formatAndCheck(
                 this.createFormatter("dd/mm/yyyy"),
@@ -674,7 +683,8 @@ public final class SpreadsheetPatternSpreadsheetFormatterDateTimeTest extends Sp
     private void parseFormatAndCheck(final String pattern,
                                      final LocalDateTime value,
                                      final String text) {
-        this.formatAndCheck(this.createFormatter(pattern),
+        this.formatAndCheck(
+                this.createFormatter(pattern),
                 value,
                 this.createContext(),
                 SpreadsheetText.with(text)

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFractionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterFractionTest.java
@@ -32,6 +32,7 @@ import walkingkooka.text.cursor.parser.ParserReporterException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -158,6 +159,17 @@ public final class SpreadsheetPatternSpreadsheetFormatterFractionTest extends Sp
             fail("Expected " + ParserReporterException.class.getSimpleName() + " to be thrown with pattern " + CharSequences.quote(pattern));
         } catch (final ParserReporterException expected) {
         }
+    }
+
+    // format...........................................................................................................
+
+    @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                this.createFormatter("#/#"), // format
+                Optional.empty(), // value
+                Optional.empty() // expected
+        );
     }
 
     // fraction space. space dot space ...................................................................................
@@ -452,8 +464,10 @@ public final class SpreadsheetPatternSpreadsheetFormatterFractionTest extends Sp
     }
 
     @Override
-    public BigDecimal value() {
-        return new BigDecimal(123);
+    public Optional<BigDecimal> value() {
+        return Optional.of(
+                new BigDecimal(123)
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterGeneralTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterGeneralTest.java
@@ -31,10 +31,20 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class SpreadsheetPatternSpreadsheetFormatterGeneralTest extends SpreadsheetPatternSpreadsheetFormatterTestCase<SpreadsheetPatternSpreadsheetFormatterGeneral, GeneralSpreadsheetFormatParserToken> {
 
     private final static ExpressionNumberKind KIND = ExpressionNumberKind.BIG_DECIMAL;
+
+    @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                SpreadsheetPatternSpreadsheetFormatterGeneral.INSTANCE, // formatter
+                Optional.empty(), // value
+                Optional.empty() // expected
+        );
+    }
 
     @Test
     public void testFormatZeroBigDecimal() {

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterNumberTest.java
@@ -53,6 +53,15 @@ public final class SpreadsheetPatternSpreadsheetFormatterNumberTest extends Spre
         NumberSpreadsheetFormatParserToken> {
 
     @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                this.createFormatter("0.00"),
+                Optional.empty(), // value
+                Optional.empty() // expected
+        );
+    }
+
+    @Test
     public void testFormatDateFails() {
         this.formatAndCheck(
                 this.createFormatter("0.00"),

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterTextTest.java
@@ -45,6 +45,15 @@ public final class SpreadsheetPatternSpreadsheetFormatterTextTest extends Spread
     // format...........................................................................................................
 
     @Test
+    public void testFormatNull() {
+        this.formatAndCheck(
+                this.createFormatter("\"Hello \"@@@"),
+                Optional.empty(),
+                SpreadsheetText.EMPTY.setText("Hello ")
+        );
+    }
+
+    @Test
     public void testFormatPlaceholder() {
         this.parseFormatAndCheck("@", TEXT, TEXT);
     }
@@ -138,7 +147,12 @@ public final class SpreadsheetPatternSpreadsheetFormatterTextTest extends Spread
                                      final String value,
                                      final SpreadsheetFormatterContext context,
                                      final SpreadsheetText text) {
-        this.formatAndCheck(this.createFormatter(pattern), value, context, text);
+        this.formatAndCheck(
+                this.createFormatter(pattern),
+                value,
+                context,
+                text
+        );
     }
 
     @Override
@@ -175,14 +189,14 @@ public final class SpreadsheetPatternSpreadsheetFormatterTextTest extends Spread
         @Override
         public boolean canConvert(final Object value,
                                   final Class<?> target) {
-            return value instanceof String && String.class == target;
+            return (null == value || value instanceof String) && String.class == target;
         }
 
         @Override
         public <T> Either<T, String> convert(final Object value, final Class<T> target) {
             return this.canConvert(value, target) ?
                     this.successfulConversion(
-                            value.toString(),
+                            target.cast(value),
                             target
                     ) :
                     this.failConversion(

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
@@ -1590,7 +1590,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     .toFormat()
                     .formatter()
                     .format(
-                            number,
+                            Optional.of(number),
                             context
                     );
         }
@@ -1632,7 +1632,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     .toFormat()
                     .formatter()
                     .format(
-                            number,
+                            Optional.of(number),
                             context
                     );
         }
@@ -1679,7 +1679,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     .toFormat()
                     .formatter()
                     .format(
-                            number,
+                            Optional.of(number),
                             context
                     );
         }
@@ -1749,7 +1749,7 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     .toFormat()
                     .formatter()
                     .format(
-                            number,
+                            Optional.of(number),
                             context
                     );
         }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTestCase.java
@@ -39,6 +39,7 @@ import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -472,7 +473,7 @@ public abstract class SpreadsheetPatternTestCase<P extends SpreadsheetPattern>
                 () -> this.createPattern()
                         .createFormatter()
                         .formatSpreadsheetText(
-                                "Value",
+                                Optional.of("Value"),
                                 null
                         )
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTest.java
@@ -28,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Locale;
+import java.util.Optional;
 
 public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTest extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTestCase<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDate>
         implements SpreadsheetMetadataTesting {
@@ -44,7 +45,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDa
         final LocalDate date = LocalDate.of(1999, 12, 31);
         final String formatted = pattern.formatter()
                 .format(
-                        date,
+                        Optional.of(date),
                         SPREADSHEET_FORMATTER_CONTEXT
                 ).get()
                 .text();

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTimeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 
 import java.time.LocalDateTime;
 import java.util.Locale;
+import java.util.Optional;
 
 public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTimeTest extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTestCase<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTime>
         implements SpreadsheetMetadataTesting {
@@ -50,7 +51,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDa
         final LocalDateTime date = LocalDateTime.of(1999, 12, 31, 12, 58, 59);
         final String formatted = pattern.formatter()
                 .format(
-                        date,
+                        Optional.of(date),
                         SPREADSHEET_FORMATTER_CONTEXT
                 )
                 .get()

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
@@ -39,6 +39,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import java.math.MathContext;
 import java.time.LocalDateTime;
 import java.util.Locale;
+import java.util.Optional;
 
 public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTestCase<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumber> {
 
@@ -71,7 +72,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNu
 
         final String formatted = pattern.formatter()
                 .format(
-                        number,
+                        Optional.of(number),
                         spreadsheetFormatterContext()
                 ).get()
                 .text();

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTimeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeParsePattern;
 
 import java.time.LocalTime;
 import java.util.Locale;
+import java.util.Optional;
 
 public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTimeTest extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTestCase<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTime>
         implements SpreadsheetMetadataTesting {
@@ -50,7 +51,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTi
         final LocalTime time = LocalTime.of(12, 58, 59);
         final String formatted = pattern.formatter()
                 .format(
-                        time,
+                        Optional.of(time),
                         SPREADSHEET_FORMATTER_CONTEXT
                 ).get()
                 .text();

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -327,8 +327,7 @@ public final class Sample {
                         Optional.of(
                                 this.formatValue(
                                         cell.formula()
-                                                .value()
-                                                .get(),
+                                                .value(),
                                         formatter.orElse(
                                                 this.spreadsheetMetadata()
                                                         .spreadsheetFormatter(
@@ -345,9 +344,13 @@ public final class Sample {
             }
 
             @Override
-            public Optional<TextNode> formatValue(final Object value,
+            public Optional<TextNode> formatValue(final Optional<Object> value,
                                                   final SpreadsheetFormatter formatter) {
-                checkEquals(false, value instanceof Optional, "Value must not be optional" + value);
+                checkEquals(
+                        false,
+                        value.orElse(null) instanceof Optional,
+                        "Value must not be optional" + value
+                );
 
                 return formatter.format(
                         value,

--- a/src/test/java/walkingkooka/spreadsheet/template/SpreadsheetTemplateContextTemplateContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/template/SpreadsheetTemplateContextTemplateContextTest.java
@@ -91,7 +91,9 @@ public final class SpreadsheetTemplateContextTemplateContextTest implements Temp
                         TextNode.text("111.")
                 ),
                 SPREADSHEET_FORMATTER_CONTEXT.format(
-                        EXPRESSION_NUMBER_KIND.create(111)
+                        Optional.of(
+                                EXPRESSION_NUMBER_KIND.create(111)
+                        )
                 )
         );
     }


### PR DESCRIPTION
- SpreadsheetFormatter.format value parameter type Optional<Object> was Object
- SpreadsheetPatternSpreadsheetFormatter.formatSpreadsheetText value parameter type Optional<Object> was Object
- SpreadsheetEngineContext.formatValue value parameter type Optional<Object> was Object
- SpreadsheetPatternSpreadsheetFormatterText supports null values, placeholder '@' will not include null values.
- Most other formatters return Optional#empty when the value to be formatted is missing.