### PR TITLE
SpreadsheetError.parse support missing SpreadsheetErrorKind

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetError.java
@@ -156,30 +156,37 @@ public final class SpreadsheetError implements Value<Optional<Object>>,
     public static SpreadsheetError parse(final String text) {
         CharSequences.failIfNullOrEmpty(text, "text");
 
-        final int nextToken = text.indexOf(' ');
-        final String kindText = -1 == nextToken ?
-                text :
-                text.substring(
-                        0,
-                        nextToken
-                );
-        if (kindText.isEmpty()) {
-            throw new IllegalArgumentException("Missing error kind");
-        }
-
         final SpreadsheetErrorKind kind;
+        final String message;
 
-        try {
-            kind = SpreadsheetErrorKind.parse(kindText);
-        } catch (final IllegalArgumentException cause) {
-            throw new IllegalArgumentException("Invalid error kind", cause);
+        // missing prefix text is the message
+        if (text.charAt(0) == SpreadsheetErrorKind.PREFIX) {
+            final int nextToken = text.indexOf(' ');
+            final String kindText = -1 == nextToken ?
+                    text :
+                    text.substring(
+                            0,
+                            nextToken
+                    );
+            if (kindText.isEmpty()) {
+                throw new IllegalArgumentException("Missing error kind");
+            }
+
+            try {
+                kind = SpreadsheetErrorKind.parse(kindText);
+            } catch (final IllegalArgumentException cause) {
+                throw new IllegalArgumentException("Invalid error kind", cause);
+            }
+
+            message = -1 == nextToken ?
+                    "" :
+                    text.substring(nextToken + 1);
+        } else {
+            kind = SpreadsheetErrorKind.ERROR;
+            message = text;
         }
 
-        return kind.setMessage(
-                        -1 == nextToken ?
-                                "" :
-                                text.substring(nextToken + 1)
-                );
+        return kind.setMessage(message);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
@@ -106,6 +106,12 @@ public enum SpreadsheetErrorKind implements HasText {
 
     CALC("#CALC!", 14);
 
+    /**
+     * A prefix character that precedes all {@link SpreadsheetErrorKind}.
+     * This will be used to identify a message which may or may not have an {@link SpreadsheetErrorKind}.
+     */
+    static char PREFIX = '#';
+
     SpreadsheetErrorKind(final String text,
                          final int value) {
         this.text = text;

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorTest.java
@@ -414,15 +414,25 @@ public final class SpreadsheetErrorTest implements ParseStringTesting<Spreadshee
     // parseString......................................................................................................
 
     @Test
+    public void testParseMissingPrefix() {
+        final String text = "Message123";
+
+        this.parseStringAndCheck(
+                text,
+                SpreadsheetErrorKind.ERROR.setMessage(text)
+        );
+    }
+
+    @Test
     public void testParseInvalidKindFails() {
         this.parseStringFails(
-                "Invalid123",
+                "#Invalid123",
                 new IllegalArgumentException("Invalid error kind")
         );
     }
 
     @Test
-    public void testParseWithoutMessage() {
+    public void testParseDiv0WithoutMessage() {
         this.parseStringAndCheck(
                 "#DIV/0!",
                 SpreadsheetErrorKind.DIV0.setMessage("")
@@ -430,7 +440,7 @@ public final class SpreadsheetErrorTest implements ParseStringTesting<Spreadshee
     }
 
     @Test
-    public void testParseWithoutMessage2() {
+    public void testParseNaWithoutMessage2() {
         this.parseStringAndCheck(
                 "#N/A",
                 SpreadsheetErrorKind.NA.setMessage("")
@@ -438,7 +448,7 @@ public final class SpreadsheetErrorTest implements ParseStringTesting<Spreadshee
     }
 
     @Test
-    public void testParseWithMessage() {
+    public void testParseDiv0WithMessage() {
         this.parseStringAndCheck(
                 "#DIV/0! message123",
                 SpreadsheetErrorKind.DIV0.setMessage("message123")
@@ -446,7 +456,7 @@ public final class SpreadsheetErrorTest implements ParseStringTesting<Spreadshee
     }
 
     @Test
-    public void testParseWithMessage2() {
+    public void testParseNaWithMessage2() {
         this.parseStringAndCheck(
                 "#N/A message123",
                 SpreadsheetErrorKind.NA.setMessage("message123")


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6409
- SpreadsheetError needs to handle messages without SpreadsheetErrorKind prefix