### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorNamesList SortedSets.tree …

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.java
@@ -67,7 +67,7 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesList extends 
             throw new IllegalArgumentException("Expected several sorted column/rows got 0");
         }
 
-        final Set<SpreadsheetSelection> duplicates = SortedSets.tree();
+        final Set<SpreadsheetSelection> duplicates = SortedSets.tree(SpreadsheetSelection.IGNORES_REFERENCE_KIND_COMPARATOR);
 
         for (final SpreadsheetColumnOrRowSpreadsheetComparatorNames columnOrRowComparators : comparatorNames) {
             final SpreadsheetColumnOrRowReferenceOrRange columnOrRow = columnOrRowComparators.columnOrRow();

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
@@ -163,6 +163,40 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest impl
     }
 
     @Test
+    public void testWithDuplicateColumnFails2() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.with(
+                        Lists.of(
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseColumn("A"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text UP")
+                                        )
+                                ),
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseColumn("$A"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text UP")
+                                        )
+                                ),
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseColumn("B"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text-case-sensitive UP")
+                                        )
+                                )
+                        )
+                )
+        );
+        this.checkEquals(
+                "Duplicate column $A",
+                thrown.getMessage(),
+                "message"
+        );
+    }
+
+    @Test
     public void testWithDuplicateRowFails() {
         final IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class,
@@ -176,6 +210,40 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest impl
                                 ),
                                 SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
                                         SpreadsheetSelection.parseRow("2"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text UP")
+                                        )
+                                ),
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseRow("$1"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text-case-sensitive UP")
+                                        )
+                                )
+                        )
+                )
+        );
+        this.checkEquals(
+                "Duplicate row $1",
+                thrown.getMessage(),
+                "message"
+        );
+    }
+
+    @Test
+    public void testWithDuplicateRowFails2() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.with(
+                        Lists.of(
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseRow("1"),
+                                        Lists.of(
+                                                SpreadsheetComparatorNameAndDirection.parse("text UP")
+                                        )
+                                ),
+                                SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                        SpreadsheetSelection.parseRow("$1"),
                                         Lists.of(
                                                 SpreadsheetComparatorNameAndDirection.parse("text UP")
                                         )


### PR DESCRIPTION
…SpreadsheetSelection.IGNORES_REFERENCE_KIND_COMPARATOR

- Not actually needed but better than using SortedSet without comparator.