### PR TITLE
SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator FormHandl…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
@@ -41,6 +41,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 import walkingkooka.visit.Visiting;
 
@@ -350,7 +351,7 @@ public class FakeSpreadsheetMetadataVisitor extends SpreadsheetMetadataVisitor {
     }
 
     @Override
-    protected void visitValidatorFormHandlers(final FormHandlerAliasSet aliases) {
+    protected void visitValidatorFormHandler(final FormHandlerSelector selector) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataDefaultTextResource.json
@@ -123,7 +123,7 @@
   },
   "twoDigitYear": 20,
   "validatorConverter": "collection(error-to-number, error-throwing, plugin-selector-like-to-string, string-to-expression, string-to-selection, selection-to-selection, selection-to-string, general)",
-  "validatorFormHandlers": "",
+  "validatorFormHandler": "non-null",
   "validatorFunctions": "",
   "validatorValidators": "",
   "validators": "",

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -71,6 +71,8 @@ import walkingkooka.tree.text.FontFamily;
 import walkingkooka.tree.text.FontSize;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerName;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 
 import java.math.RoundingMode;
@@ -373,6 +375,11 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     public static final SpreadsheetMetadataPropertyName<ConverterSelector> VALIDATOR_CONVERTER = registerConstant(SpreadsheetMetadataPropertyNameConverterSelectorValidator.instance());
 
     /**
+     * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link FormHandlerSelector}</code> which will be used to pick available functions within {@link SpreadsheetCell#validator()}.
+     */
+    public static final SpreadsheetMetadataPropertyName<FormHandlerSelector> VALIDATOR_FORM_HANDLER = registerConstant(SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator.instance());
+
+    /**
      * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link ExpressionFunctionAliasSet}</code> which will be used to pick available functions within validator expressions.
      */
     public static final SpreadsheetMetadataPropertyName<ExpressionFunctionAliasSet> VALIDATOR_FUNCTIONS = registerConstant(SpreadsheetMetadataPropertyNameExpressionFunctionAliasSetValidator.instance());
@@ -386,11 +393,6 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
      * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link ValidatorAliasSet}</code> which will be used to pick available validators within {@link SpreadsheetCell#validator()}.
      */
     public static final SpreadsheetMetadataPropertyName<ValidatorAliasSet> VALIDATORS = registerConstant(SpreadsheetMetadataPropertyNameValidatorAliasSetValidators.instance());
-
-    /**
-     * A {@link SpreadsheetMetadataPropertyName} holding the <code>{@link FormHandlerAliasSet}</code> which will be used to pick available functions within {@link SpreadsheetCell#validator()}.
-     */
-    public static final SpreadsheetMetadataPropertyName<FormHandlerAliasSet> VALIDATOR_FORM_HANDLERS = registerConstant(SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula.instance());
 
     /**
      * A {@link SpreadsheetMetadataPropertyName} holding the <code>value-separator</code> {@link Character}
@@ -826,6 +828,11 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
         );
         ConverterSelector.with(
                 ConverterName.NEVER,
+                ""
+        );
+        FormHandlerAliasSet.parse("helloFormHandler");
+        FormHandlerSelector.with(
+                FormHandlerName.with("HelloFormHandler"),
                 ""
         );
         SpreadsheetExporterAliasSet.parse("json");

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.validation.form.provider.FormHandlerSelector;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Base class for any property that holds a {@link FormHandlerSelector}.
+ */
+abstract class SpreadsheetMetadataPropertyNameFormHandlerSelector extends SpreadsheetMetadataPropertyName<FormHandlerSelector> {
+
+    /**
+     * Package private to limit subclassing.
+     */
+    SpreadsheetMetadataPropertyNameFormHandlerSelector(final String name) {
+        super(name);
+    }
+
+    @Override
+    final FormHandlerSelector checkValueNonNull(final Object value) {
+        return this.checkValueType(
+                value,
+                v -> v instanceof FormHandlerSelector
+        );
+    }
+
+    @Override
+    final String expected() {
+        return FormHandlerSelector.class.getSimpleName();
+    }
+
+    @Override
+    final Optional<FormHandlerSelector> extractLocaleAwareValue(final Locale locale) {
+        return Optional.empty();
+    }
+
+    @Override
+    public final Class<FormHandlerSelector> type() {
+        return FormHandlerSelector.class;
+    }
+
+    // parseUrlFragmentSaveValue........................................................................................
+
+    @Override
+    final FormHandlerSelector parseUrlFragmentSaveValueNonNull(final String value) {
+        return FormHandlerSelector.parse(value);
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019 Miroslav Pokorny (github.com/mP1)
  *
@@ -17,28 +18,32 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 
-import walkingkooka.validation.form.provider.FormHandlerAliasSet;
-
-final class SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula extends SpreadsheetMetadataPropertyNameFormHandlerAliasSet {
+/**
+ * This {@link SpreadsheetMetadataPropertyName} holds the default {@link FormHandlerSelector}.
+ */
+final class SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator extends SpreadsheetMetadataPropertyNameFormHandlerSelector {
 
     /**
      * Singleton
      */
-    static SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula instance() {
-        return new SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula();
+    static SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator instance() {
+        return new SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator();
     }
 
     /**
      * Private constructor use singleton.
      */
-    private SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula() {
-        super("validatorFormHandlers");
+    private SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator() {
+        super(
+                "validatorFormHandler"
+        );
     }
 
     @Override
-    void accept(final FormHandlerAliasSet aliases,
+    void accept(final FormHandlerSelector value,
                 final SpreadsheetMetadataVisitor visitor) {
-        visitor.visitValidatorFormHandlers(aliases);
+        visitor.visitValidatorFormHandler(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -78,6 +78,7 @@ import walkingkooka.tree.text.Length;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 import walkingkooka.validation.provider.ValidatorProvider;
 import walkingkooka.validation.provider.ValidatorProviders;
@@ -299,8 +300,8 @@ public interface SpreadsheetMetadataTesting extends Testing {
                     SpreadsheetMetadataPropertyName.VALIDATOR_CONVERTER,
                     ConverterSelector.parse("collection (error-to-number, error-throwing, string-to-error, string-to-expression, string-to-selection, selection-to-selection, selection-to-string, general)")
             ).set(
-                    SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLERS,
-                    FormHandlerAliasSet.EMPTY
+                    SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLER,
+                    FormHandlerSelector.parse("non-null")
             ).set(
                     SpreadsheetMetadataPropertyName.VALIDATOR_FUNCTIONS,
                     ExpressionFunctionAliasSet.EMPTY

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
@@ -42,6 +42,7 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 import walkingkooka.visit.Visiting;
 import walkingkooka.visit.Visitor;
@@ -328,7 +329,7 @@ public abstract class SpreadsheetMetadataVisitor extends Visitor<SpreadsheetMeta
         // nop
     }
 
-    protected void visitValidatorFormHandlers(final FormHandlerAliasSet aliases) {
+    protected void visitValidatorFormHandler(final FormHandlerSelector selector) {
         // nop
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -988,7 +988,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "  \"timeParser\": \"time-parse-pattern h:mm:ss AM/PM;h:mm:ss;h:mm:ss.0;h:mm AM/PM;h:mm\",\n" +
                         "  \"twoDigitYear\": 20,\n" +
                         "  \"validatorConverter\": \"collection(error-to-number, error-throwing, plugin-selector-like-to-string, string-to-expression, string-to-selection, selection-to-selection, selection-to-string, general)\",\n" +
-                        "  \"validatorFormHandlers\": \"\",\n" +
+                        "  \"validatorFormHandler\": \"non-null\",\n" +
                         "  \"validatorFunctions\": \"\",\n" +
                         "  \"validatorValidators\": \"\",\n" +
                         "  \"validators\": \"collection, expression, non-null\",\n" +
@@ -1161,7 +1161,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                         "  \"timeParser\": \"time-parse-pattern h:mm:ss AM/PM;h:mm:ss;h:mm:ss.0;h:mm AM/PM;h:mm\",\n" +
                         "  \"twoDigitYear\": 20,\n" +
                         "  \"validatorConverter\": \"collection(error-to-number, error-throwing, plugin-selector-like-to-string, string-to-expression, string-to-selection, selection-to-selection, selection-to-string, general)\",\n" +
-                        "  \"validatorFormHandlers\": \"\",\n" +
+                        "  \"validatorFormHandler\": \"non-null\",\n" +
                         "  \"validatorFunctions\": \"\",\n" +
                         "  \"validatorValidators\": \"\",\n" +
                         "  \"validators\": \"collection, expression, non-null\",\n" +

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -93,6 +93,7 @@ import walkingkooka.tree.text.TextStyle;
 import walkingkooka.tree.text.TextStylePropertyName;
 import walkingkooka.tree.text.WordWrap;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 import walkingkooka.validation.provider.ValidatorSelector;
 
@@ -3055,8 +3056,8 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 ConverterSelector.parse("validator-converter-123")
         );
         properties.put(
-                SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLERS,
-                FormHandlerAliasSet.parse("hello-form-handler")
+                SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLER,
+                FormHandlerSelector.parse("hello-form-handler")
         );
         properties.put(
                 SpreadsheetMetadataPropertyName.VALIDATOR_FUNCTIONS,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class SpreadsheetMetadataPropertyNameFormHandlerSelectorTest implements ClassTesting<SpreadsheetMetadataPropertyNameFormHandlerSelector> {
+
+    @Override
+    public Class<SpreadsheetMetadataPropertyNameFormHandlerSelector> type() {
+        return SpreadsheetMetadataPropertyNameFormHandlerSelector.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.validation.form.provider.FormHandlerSelector;
+
+public abstract class SpreadsheetMetadataPropertyNameFormHandlerSelectorTestCase<N extends SpreadsheetMetadataPropertyNameFormHandlerSelector> extends SpreadsheetMetadataPropertyNameTestCase<N, FormHandlerSelector> {
+
+    SpreadsheetMetadataPropertyNameFormHandlerSelectorTestCase() {
+        super();
+    }
+
+    @Override
+    final String propertyValueType() {
+        return FormHandlerSelector.class.getSimpleName();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorValidatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelectorValidatorTest.java
@@ -18,24 +18,24 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 
-public final class SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormulaTest extends SpreadsheetMetadataPropertyNameFormHandlerAliasSetTestCase<SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula> {
+public final class SpreadsheetMetadataPropertyNameFormHandlerSelectorValidatorTest extends SpreadsheetMetadataPropertyNameFormHandlerSelectorTestCase<SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator> {
 
     @Override
-    SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula createName() {
-        return SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula.instance();
+    SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator createName() {
+        return SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator.instance();
     }
 
     @Override
-    FormHandlerAliasSet propertyValue() {
-        return FormHandlerAliasSet.parse("hello-form-handler");
+    FormHandlerSelector propertyValue() {
+        return FormHandlerSelector.parse("hello");
     }
 
     // class............................................................................................................
 
     @Override
-    public Class<SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula> type() {
-        return SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula.class;
+    public Class<SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator> type() {
+        return SpreadsheetMetadataPropertyNameFormHandlerSelectorValidator.class;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
@@ -47,6 +47,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetViewport;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
 import walkingkooka.tree.text.TextStyle;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
+import walkingkooka.validation.form.provider.FormHandlerSelector;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 import walkingkooka.visit.Visiting;
 
@@ -764,6 +765,19 @@ public final class SpreadsheetMetadataVisitorTest implements SpreadsheetMetadata
     }
 
     @Test
+    public void testVisitValidatorFormHandler() {
+        new TestSpreadsheetMetadataVisitor() {
+            @Override
+            protected void visitValidatorFormHandler(final FormHandlerSelector s) {
+                this.visited = s;
+            }
+        }.accept(
+                SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLER,
+                FormHandlerSelector.parse("hello-form-handler")
+        );
+    }
+
+    @Test
     public void testVisitValidatorFunctions() {
         new TestSpreadsheetMetadataVisitor() {
             @Override
@@ -799,19 +813,6 @@ public final class SpreadsheetMetadataVisitorTest implements SpreadsheetMetadata
         }.accept(
                 SpreadsheetMetadataPropertyName.VALIDATORS,
                 ValidatorAliasSet.parse("nonNull")
-        );
-    }
-
-    @Test
-    public void testVisitValidatorFormHandlers() {
-        new TestSpreadsheetMetadataVisitor() {
-            @Override
-            protected void visitValidatorFormHandlers(final FormHandlerAliasSet a) {
-                this.visited = a;
-            }
-        }.accept(
-                SpreadsheetMetadataPropertyName.VALIDATOR_FORM_HANDLERS,
-                FormHandlerAliasSet.EMPTY
         );
     }
 


### PR DESCRIPTION
…erSelector was FormHandlerAliasSet FIX

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6334
- SpreadsheetMetadataPropertyNameFormHandlerAliasSetFormula should be FormHandlerSelector not FormHandlerAliasSet