### PR TITLE
SpreadsheetNumberParsePattern honours SpreadsheetParserContext.zeroDigit

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentDigit.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentDigit.java
@@ -76,11 +76,7 @@ abstract class SpreadsheetNumberParsePatternComponentDigit extends SpreadsheetNu
             }
 
             final char c = cursor.at();
-
-            final int digit = Character.digit(
-                    c,
-                    10
-            );
+            final int digit = context.digit(c);
             if (-1 != digit) {
                 request.digits.append(c);
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTestCase.java
@@ -47,6 +47,7 @@ public abstract class SpreadsheetNumberParsePatternTestCase<T> implements ClassT
     final static char PLUS = 'p';
     final static char MINUS = 'm';
     final static char DECIMAL = 'd';
+    final static char ZERO = '0';
 
     @Override
     public final DecimalNumberContext decimalNumberContext() {
@@ -87,6 +88,11 @@ public abstract class SpreadsheetNumberParsePatternTestCase<T> implements ClassT
             }
 
             @Override
+            public char zeroDigit() {
+                return ZERO;
+            }
+
+            @Override
             public MathContext mathContext() {
                 return MathContext.UNLIMITED;
             }
@@ -101,6 +107,7 @@ public abstract class SpreadsheetNumberParsePatternTestCase<T> implements ClassT
                         .label("negativeSign").value(this.negativeSign())
                         .label("percentSymbol").value(this.percentSymbol())
                         .label("positiveSign").value(this.positiveSign())
+                        .label("zeroDigit").value(this.zeroDigit())
                         .label("mathContext").value(this.mathContext())
                         .build();
             }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
@@ -89,6 +89,7 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
     final static char MINUS = 'm';
     final static char PERCENT = 'q';
     final static char PLUS = 'p';
+    final static char ZERO = '0';
 
     SpreadsheetParsePatternTestCase() {
         super();
@@ -543,6 +544,11 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
             @Override
             public char positiveSign() {
                 return PLUS;
+            }
+
+            @Override
+            public char zeroDigit() {
+                return ZERO;
             }
         };
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetPatternTest.java
@@ -1458,6 +1458,11 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     public char positiveSign() {
                         return '+';
                     }
+
+                    @Override
+                    public char zeroDigit() {
+                        return '0';
+                    }
                 },
                 "1.5",
                 SpreadsheetFormulaParserToken.number(
@@ -1500,6 +1505,11 @@ public final class SpreadsheetPatternTest implements ClassTesting2<SpreadsheetPa
                     @Override
                     public char positiveSign() {
                         return '+';
+                    }
+
+                    @Override
+                    public char zeroDigit() {
+                        return '0';
                     }
                 },
                 "1.5*",

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaParsersTest.java
@@ -4313,6 +4313,11 @@ public final class SpreadsheetFormulaParsersTest implements PublicStaticHelperTe
             }
 
             @Override
+            public char zeroDigit() {
+                return decimalNumberContext.zeroDigit();
+            }
+
+            @Override
             public Locale locale() {
                 return decimalNumberContext.locale();
             }


### PR DESCRIPTION
- Previously parsing always assumed '0' - '9' and ignored SpreadsheetParserContext.zeroDigit() this has been fixed.