### PR TITLE
SpreadsheetCell: SpreadsheetFormula with inputValue FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
@@ -200,7 +200,7 @@ public final class SpreadsheetCell implements CanBeEmpty,
     private final SpreadsheetFormula formula;
 
     /**
-     * If a formula has a Collection value, return the value with {@link SpreadsheetErrorKind#VALUE}.
+     * If a formula has a Collection value, return the {@link SpreadsheetFormula#expressionValue()} with {@link SpreadsheetErrorKind#VALUE}.
      * A cell range resolves to a {@link List}, thus a cell = a range, will show an #VALUE!.
      */
     private static SpreadsheetFormula checkFormula(final SpreadsheetFormula formula) {
@@ -208,7 +208,7 @@ public final class SpreadsheetCell implements CanBeEmpty,
 
         // if value is a List formula should have an ERROR of #VALUE!
         return formula.setExpressionValue(
-                formula.value()
+                formula.expressionValue()
                         .map(v -> v instanceof Collection ? SpreadsheetErrorKind.VALUE : v)
         );
         // TODO https://github.com/mP1/walkingkooka-spreadsheet/issues/2205

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellTest.java
@@ -176,6 +176,30 @@ public final class SpreadsheetCellTest implements CanBeEmptyTesting,
         this.formattedValueAndCheckNone(cell);
     }
 
+    @Test
+    public void testWithFormulaWithInputValue() {
+        final SpreadsheetFormula formula = SpreadsheetFormula.EMPTY.setInputValue(
+                Optional.of(
+                        Optional.of(123)
+                )
+        );
+
+        final SpreadsheetCell cell = SpreadsheetCell.with(
+                REFERENCE,
+                formula
+        );
+
+        this.referenceAndCheck(cell);
+        this.formulaAndCheck(
+                cell,
+                formula
+        );
+        this.formatterAndCheckNone(cell);
+        this.parserAndCheckNone(cell);
+        this.styleAndCheck(cell);
+        this.formattedValueAndCheckNone(cell);
+    }
+
     // SetReference.....................................................................................................
 
     @Test


### PR DESCRIPTION
- The mistake was caused by SpreadsheetCell#checkFormula processing #value and not #expressionValue.