### PR TITLE
SpreadsheetMetadata.spreadsheetValidatorContext referenceToExpression…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1132,7 +1132,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      */
     public final SpreadsheetValidatorContext spreadsheetValidatorContext(final SpreadsheetCellReference cell,
                                                                          final Function<ValidatorSelector, Validator<SpreadsheetExpressionReference, SpreadsheetValidatorContext>> validatorSelectorToValidator,
-                                                                         final BiFunction<Object, SpreadsheetCellReference, SpreadsheetExpressionEvaluationContext> referenceToExpressionEvaluationContext,
+                                                                         final BiFunction<Object, SpreadsheetExpressionReference, SpreadsheetExpressionEvaluationContext> referenceToExpressionEvaluationContext,
                                                                          final SpreadsheetLabelNameResolver labelNameResolver,
                                                                          final ConverterProvider converterProvider,
                                                                          final ProviderContext providerContext) {

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
@@ -25,7 +25,7 @@ import walkingkooka.environment.EnvironmentContexts;
 import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserProviders;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
@@ -232,7 +232,7 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
                             throw new UnsupportedOperationException();
                         },
                         (final Object value,
-                         final SpreadsheetCellReference cell) -> {
+                         final SpreadsheetExpressionReference cellOrLabel) -> {
                             throw new UnsupportedOperationException();
                         },
                         LABEL_NAME_RESOLVER,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -69,7 +69,7 @@ import walkingkooka.spreadsheet.importer.SpreadsheetImporterAliasSet;
 import walkingkooka.spreadsheet.importer.SpreadsheetImporterSelector;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserProvider;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserProviders;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
@@ -2658,7 +2658,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                                     throw new UnsupportedOperationException();
                                 },
                                 (final Object value,
-                                 final SpreadsheetCellReference cell) -> {
+                                 final SpreadsheetExpressionReference cellOrLabel) -> {
                                     throw new UnsupportedOperationException();
                                 },
                                 LABEL_NAME_RESOLVER,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
@@ -40,7 +40,6 @@ import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
 import walkingkooka.spreadsheet.format.SpreadsheetColorName;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterProviders;
-import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
@@ -82,8 +81,8 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
         throw new UnsupportedOperationException();
     };
 
-    final static BiFunction<Object, SpreadsheetCellReference, SpreadsheetExpressionEvaluationContext> VALUE_N_CELL_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT = (final Object value,
-                                                                                                                                                                   final SpreadsheetCellReference cell) -> {
+    final static BiFunction<Object, SpreadsheetExpressionReference, SpreadsheetExpressionEvaluationContext> VALUE_N_CELL_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT = (final Object value,
+                                                                                                                                                                         final SpreadsheetExpressionReference cellOrLabel) -> {
         throw new UnsupportedOperationException();
     };
 


### PR DESCRIPTION
…EvaluationContext SpreadsheetExpressionReference was SpreadsheetCell

- Change required to match SpreadsheetValidatorContext where ValidationReference is SpreadsheetExpressionReference not SpreadsheetCellReference.