### PR TITLE
SpreadsheetComparatorNameList setElements null check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorNameList.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorNameList.java
@@ -67,26 +67,29 @@ public final class SpreadsheetComparatorNameList extends AbstractList<Spreadshee
     public static SpreadsheetComparatorNameList with(final List<SpreadsheetComparatorName> names) {
         Objects.requireNonNull(names, "names");
 
-        return names instanceof SpreadsheetComparatorNameList ?
-                (SpreadsheetComparatorNameList) names :
-                with0(
-                        Lists.immutable(names)
+        SpreadsheetComparatorNameList spreadsheetComparatorNameList;
+
+        if(names instanceof SpreadsheetComparatorNameList) {
+            spreadsheetComparatorNameList = (SpreadsheetComparatorNameList) names;
+        } else {
+            final List<SpreadsheetComparatorName> copy = Lists.array();
+            for(final SpreadsheetComparatorName name : names) {
+                copy.add(
+                        Objects.requireNonNull(name, "includes null name")
                 );
-    }
+            }
 
-    private static SpreadsheetComparatorNameList with0(final List<SpreadsheetComparatorName> names) {
-        final SpreadsheetComparatorNameList list;
-
-        switch (names.size()) {
-            case 0:
-                list = EMPTY;
-                break;
-            default:
-                list = new SpreadsheetComparatorNameList(names);
-                break;
+            switch (names.size()) {
+                case 0:
+                    spreadsheetComparatorNameList = EMPTY;
+                    break;
+                default:
+                    spreadsheetComparatorNameList = new SpreadsheetComparatorNameList(copy);
+                    break;
+            }
         }
 
-        return list;
+        return spreadsheetComparatorNameList;
     }
 
     private SpreadsheetComparatorNameList(final List<SpreadsheetComparatorName> names) {

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorNameListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorNameListTest.java
@@ -119,6 +119,24 @@ public class SpreadsheetComparatorNameListTest implements ListTesting2<Spreadshe
         );
     }
 
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        SpreadsheetComparatorName.DATE,
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "includes null name",
+                thrown.getMessage()
+        );
+    }
+
     @Override
     public SpreadsheetComparatorNameList createList() {
         return SpreadsheetComparatorNameList.with(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6449
- SpreadsheetComparatorNameList.setElements should null check elements