### PR TITLE
SpreadsheetParserSelectorTokenList.setElements includes null check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserSelectorTokenList.java
+++ b/src/main/java/walkingkooka/spreadsheet/parser/SpreadsheetParserSelectorTokenList.java
@@ -60,14 +60,30 @@ import java.util.Objects;
 public final class SpreadsheetParserSelectorTokenList extends AbstractList<SpreadsheetParserSelectorToken>
         implements ImmutableListDefaults<SpreadsheetParserSelectorTokenList, SpreadsheetParserSelectorToken> {
 
+    public final static SpreadsheetParserSelectorTokenList EMPTY = new SpreadsheetParserSelectorTokenList(Lists.empty());
+
     public static SpreadsheetParserSelectorTokenList with(final List<SpreadsheetParserSelectorToken> tokens) {
         Objects.requireNonNull(tokens, "tokens");
 
-        return tokens instanceof SpreadsheetParserSelectorTokenList ?
-                (SpreadsheetParserSelectorTokenList) tokens :
-                new SpreadsheetParserSelectorTokenList(
-                        Lists.immutable(tokens)
+        SpreadsheetParserSelectorTokenList spreadsheetParserSelectorTokens;
+
+        if (tokens instanceof SpreadsheetParserSelectorTokenList) {
+            spreadsheetParserSelectorTokens = (SpreadsheetParserSelectorTokenList) tokens;
+        } else {
+            final List<SpreadsheetParserSelectorToken> copy = Lists.array();
+            for (final SpreadsheetParserSelectorToken token : tokens) {
+                copy.add(
+                        Objects.requireNonNull(token, "Includes null token")
                 );
+            }
+
+            spreadsheetParserSelectorTokens =
+                    copy.isEmpty() ?
+                            EMPTY :
+                            new SpreadsheetParserSelectorTokenList(copy);
+        }
+
+        return spreadsheetParserSelectorTokens;
     }
 
     private SpreadsheetParserSelectorTokenList(final List<SpreadsheetParserSelectorToken> tokens) {

--- a/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserSelectorTokenListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/parser/SpreadsheetParserSelectorTokenListTest.java
@@ -116,6 +116,24 @@ public class SpreadsheetParserSelectorTokenListTest implements ListTesting2<Spre
         );
     }
 
+    @Test
+    public void testSetElementsIncludesNullFails() {
+        final NullPointerException thrown = assertThrows(
+                NullPointerException.class,
+                () -> this.createList()
+                        .setElements(
+                                Lists.of(
+                                        COMPONENT1,
+                                        null
+                                )
+                        )
+        );
+        this.checkEquals(
+                "Includes null token",
+                thrown.getMessage()
+        );
+    }
+
     @Override
     public SpreadsheetParserSelectorTokenList createList() {
         return SpreadsheetParserSelectorTokenList.with(


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6446
- SpreadsheetParserSelectorTokenList.setElements should null check elements