### PR TITLE
SpreadsheetFormula.error

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/conditionalformat/SpreadsheetConditionalFormattingRuleTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/conditionalformat/SpreadsheetConditionalFormattingRuleTest.java
@@ -217,7 +217,7 @@ public final class SpreadsheetConditionalFormattingRuleTest implements ClassTest
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createObject(), "\"description#\" 123 123 style");
+        this.toStringAndCheck(this.createObject(), "\"description#\" 123 123  style");
     }
 
     @Override


### PR DESCRIPTION
- Expression evaluation errors are still SpreadsheetFormula.expressionValues.
- A separate error property is necessary so validators can save an error without replacing the validated value.