### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.setElements incl…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.java
@@ -70,6 +70,10 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesList extends 
         final Set<SpreadsheetSelection> duplicates = SortedSets.tree(SpreadsheetSelection.IGNORES_REFERENCE_KIND_COMPARATOR);
 
         for (final SpreadsheetColumnOrRowSpreadsheetComparatorNames columnOrRowComparators : comparatorNames) {
+            if(null == columnOrRowComparators) {
+                throw new NullPointerException("Includes null names");
+            }
+
             final SpreadsheetColumnOrRowReferenceOrRange columnOrRow = columnOrRowComparators.columnOrRow();
 
             if (false == duplicates.isEmpty()) {

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest.java
@@ -325,6 +325,29 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorNamesListTest impl
         );
     }
 
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        SpreadsheetColumnOrRowSpreadsheetComparatorNames.with(
+                                                SpreadsheetSelection.parseRow("1"),
+                                                Lists.of(
+                                                        SpreadsheetComparatorNameAndDirection.parse("text UP")
+                                                )
+                                        ),
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "Includes null names",
+                thrown.getMessage()
+        );
+    }
+
     @Override
     public SpreadsheetColumnOrRowSpreadsheetComparatorNamesList createList() {
         return Cast.to(


### PR DESCRIPTION
…udes null check

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6451
- SpreadsheetColumnOrRowSpreadsheetComparatorNamesList.setElements should null check elements