### PR TITLE
SpreadsheetMetadata.dateTimeContext checks-DATE_TIME_SYMBOLS property

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -539,10 +539,16 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
 
         missing.reportIfMissing();
 
+        DateTimeSymbols dateTimeSymbols = this.get(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS)
+                .orElse(null);
+        if (null == dateTimeSymbols) {
+            dateTimeSymbols = DateTimeSymbols.fromDateFormatSymbols(
+                    new DateFormatSymbols(locale)
+            );
+        }
+
         return DateTimeContexts.basic(
-                DateTimeSymbols.fromDateFormatSymbols(
-                        new DateFormatSymbols(locale)
-                ),
+                dateTimeSymbols,
                 locale,
                 defaultYear,
                 twoYearDigit,

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -27,6 +27,7 @@ import walkingkooka.collect.set.SortedSets;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
+import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberSymbols;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.net.Url;
@@ -139,11 +140,13 @@ import walkingkooka.validation.provider.ValidatorSelector;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -4533,6 +4536,58 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                         ).get()
                                 )
                                 .root()
+                )
+        );
+
+        this.saveCellAndCheck(
+                engine,
+                a1Cell,
+                context,
+                SpreadsheetDelta.EMPTY
+                        .setCells(
+                                Sets.of(a1FormattedCell)
+                        ).setColumnWidths(
+                                columnWidths("A")
+                        ).setRowHeights(
+                                rowHeights("1")
+                        ).setColumnCount(
+                                OptionalInt.of(1)
+                        ).setRowCount(
+                                OptionalInt.of(1)
+                        )
+        );
+    }
+
+    @Test
+    public void testSaveCellWithMetadataDateTimeSymbols() {
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine();
+
+        final SpreadsheetMetadata metadata = METADATA.set(
+                SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS,
+                DateTimeSymbols.fromDateFormatSymbols(
+                        new DateFormatSymbols(Locale.FRANCE)
+                )
+        ).set(
+                SpreadsheetMetadataPropertyName.DATE_TIME_FORMATTER,
+                SpreadsheetFormatterSelector.parse("date-time-format-pattern ddd/mmmm/yyyy")
+        );
+        final SpreadsheetEngineContext context = this.createContext(metadata);
+
+        final LocalDateTime value = LocalDateTime.of(1999, 12, 31, 12, 58, 59);
+
+        final SpreadsheetFormula a1Formula = SpreadsheetFormula.EMPTY.setInputValue(
+                Optional.of(value)
+        );
+        final SpreadsheetCell a1Cell = SpreadsheetSelection.A1.setFormula(a1Formula)
+                .setStyle(STYLE);
+
+        final SpreadsheetCell a1FormattedCell = a1Cell.setFormattedValue(
+                Optional.of(
+                        STYLE.setChildren(
+                                Lists.of(
+                                        TextNode.text("ven./décembre/1999")
+                                )
+                        )
                 )
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1497,7 +1497,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
     // HasDateTimeContext...............................................................................................
 
     @Test
-    public void testDateTimeContext() {
+    public void testDateTimeContextMissingDateTimeSymbols() {
         Arrays.stream(Locale.getAvailableLocales())
                 .forEach(l -> {
                             final int twoDigitYear = 49;
@@ -1517,6 +1517,29 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
                         }
                 );
+    }
+
+    @Test
+    public void testDateTimeContextWithDateTimeSymbols() {
+        final Locale locale = Locale.forLanguageTag("FR");
+
+        final DateTimeSymbols dateTimeSymbols = DateTimeSymbols.fromDateFormatSymbols(
+                new DateFormatSymbols(locale)
+        );
+
+        final int twoDigitYear = 49;
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY
+                .set(SpreadsheetMetadataPropertyName.DEFAULT_YEAR, DEFAULT_YEAR)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, locale)
+                .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, twoDigitYear);
+
+        final DateTimeContext context = metadata.dateTimeContext(NOW);
+
+        this.checkEquals(
+                dateTimeSymbols,
+                context.dateTimeSymbols(),
+                "dateTimeSymbols"
+        );
     }
 
     // HasDecimalNumberContext..........................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest.java
@@ -367,7 +367,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest e
                 METADATA.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         Locale.forLanguageTag("ES")
-                ),
+                ).remove(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS),
                 SPREADSHEET_PARSER_PROVIDER,
                 PROVIDER_CONTEXT
         );
@@ -442,7 +442,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest e
                 METADATA.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         Locale.forLanguageTag("ES")
-                ),
+                ).remove(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS),
                 SPREADSHEET_PARSER_PROVIDER,
                 PROVIDER_CONTEXT
         );
@@ -510,7 +510,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest e
                 METADATA.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         Locale.forLanguageTag("ES")
-                ),
+                ).remove(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS),
                 SPREADSHEET_PARSER_PROVIDER,
                 PROVIDER_CONTEXT
         );
@@ -576,7 +576,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest e
                 METADATA.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         Locale.forLanguageTag("ES")
-                ),
+                ).remove(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS),
                 SPREADSHEET_PARSER_PROVIDER,
                 PROVIDER_CONTEXT
         );
@@ -769,7 +769,7 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreTest e
                 METADATA.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         Locale.forLanguageTag("ES")
-                ),
+                ).remove(SpreadsheetMetadataPropertyName.DATE_TIME_SYMBOLS),
                 SPREADSHEET_PARSER_PROVIDER,
                 PROVIDER_CONTEXT
         );


### PR DESCRIPTION
- TODO formatting needs to check SpreadsheetCell#dateTimeSymbols