### PR TITLE
SpreadsheetFormatterSelectorTokenList.setElements includes null check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSelectorTokenList.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSelectorTokenList.java
@@ -61,14 +61,30 @@ import java.util.Objects;
 public final class SpreadsheetFormatterSelectorTokenList extends AbstractList<SpreadsheetFormatterSelectorToken>
         implements ImmutableListDefaults<SpreadsheetFormatterSelectorTokenList, SpreadsheetFormatterSelectorToken> {
 
+    public final static SpreadsheetFormatterSelectorTokenList EMPTY = new SpreadsheetFormatterSelectorTokenList(Lists.empty());
+
     public static SpreadsheetFormatterSelectorTokenList with(final List<SpreadsheetFormatterSelectorToken> tokens) {
         Objects.requireNonNull(tokens, "tokens");
 
-        return tokens instanceof SpreadsheetFormatterSelectorTokenList ?
-                (SpreadsheetFormatterSelectorTokenList) tokens :
-                new SpreadsheetFormatterSelectorTokenList(
-                        Lists.immutable(tokens)
+        SpreadsheetFormatterSelectorTokenList spreadsheetFormatterSelectorTokens;
+
+        if (tokens instanceof SpreadsheetFormatterSelectorTokenList) {
+            spreadsheetFormatterSelectorTokens = (SpreadsheetFormatterSelectorTokenList) tokens;
+        } else {
+            final List<SpreadsheetFormatterSelectorToken> copy = Lists.array();
+            for (final SpreadsheetFormatterSelectorToken token : tokens) {
+                copy.add(
+                        Objects.requireNonNull(token, "Includes null token")
                 );
+            }
+
+            spreadsheetFormatterSelectorTokens =
+                    copy.isEmpty() ?
+                            EMPTY :
+                            new SpreadsheetFormatterSelectorTokenList(copy);
+        }
+
+        return spreadsheetFormatterSelectorTokens;
     }
 
     private SpreadsheetFormatterSelectorTokenList(final List<SpreadsheetFormatterSelectorToken> tokens) {

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSelectorTokenListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSelectorTokenListTest.java
@@ -116,6 +116,24 @@ public class SpreadsheetFormatterSelectorTokenListTest implements ListTesting2<S
         );
     }
 
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        COMPONENT1,
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "Includes null token",
+                thrown.getMessage()
+        );
+    }
+
     @Override
     public SpreadsheetFormatterSelectorTokenList createList() {
         return SpreadsheetFormatterSelectorTokenList.with(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6447
- SpreadsheetFormatterSelectorTokenList.setElements should null check elements