### PR TITLE
SpreadsheetColumnOrRowSpreadsheetComparatorsList.setElements includes…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsList.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsList.java
@@ -55,6 +55,8 @@ final class SpreadsheetColumnOrRowSpreadsheetComparatorsList extends AbstractLis
         int i = 0;
 
         for (final SpreadsheetColumnOrRowSpreadsheetComparators columnOrRowComparators : columnOrRows) {
+            Objects.requireNonNull(columnOrRowComparators, "Includes null comparator");
+
             final SpreadsheetColumnOrRowReferenceOrRange columnOrRow = columnOrRowComparators.columnOrRow();
             if (null == first) {
                 first = columnOrRow.columnOrRowReferenceKind();

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetColumnOrRowSpreadsheetComparatorsListTest.java
@@ -29,6 +29,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.text.HasTextTesting;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetColumnOrRowSpreadsheetComparatorsListTest implements ImmutableListTesting<SpreadsheetColumnOrRowSpreadsheetComparatorsList, SpreadsheetColumnOrRowSpreadsheetComparators>,
         ClassTesting<SpreadsheetColumnOrRowSpreadsheetComparatorsList>,
@@ -112,6 +113,29 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparatorsListTest implemen
                                 SpreadsheetComparatorProviders.spreadsheetComparators(),
                                 PROVIDER_CONTEXT
                         )
+        );
+    }
+
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        SpreadsheetColumnOrRowSpreadsheetComparators.with(
+                                                SpreadsheetSelection.parseColumn("A"),
+                                                Lists.of(
+                                                        SpreadsheetComparators.text()
+                                                )
+                                        ),
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "Includes null comparator",
+                thrown.getMessage()
         );
     }
 


### PR DESCRIPTION
… null check

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6450
- SpreadsheetColumnOrRowSpreadsheetComparatorsList.setElements should null check elements