### PR TITLE
SpreadsheetMetadata.spreadsheetValidatorContext SpreadsheetMetadataPr…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1145,7 +1145,9 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
 
         final SpreadsheetMetadataComponents components = SpreadsheetMetadataComponents.with(this);
 
-        components.getOrNull(SpreadsheetMetadataPropertyName.FORMULA_CONVERTER);
+        final SpreadsheetMetadataPropertyName<ConverterSelector> converter = SpreadsheetMetadataPropertyName.VALIDATOR_CONVERTER;
+
+        components.getOrNull(converter);
 
         components.reportIfMissing();
 
@@ -1155,7 +1157,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                         Cast.to(validatorSelectorToValidator),
                         Cast.to(referenceToExpressionEvaluationContext),
                         this.spreadsheetConverterContext(
-                                SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
+                                converter,
                                 labelNameResolver,
                                 converterProvider, // ConverterProvider
                                 providerContext // ProviderContext

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
@@ -241,7 +241,7 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
                 )
         );
         this.checkEquals(
-                "Metadata missing: formulaConverter",
+                "Metadata missing: validatorConverter",
                 thrown.getMessage(),
                 "message"
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -2623,12 +2623,6 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                                 SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND,
                                 EXPRESSION_NUMBER_KIND
                         ).set(
-                                SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
-                                ConverterSelector.parse("never")
-                        ).set(
-                                SpreadsheetMetadataPropertyName.VALIDATOR_VALIDATORS,
-                                ValidatorAliasSet.EMPTY
-                        ).set(
                                 SpreadsheetMetadataPropertyName.GROUP_SEPARATOR,
                                 GROUP_SEPARATOR
                         ).set(
@@ -2652,6 +2646,12 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                         ).set(
                                 SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR,
                                 50
+                        ).set(
+                                SpreadsheetMetadataPropertyName.VALIDATOR_CONVERTER,
+                                ConverterSelector.parse("never")
+                        ).set(
+                                SpreadsheetMetadataPropertyName.VALIDATOR_VALIDATORS,
+                                ValidatorAliasSet.EMPTY
                         ).spreadsheetValidatorContext(
                                 SpreadsheetSelection.A1,
                                 (final ValidatorSelector validatorSelector) -> {


### PR DESCRIPTION
…opertyName.VALIDATOR_CONVERTER replaces FORMULA_CONVERTER

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6331
- SpreadsheetValidatorContext should use SpreadsheetMetadataPropertyName.VALIDATOR_CONVERTER