### PR TITLE
SpreadsheetFormatterSampleList.setElements null check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSampleList.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSampleList.java
@@ -57,14 +57,34 @@ import java.util.Objects;
 public final class SpreadsheetFormatterSampleList extends AbstractList<SpreadsheetFormatterSample>
         implements ImmutableListDefaults<SpreadsheetFormatterSampleList, SpreadsheetFormatterSample> {
 
+    public final static SpreadsheetFormatterSampleList EMPTY = new SpreadsheetFormatterSampleList(Lists.empty());
+
     public static SpreadsheetFormatterSampleList with(final List<SpreadsheetFormatterSample> samples) {
         Objects.requireNonNull(samples, "samples");
 
-        return samples instanceof SpreadsheetFormatterSampleList ?
-                (SpreadsheetFormatterSampleList) samples :
-                new SpreadsheetFormatterSampleList(
-                        Lists.immutable(samples)
+        SpreadsheetFormatterSampleList spreadsheetFormatterSampleList;
+
+        if (samples instanceof SpreadsheetFormatterSampleList) {
+            spreadsheetFormatterSampleList = (SpreadsheetFormatterSampleList) samples;
+        } else {
+            final List<SpreadsheetFormatterSample> copy = Lists.array();
+            for (final SpreadsheetFormatterSample sample : samples) {
+                copy.add(
+                        Objects.requireNonNull(sample, "includes null sample")
                 );
+            }
+
+            switch (samples.size()) {
+                case 0:
+                    spreadsheetFormatterSampleList = EMPTY;
+                    break;
+                default:
+                    spreadsheetFormatterSampleList = new SpreadsheetFormatterSampleList(copy);
+                    break;
+            }
+        }
+
+        return spreadsheetFormatterSampleList;
     }
 
     private SpreadsheetFormatterSampleList(final List<SpreadsheetFormatterSample> samples) {

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSampleListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSampleListTest.java
@@ -113,6 +113,25 @@ public class SpreadsheetFormatterSampleListTest implements ListTesting2<Spreadsh
         );
     }
 
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        SAMPLE1,
+                                        SAMPLE2,
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "includes null sample",
+                thrown.getMessage()
+        );
+    }
+
     @Override
     public SpreadsheetFormatterSampleList createList() {
         return SpreadsheetFormatterSampleList.with(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6448
- SpreadsheetFormatterSampleList.setElements should null check elements