### PR TITLE
SpreadsheetViewportNavigationList.setElements null check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationList.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationList.java
@@ -84,7 +84,11 @@ public final class SpreadsheetViewportNavigationList extends AbstractList<Spread
 
         final int size = list.size();
         final SpreadsheetViewportNavigation[] copy = new SpreadsheetViewportNavigation[list.size()];
-        list.toArray(copy);
+
+        int i = 0;
+        for(final SpreadsheetViewportNavigation navigation : list) {
+            copy[i++] = Objects.requireNonNull(navigation, "includes null navigation");
+        }
 
         final SpreadsheetViewportNavigationList result;
         switch (size) {

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetViewportNavigationListTest.java
@@ -35,6 +35,7 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetViewportNavigationListTest implements ImmutableListTesting<SpreadsheetViewportNavigationList, SpreadsheetViewportNavigation>,
         ParseStringTesting<SpreadsheetViewportNavigationList>,
@@ -42,6 +43,20 @@ public final class SpreadsheetViewportNavigationListTest implements ImmutableLis
         ClassTesting<SpreadsheetViewportNavigationList>,
         HasTextTesting,
         JsonNodeMarshallingTesting<SpreadsheetViewportNavigationList> {
+
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        null,
+                                        SpreadsheetViewportNavigation.rightColumn()
+                                )
+                        )
+        );
+    }
 
     @Test
     public void testSetElementsDoesntDoubleWrap() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6445
- SpreadsheetViewportNavigationList.setElements should null check elements