### PR TITLE
BasicSpreadsheetEngine.validate should use SpreadsheetMetadata.VALIDA…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -227,7 +227,11 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
                     if (SpreadsheetMetadataPropertyName.FIND_FUNCTIONS.equals(functionAliases)) {
                         converterSelector = SpreadsheetMetadataPropertyName.FIND_CONVERTER;
                     } else {
-                        throw new IllegalArgumentException("Missing " + ConverterSelector.class.getSimpleName() + " for  " + functionAliases);
+                        if (SpreadsheetMetadataPropertyName.VALIDATOR_FUNCTIONS.equals(functionAliases)) {
+                            converterSelector = SpreadsheetMetadataPropertyName.VALIDATOR_CONVERTER;
+                        } else {
+                            throw new IllegalArgumentException("Missing " + ConverterSelector.class.getSimpleName() + " for  " + functionAliases);
+                        }
                     }
                 }
 


### PR DESCRIPTION
…TOR-FUNCTIONS

- Closes SpreadsheetValidatorContext should use SpreadsheetMetadataPropertyName.VALIDATOR_FUNCTIONS
- https://github.com/mP1/walkingkooka-spreadsheet/issues/6332