### PR TITLE
SpreadsheetDelta.setReferences makes relative FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetDelta.java
@@ -507,7 +507,7 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
 
                 SortedSet<SpreadsheetExpressionReference> spreadsheetExpressionReferences;
 
-                if(cellReferences instanceof SortedSet) {
+                if (cellReferences instanceof SortedSet) {
                     spreadsheetExpressionReferences = (SortedSet<SpreadsheetExpressionReference>) cellReferences;
                 } else {
                     spreadsheetExpressionReferences = new TreeSet<>(SpreadsheetSelection.IGNORES_REFERENCE_KIND_COMPARATOR);
@@ -515,8 +515,18 @@ public abstract class SpreadsheetDelta implements Patchable<SpreadsheetDelta>,
                 }
 
                 filtered.put(
-                        cell,
-                        SortedSets.immutable(spreadsheetExpressionReferences)
+                        cell.toRelative(),
+                        spreadsheetExpressionReferences.stream()
+                                .map(SpreadsheetExpressionReference::toRelative)
+                                .collect(
+                                        Collectors.collectingAndThen(
+                                                Collectors.toCollection(
+                                                        () -> SortedSets.tree(SpreadsheetSelection.IGNORES_REFERENCE_KIND_COMPARATOR
+                                                        )
+                                                ),
+                                                SortedSets::immutable
+                                        )
+                                )
                 );
             }
         }

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetDeltaTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.collect.set.SortedSets;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.TypeNameTesting;
@@ -557,6 +558,39 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
         this.referencesAndCheck(
                 after,
                 different
+        );
+
+        this.cellsAndCheck(after);
+        this.columnsAndCheck(after);
+        this.labelsAndCheck(after);
+        this.rowsAndCheck(after);
+
+        this.deletedCellsAndCheck(after);
+        this.deletedColumnsAndCheck(after);
+        this.deletedRowsAndCheck(after);
+
+        this.columnWidthsAndCheck(after);
+        this.rowHeightsAndCheck(after);
+    }
+
+    @Test
+    public final void testSetReferencesWithDifferentMakesRelative() {
+        final D before = this.createSpreadsheetDelta();
+
+        final SpreadsheetCellReference b2 = SpreadsheetSelection.parseCell("$B$2");
+        final SpreadsheetDelta after = before.setReferences(
+                Maps.of(
+                        SpreadsheetSelection.A1.toAbsolute(),
+                        Sets.of(b2)
+                )
+        );
+        assertNotSame(before, after);
+        this.referencesAndCheck(
+                after,
+                Maps.of(
+                        SpreadsheetSelection.A1,
+                        Sets.of(b2.toRelative())
+                )
         );
 
         this.cellsAndCheck(after);
@@ -1925,6 +1959,16 @@ public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> imple
                 references,
                 delta.references(),
                 "references"
+        );
+
+        this.checkEquals(
+            Sets.empty(),
+            delta.references()
+                    .keySet()
+                    .stream()
+                    .filter(r -> false == r.toRelative().equals(r))
+                    .collect(Collectors.toCollection(SortedSets::tree)),
+                () -> "non relative cell references found"
         );
 
         assertThrows(


### PR DESCRIPTION
- Previously it was possible for the Map from SpreadsheetDelta.references() to contain absolute references.