### PR TITLE
TreeMapSpreadsheetExpressionReferenceStore store relative never absol…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStore.java
@@ -160,12 +160,20 @@ final class TreeMapSpreadsheetExpressionReferenceStore<T extends SpreadsheetExpr
         Objects.requireNonNull(reference, "reference");
         Objects.requireNonNull(cells, "cells");
 
+        this.saveCellsWithRelativeReference(
+                (T)reference.toRelative(),
+                cells
+        );
+    }
+
+    private void saveCellsWithRelativeReference(final T reference,
+                                                final Set<SpreadsheetCellReference> cells) {
         final Set<SpreadsheetCellReference> previous = this.referenceToCells.get(reference);
         if (null == previous) {
             cells.forEach(cell -> this.addCellNonNull(
                             ReferenceAndSpreadsheetCellReference.with(
                                     reference,
-                                    cell
+                                    cell.toRelative()
                             )
                     )
             );
@@ -179,7 +187,7 @@ final class TreeMapSpreadsheetExpressionReferenceStore<T extends SpreadsheetExpr
                     .forEach(cell -> this.addCellNonNull(
                                     ReferenceAndSpreadsheetCellReference.with(
                                             reference,
-                                            cell
+                                            cell.toRelative()
                                     )
                             )
                     );
@@ -189,7 +197,7 @@ final class TreeMapSpreadsheetExpressionReferenceStore<T extends SpreadsheetExpr
                     .forEach(cell -> this.removeCellNonNull(
                                     ReferenceAndSpreadsheetCellReference.with(
                                             reference,
-                                            cell
+                                            cell.toRelative()
                                     )
                             )
                     );
@@ -200,6 +208,8 @@ final class TreeMapSpreadsheetExpressionReferenceStore<T extends SpreadsheetExpr
     public void addCell(final ReferenceAndSpreadsheetCellReference<T> referenceAndCell) {
         this.addCellNonNull(
                 Objects.requireNonNull(referenceAndCell, "referenceAndCell")
+                        .setCell(referenceAndCell.cell().toRelative())
+                        .setReference((T) referenceAndCell.reference().toRelative())
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -2197,7 +2197,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 a1.reference(),
-                b2
+                b2.toRelative()
         );
         this.loadReferencesAndCheck(
                 cellReferenceStore,
@@ -2626,7 +2626,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 b2.reference(),
-                a1Reference
+                a1Reference.toRelative()
         );
     }
 
@@ -3038,7 +3038,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 a1.reference(),
-                b2Reference
+                b2Reference.toRelative()
         );
         this.loadReferencesAndCheck(
                 cellReferenceStore,
@@ -3547,7 +3547,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 a1.reference(),
-                e5Reference
+                e5Reference.toRelative()
         );
 
         this.loadReferencesAndCheck(
@@ -4482,7 +4482,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 a1.reference(),
-                b2Reference
+                b2Reference.toRelative()
         );
 
         this.loadReferencesAndCheck(
@@ -4493,7 +4493,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         this.findReferencesWithCellAndCheck(
                 cellReferenceStore,
                 a1.reference(),
-                b2Reference
+                b2Reference.toRelative()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/TreeMapSpreadsheetExpressionReferenceStoreTest.java
@@ -199,10 +199,14 @@ public class TreeMapSpreadsheetExpressionReferenceStoreTest extends SpreadsheetE
         this.cellToReferencesAndCheck(
                 store,
                 Maps.of(
-                        b1,
-                        Sets.of(a1),
-                        c1,
-                        Sets.of(a1)
+                        b1.toRelative(),
+                        Sets.of(
+                                a1.toRelative()
+                        ),
+                        c1.toRelative(),
+                        Sets.of(
+                                a1.toRelative()
+                        )
                 )
         );
     }
@@ -627,7 +631,7 @@ public class TreeMapSpreadsheetExpressionReferenceStoreTest extends SpreadsheetE
                 store,
                 0, // from
                 3, // to
-                a, b, c // expected
+                a.toRelative(), b.toRelative(), c.toRelative() // expected
         );
     }
 
@@ -851,15 +855,19 @@ public class TreeMapSpreadsheetExpressionReferenceStoreTest extends SpreadsheetE
         this.cellToReferencesAndCheck(
                 store,
                 Maps.of(
-                        b1,
-                        Sets.of(a1)
+                        b1.toRelative(),
+                        Sets.of(
+                                a1.toRelative()
+                        )
                 )
         );
         this.referenceToCellsAndCheck(
                 store,
                 Maps.of(
-                        a1,
-                        Sets.of(b1)
+                        a1.toRelative(),
+                        Sets.of(
+                                b1.toRelative()
+                        )
                 )
         );
     }
@@ -1127,8 +1135,8 @@ public class TreeMapSpreadsheetExpressionReferenceStoreTest extends SpreadsheetE
         this.cellToReferencesAndCheck(
                 store,
                 Maps.of(
-                        b1,
-                        Sets.of(a1)
+                        b1.toRelative(),
+                        Sets.of(a1.toRelative())
                 )
         );
         this.referenceToCellsAndCheck(


### PR DESCRIPTION
…ute references

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6080
- SpreadsheetExpressionReferenceStore should transform absolute references to relative and only return relative refs