### PR TITLE
SpreadsheetConverterStringToSpreadsheetMetadataPropertyName

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.convert;
+
+import walkingkooka.Either;
+import walkingkooka.convert.Converter;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+
+/**
+ * A {@link Converter} that converts {@link String} to {@link walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName}.
+ */
+final class SpreadsheetConverterStringToSpreadsheetMetadataPropertyName extends SpreadsheetConverter {
+
+    /**
+     * Singleton
+     */
+    final static SpreadsheetConverterStringToSpreadsheetMetadataPropertyName INSTANCE = new SpreadsheetConverterStringToSpreadsheetMetadataPropertyName();
+
+    /**
+     * Private ctor use singleton
+     */
+    private SpreadsheetConverterStringToSpreadsheetMetadataPropertyName() {
+        super();
+    }
+
+    @Override
+    public boolean canConvert(final Object value,
+                              final Class<?> type,
+                              final SpreadsheetConverterContext context) {
+        return value instanceof String &&
+                isMetadataPropertyNameSubClass(type);
+    }
+
+    /**
+     * Unfortunately GWT {@link Class#isAssignableFrom(Class)} is not supported so checking parent class is required.
+     */
+    private static boolean isMetadataPropertyNameSubClass(final Class<?> type) {
+        boolean subClass = false;
+
+        Class<?> temp = type;
+
+        while(Object.class != temp) {
+            subClass = SpreadsheetMetadataPropertyName.class == temp;
+            if(subClass) {
+                break;
+            }
+
+            temp = temp.getSuperclass();
+        }
+
+        return subClass;
+    }
+
+    @Override
+    <T> Either<T, String> convert0(final Object value,
+                                   final Class<T> type,
+                                   final SpreadsheetConverterContext context) {
+        Either<T, String> result;
+
+        try {
+            result = this.successfulConversion(
+                    SpreadsheetMetadataPropertyName.with((String)value),
+                    type
+            );
+        } catch (final RuntimeException cause) {
+            result = Either.right(cause.getMessage());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "String to " + SpreadsheetMetadataPropertyName.class.getSimpleName();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -182,6 +182,13 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     }
 
     /**
+     * {@see SpreadsheetConverterStringToSpreadsheetMetadataPropertyName}
+     */
+    public static Converter<SpreadsheetConverterContext> stringToSpreadsheetMetadataPropertyName() {
+        return SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.INSTANCE;
+    }
+
+    /**
      * A {@link Converter} that uses the given {@link Parser} to parse text into a {@link DateSpreadsheetFormulaParserToken} and converting
      * that into a {@link LocalDate}.
      */

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
@@ -151,6 +151,11 @@ final class SpreadsheetConvertersConverterProvider implements ConverterProvider 
 
                 converter = SpreadsheetConverters.stringToSelection();
                 break;
+            case STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME_STRING:
+                parameterCountCheck(copy, 0);
+
+                converter = SpreadsheetConverters.stringToSpreadsheetMetadataPropertyName();
+                break;
             default:
                 throw new IllegalArgumentException("Unknown converter " + name);
         }
@@ -229,6 +234,10 @@ final class SpreadsheetConvertersConverterProvider implements ConverterProvider 
 
     final static ConverterName STRING_TO_SELECTION = ConverterName.with(STRING_TO_SELECTION_STRING);
 
+    private final static String STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME_STRING = "string-to-spreadsheet-metadata-property-name";
+
+    final static ConverterName STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME = ConverterName.with(STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME_STRING);
+
     @Override
     public ConverterInfoSet converterInfos() {
         return INFOS;
@@ -247,7 +256,8 @@ final class SpreadsheetConvertersConverterProvider implements ConverterProvider 
                     converterInfo(SELECTION_TO_SELECTION),
                     converterInfo(SELECTION_TO_STRING),
                     converterInfo(STRING_TO_EXPRESSION),
-                    converterInfo(STRING_TO_SELECTION)
+                    converterInfo(STRING_TO_SELECTION),
+                    converterInfo(STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME)
             )
     );
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterStringToSpreadsheetMetadataPropertyNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterStringToSpreadsheetMetadataPropertyNameTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.convert;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.spreadsheet.format.SpreadsheetColorName;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataTesting;
+
+public final class SpreadsheetConverterStringToSpreadsheetMetadataPropertyNameTest extends SpreadsheetConverterTestCase<SpreadsheetConverterStringToSpreadsheetMetadataPropertyName>
+        implements SpreadsheetMetadataTesting {
+
+    @Test
+    public void testConvertEmptyString() {
+        this.convertFails(
+                SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.INSTANCE,
+                "",
+                SpreadsheetMetadataPropertyName.class,
+                this.createContext(),
+                "Empty \"name\""
+        );
+    }
+
+    @Test
+    public void testConvertInvalidSpreadsheetMetadataPropertyName() {
+        this.convertFails(
+                SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.INSTANCE,
+                "!invalid",
+                SpreadsheetMetadataPropertyName.class,
+                this.createContext(),
+                "Unknown metadata property name \"!invalid\""
+        );
+    }
+
+    @Test
+    public void testConvertNamedColor() {
+        this.convertStringAndCheck(
+                SpreadsheetMetadataPropertyName.namedColor(SpreadsheetColorName.RED)
+        );
+    }
+
+    @Test
+    public void testConvertNumberedColor() {
+        this.convertStringAndCheck(
+                SpreadsheetMetadataPropertyName.numberedColor(1)
+        );
+    }
+
+    @Test
+    public void testConvertPositiveSign() {
+        this.convertStringAndCheck(
+                SpreadsheetMetadataPropertyName.POSITIVE_SIGN
+        );
+    }
+
+    @Test
+    public void testConvertRoundingMode() {
+        this.convertStringAndCheck(
+                SpreadsheetMetadataPropertyName.ROUNDING_MODE
+        );
+    }
+
+    private void convertStringAndCheck(final SpreadsheetMetadataPropertyName<?> propertyName) {
+        this.convertAndCheck(
+                propertyName.value(),
+                propertyName
+        );
+    }
+
+    @Override
+    public SpreadsheetConverterStringToSpreadsheetMetadataPropertyName createConverter() {
+        return SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.INSTANCE;
+    }
+
+    @Override
+    public SpreadsheetConverterContext createContext() {
+        return SPREADSHEET_FORMATTER_CONTEXT;
+    }
+
+    // toString.........................................................................................................
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(
+                SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.INSTANCE,
+                "String to SpreadsheetMetadataPropertyName"
+        );
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetConverterStringToSpreadsheetMetadataPropertyName> type() {
+        return SpreadsheetConverterStringToSpreadsheetMetadataPropertyName.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
@@ -231,6 +231,15 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
     }
 
     @Test
+    public void testConverterSelectorWithStringToSpreadsheetMetadataPropertyName() {
+        this.converterAndCheck(
+                SpreadsheetConvertersConverterProvider.STRING_TO_SPREADSHEET_METADATA_PROPERTY_NAME + "",
+                PROVIDER_CONTEXT,
+                SpreadsheetConverters.stringToSpreadsheetMetadataPropertyName()
+        );
+    }
+
+    @Test
     public void testConverterNameWithSelectionToString() {
         this.converterAndCheck(
                 SpreadsheetConvertersConverterProvider.SELECTION_TO_STRING,

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -910,7 +910,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "  \"color-White\": 2,\n" +
                         "  \"color-Yellow\": 6,\n" +
                         "  \"comparators\": \"date, date-time, day-of-month, day-of-week, hour-of-am-pm, hour-of-day, minute-of-hour, month-of-year, nano-of-second, number, seconds-of-minute, text, text-case-insensitive, time, year\",\n" +
-                        "  \"converters\": \"basic, collection, error-throwing, error-to-number, error-to-string, general, plugin-selector-like-to-string, selection-to-selection, selection-to-string, spreadsheet-cell-to, string-to-expression, string-to-selection\",\n" +
+                        "  \"converters\": \"basic, collection, error-throwing, error-to-number, error-to-string, general, plugin-selector-like-to-string, selection-to-selection, selection-to-string, spreadsheet-cell-to, string-to-expression, string-to-selection, string-to-spreadsheet-metadata-property-name\",\n" +
                         "  \"currency-symbol\": \"CURR\",\n" +
                         "  \"date-formatter\": \"date-format-pattern dddd, d mmmm yyyy\",\n" +
                         "  \"date-parser\": \"date-parse-pattern dddd, d mmmm yyyy;dddd, d mmmm yy;dddd, d mmmm;d mmmm yyyy;d mmmm yy;d mmmm;d mmm yyyy;d mmm yy;d mmm;d/m/yy;d/m/yyyy;d/m\",\n" +
@@ -1077,7 +1077,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "  \"color-White\": 2,\n" +
                         "  \"color-Yellow\": 6,\n" +
                         "  \"comparators\": \"date, date-time, day-of-month, day-of-week, hour-of-am-pm, hour-of-day, minute-of-hour, month-of-year, nano-of-second, number, seconds-of-minute, text, text-case-insensitive, time, year\",\n" +
-                        "  \"converters\": \"basic, collection, error-throwing, error-to-number, error-to-string, general, plugin-selector-like-to-string, selection-to-selection, selection-to-string, spreadsheet-cell-to, string-to-expression, string-to-selection\",\n" +
+                        "  \"converters\": \"basic, collection, error-throwing, error-to-number, error-to-string, general, plugin-selector-like-to-string, selection-to-selection, selection-to-string, spreadsheet-cell-to, string-to-expression, string-to-selection, string-to-spreadsheet-metadata-property-name\",\n" +
                         "  \"currency-symbol\": \"CURR\",\n" +
                         "  \"date-formatter\": \"date-format-pattern dddd, d mmmm yyyy\",\n" +
                         "  \"date-parser\": \"date-parse-pattern dddd, d mmmm yyyy;dddd, d mmmm yy;dddd, d mmmm;d mmmm yyyy;d mmmm yy;d mmmm;d mmm yyyy;d mmm yy;d mmm;d/m/yy;d/m/yyyy;d/m\",\n" +


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6118
- SpreadsheetMetadataPropertyName converter supports String -> SpreadsheetMetadataPropertyName

- This will be useful for terminal functions.