### PR TITLE
SpreadsheetColumnOrRowReferenceSpreadsheetParser optional required su…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetColumnReferenceSpreadsheetParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetColumnReferenceSpreadsheetParser.java
@@ -33,13 +33,15 @@ final class SpreadsheetColumnReferenceSpreadsheetParser extends SpreadsheetColum
     /**
      * Singleton
      */
-    final static SpreadsheetColumnReferenceSpreadsheetParser INSTANCE = new SpreadsheetColumnReferenceSpreadsheetParser();
+    final static SpreadsheetColumnReferenceSpreadsheetParser INSTANCE = new SpreadsheetColumnReferenceSpreadsheetParser(
+        true // REQUIRED
+    );
 
     /**
      * Private ctor use singleton
      */
-    private SpreadsheetColumnReferenceSpreadsheetParser() {
-        super();
+    private SpreadsheetColumnReferenceSpreadsheetParser(final boolean required) {
+        super(required);
     }
 
     @Override
@@ -69,6 +71,22 @@ final class SpreadsheetColumnReferenceSpreadsheetParser extends SpreadsheetColum
                     "Invalid column " + CharSequences.quoteAndEscape(text) + " not between \"A\" and \"" + SpreadsheetColumnReference.MAX_VALUE_STRING + "\""
             );
         }
+    }
+
+    @Override
+    public SpreadsheetColumnReferenceSpreadsheetParser optional() {
+        return this.setRequired(false);
+    }
+
+    @Override
+    public SpreadsheetColumnReferenceSpreadsheetParser required() {
+        return this.setRequired(true);
+    }
+
+    private SpreadsheetColumnReferenceSpreadsheetParser setRequired(final boolean required) {
+        return required == this.isRequired() ?
+                this :
+                new SpreadsheetColumnReferenceSpreadsheetParser(required);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetRowReferenceSpreadsheetParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/formula/SpreadsheetRowReferenceSpreadsheetParser.java
@@ -32,13 +32,15 @@ final class SpreadsheetRowReferenceSpreadsheetParser extends SpreadsheetColumnOr
     /**
      * Singleton
      */
-    final static SpreadsheetRowReferenceSpreadsheetParser INSTANCE = new SpreadsheetRowReferenceSpreadsheetParser();
+    final static SpreadsheetRowReferenceSpreadsheetParser INSTANCE = new SpreadsheetRowReferenceSpreadsheetParser(
+            true // REQUIRED
+    );
 
     /**
      * Private ctor use singleton
      */
-    private SpreadsheetRowReferenceSpreadsheetParser() {
-        super();
+    private SpreadsheetRowReferenceSpreadsheetParser(final boolean required) {
+        super(required);
     }
 
     @Override
@@ -54,6 +56,22 @@ final class SpreadsheetRowReferenceSpreadsheetParser extends SpreadsheetColumnOr
     @Override
     ParserToken token1(final SpreadsheetReferenceKind absoluteOrRelative, final int row, final String text) {
         return SpreadsheetFormulaParserToken.row(absoluteOrRelative.row(row), text);
+    }
+
+    @Override
+    public SpreadsheetRowReferenceSpreadsheetParser optional() {
+        return this.setRequired(false);
+    }
+
+    @Override
+    public SpreadsheetRowReferenceSpreadsheetParser required() {
+        return this.setRequired(true);
+    }
+
+    private SpreadsheetRowReferenceSpreadsheetParser setRequired(final boolean required) {
+        return required == this.isRequired() ?
+                this :
+                new SpreadsheetRowReferenceSpreadsheetParser(required);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -495,8 +495,10 @@ public abstract class SpreadsheetSelection implements HasText,
     }
 
     private static final Parser<SpreadsheetParserContext> COLUMN_OR_ROW_PARSER = SpreadsheetFormulaParsers.column()
+            .optional()
             .or(
                     SpreadsheetFormulaParsers.row()
+                            .optional()
             ).orFailIfCursorNotEmpty(ParserReporters.basic())
             .orReport(ParserReporters.basic());
 
@@ -565,17 +567,9 @@ public abstract class SpreadsheetSelection implements HasText,
                     .get();
         } catch (final ParserException cause) {
             final Throwable wrapped = cause.getCause();
-
-            if (wrapped instanceof NullPointerException) {
-                throw (NullPointerException) wrapped;
+            if(wrapped instanceof RuntimeException) {
+                throw (RuntimeException) wrapped;
             }
-            if (wrapped instanceof IllegalColumnOrRowArgumentException) {
-                throw (IllegalColumnOrRowArgumentException) wrapped;
-            }
-            if (wrapped instanceof IllegalArgumentException) {
-                throw (IllegalArgumentException) wrapped;
-            }
-
             throw new IllegalArgumentException(cause.getMessage(), cause);
         }
     }

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetColumnReferenceSpreadsheetParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetColumnReferenceSpreadsheetParserTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.formula;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.spreadsheet.formula.parser.ColumnSpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
@@ -45,8 +46,16 @@ public final class SpreadsheetColumnReferenceSpreadsheetParserTest extends Sprea
     }
 
     @Test
-    public void testParseDollarFails2() {
-        this.parseFailAndCheck("$123");
+    public void testParseDollarRowFails() {
+        final String text = "$123";
+
+        this.parseThrows(
+                text,
+                new InvalidCharacterException(
+                        text,
+                        1
+                ).getMessage()
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetRowReferenceSpreadsheetParserTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetRowReferenceSpreadsheetParserTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.formula;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.spreadsheet.formula.parser.RowSpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
@@ -42,8 +43,16 @@ public final class SpreadsheetRowReferenceSpreadsheetParserTest extends Spreadsh
     }
 
     @Test
-    public void testParseDollarFails2() {
-        this.parseFailAndCheck("$ABC");
+    public void testParseDollarColumnFails() {
+        final String text = "$ABC";
+
+        this.parseThrows(
+                text,
+                new InvalidCharacterException(
+                        text,
+                        1
+                ).getMessage()
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTest.java
@@ -404,18 +404,25 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
     public void testParseCellFails() {
         final String text = "ABC!123";
 
-        final InvalidCharacterException thrown = assertThrows(
-                InvalidCharacterException.class,
-                () -> SpreadsheetSelection.parseCell(text)
-        );
-
-        this.checkEquals(
+        this.parseStringFails(
+                text,
                 new InvalidCharacterException(
                         text,
                         text.indexOf('!')
-                ).getMessage(),
-                thrown.getMessage(),
-                () -> thrown.getClass().getName()
+                )
+        );
+    }
+
+    @Test
+    public void testParseCellFails2() {
+        final String text = "ABC123!456";
+
+        this.parseStringFails(
+                text,
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf('!')
+                )
         );
     }
 
@@ -423,19 +430,27 @@ public final class SpreadsheetSelectionTest implements ClassTesting2<Spreadsheet
 
     @Test
     public void testParseCellRangeFails() {
-        final String text = "A1:B!Hello";
+        final String text = "A1:!B";
 
-        final InvalidCharacterException thrown = assertThrows(
-                InvalidCharacterException.class,
-                () -> SpreadsheetSelection.parseCellRange(text)
-        );
-
-        this.checkEquals(
+        this.parseStringFails(
+                text,
                 new InvalidCharacterException(
                         text,
-                        text.indexOf("!")
-                ).getMessage(),
-                thrown.getMessage()
+                        text.indexOf('!')
+                )
+        );
+    }
+
+    @Test
+    public void testParseCellRangeFails2() {
+        final String text = "A1:B!Hello";
+
+        this.parseStringFails(
+                text,
+                new InvalidCharacterException(
+                        text,
+                        text.indexOf('!')
+                )
         );
     }
 


### PR DESCRIPTION
…pport

- Required now throws an InvalidCharacterException on invalid characters etc.
- Previously sub-classes were always required
- SpreadsheetSelection-parseCell now reports actual invalid character rather than "first char".