### PR TITLE
SpreadsheetMetadata.parserContext Optional<SpreadsheetCell>

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -1456,7 +1456,10 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                                     ) // SpreadsheetEngineContext implements SpreadsheetParserProvider
                                             )
                                     ),
-                            metadata.spreadsheetParserContext(context)
+                            metadata.spreadsheetParserContext(
+                                    Optional.of(cell),
+                                    context
+                            )
                     );
 
                     token = formula.token()

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -36,7 +36,6 @@ import walkingkooka.spreadsheet.formula.SpreadsheetFormulaParsers;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
 import walkingkooka.spreadsheet.provider.SpreadsheetProviderDelegator;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -121,8 +120,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
         this.functionAliases = functionAliases;
         this.spreadsheetProvider = spreadsheetProvider;
         this.providerContext = providerContext;
-
-        this.parserContext = metadata.spreadsheetParserContext(providerContext);
     }
 
     @Override
@@ -171,7 +168,8 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
     // parsing formula and executing....................................................................................
 
     @Override
-    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
+    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                      final Optional<SpreadsheetCell> cell) {
         return SpreadsheetFormulaParsers.valueOrExpression(
                         this.metadata.spreadsheetParser(
                                 this, // SpreadsheetParserProvider
@@ -179,15 +177,15 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
                         )
                 )
                 .orFailIfCursorNotEmpty(ParserReporters.basic())
-                .parse(formula, this.parserContext)
-                .get()
+                .parse(
+                        formula,
+                        this.metadata.spreadsheetParserContext(
+                                cell,
+                                this // HasNow
+                        )
+                ).get()
                 .cast(SpreadsheetFormulaParserToken.class);
     }
-
-    /**
-     * This parser is used to parse strings, date, date/time, time and numbers outside an expression but within a formula.
-     */
-    private final SpreadsheetParserContext parserContext;
 
     @Override
     public Optional<Expression> toExpression(final SpreadsheetFormulaParserToken token) {

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetEngineContext.java
@@ -79,8 +79,12 @@ final class BasicSpreadsheetEngineSpreadsheetEngineContext implements Spreadshee
     }
 
     @Override
-    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
-        return this.spreadsheetEngineContext.parseFormula(formula);
+    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                      final Optional<SpreadsheetCell> cell) {
+        return this.spreadsheetEngineContext.parseFormula(
+                formula,
+                cell
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -83,8 +83,11 @@ public class FakeSpreadsheetEngineContext extends FakeSpreadsheetProvider implem
     // formula..........................................................................................................
 
     @Override
-    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
+    public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                      final Optional<SpreadsheetCell> cell) {
         Objects.requireNonNull(formula, "formula");
+        Objects.requireNonNull(cell, "cell");
+
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -82,7 +82,8 @@ public interface SpreadsheetEngineContext extends Context,
     /**
      * Parses the formula into an {@link SpreadsheetFormulaParserToken} which can then be transformed into an {@link Expression}.
      */
-    SpreadsheetFormulaParserToken parseFormula(final TextCursor formula);
+    SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                               final Optional<SpreadsheetCell> cell);
 
     // toExpression.....................................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegator.java
@@ -61,9 +61,13 @@ public interface SpreadsheetEngineContextDelegator extends SpreadsheetEngineCont
     }
 
     @Override
-    default SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
+    default SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                       final Optional<SpreadsheetCell> cell) {
         return this.spreadsheetEngineContext()
-                .parseFormula(formula);
+                .parseFormula(
+                        formula,
+                        cell
+                );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextTesting.java
@@ -69,24 +69,69 @@ public interface SpreadsheetEngineContextTesting<C extends SpreadsheetEngineCont
     // parseFormula......................................................................................................
 
     @Test
-    default void testParseFormulaNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createContext().parseFormula(null));
+    default void testParseFormulaNullTextFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext()
+                        .parseFormula(
+                                null,
+                                SpreadsheetEngineContext.NO_CELL
+                        )
+        );
+    }
+
+    @Test
+    default void testParseFormulaNullCellFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createContext()
+                        .parseFormula(
+                                TextCursors.fake(),
+                                null
+                        )
+        );
     }
 
     default void parseFormulaAndCheck(final String expression,
                                       final SpreadsheetFormulaParserToken expected) {
-        this.parseFormulaAndCheck(this.createContext(),
+        this.parseFormulaAndCheck(
                 expression,
-                expected);
+                SpreadsheetEngineContext.NO_CELL,
+                expected
+        );
+    }
+
+    default void parseFormulaAndCheck(final String expression,
+                                      final Optional<SpreadsheetCell> cell,
+                                      final SpreadsheetFormulaParserToken expected) {
+        this.parseFormulaAndCheck(
+                this.createContext(),
+                expression,
+                cell,
+                expected
+        );
     }
 
     default void parseFormulaAndCheck(final SpreadsheetEngineContext context,
                                       final String formula,
                                       final SpreadsheetFormulaParserToken expected) {
+        this.parseFormulaAndCheck(
+                context,
+                formula,
+                SpreadsheetEngineContext.NO_CELL,
+                expected
+        );
+    }
+
+    default void parseFormulaAndCheck(final SpreadsheetEngineContext context,
+                                      final String formula,
+                                      final Optional<SpreadsheetCell> cell,
+                                      final SpreadsheetFormulaParserToken expected) {
         this.checkEquals(
                 expected,
                 context.parseFormula(
-                        TextCursors.charSequence(formula)
+                        TextCursors.charSequence(formula),
+                        cell
                 ),
                 () -> "parseFormula " + formula + " with context " + context);
     }

--- a/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
@@ -166,7 +166,10 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
         Objects.requireNonNull(expression, "expression");
 
         final SpreadsheetParserContext parserContext = this.spreadsheetMetadata()
-                .spreadsheetParserContext(this.spreadsheetConverterContext);
+                .spreadsheetParserContext(
+                        this.cell,
+                        this.spreadsheetConverterContext
+                );
 
         return SpreadsheetFormulaParsers.expression()
                 .orFailIfCursorNotEmpty(ParserReporters.basic())

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1170,14 +1170,15 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
     /**
      * Returns a {@link SpreadsheetParserContext}.
      */
-    public final SpreadsheetParserContext spreadsheetParserContext(final HasNow now) {
+    public final SpreadsheetParserContext spreadsheetParserContext(final Optional<SpreadsheetCell> cell,
+                                                                   final HasNow now) {
         final SpreadsheetMetadataMissingComponents missing = SpreadsheetMetadataMissingComponents.with(this);
 
         // DateTimeContext
         DateTimeContext dateTimeContext;
         try {
             dateTimeContext = this.dateTimeContext(
-                NO_CELL,
+                cell,
                 now
             );
         } catch (final MissingMetadataPropertiesException cause) {
@@ -1188,7 +1189,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         // ExpressionNumberContext
         ExpressionNumberContext expressionNumberContext;
         try {
-            expressionNumberContext = this.expressionNumberContext(SpreadsheetMetadata.NO_CELL);
+            expressionNumberContext = this.expressionNumberContext(cell);
         } catch (final MissingMetadataPropertiesException cause) {
             missing.addMissing(cause);
             expressionNumberContext = null;

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -406,7 +406,10 @@ public interface SpreadsheetMetadataTesting extends Testing {
 
     JsonNodeUnmarshallContext JSON_NODE_UNMARSHALL_CONTEXT = METADATA_EN_AU.jsonNodeUnmarshallContext();
 
-    SpreadsheetParserContext SPREADSHEET_PARSER_CONTEXT = METADATA_EN_AU.spreadsheetParserContext(NOW);
+    SpreadsheetParserContext SPREADSHEET_PARSER_CONTEXT = METADATA_EN_AU.spreadsheetParserContext(
+            SpreadsheetMetadata.NO_CELL,
+            NOW
+    );
 
     SpreadsheetProvider SPREADSHEET_PROVIDER = METADATA_EN_AU.spreadsheetProvider(
             SpreadsheetProviders.basic(

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore.java
@@ -137,7 +137,10 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore imple
                     .orElse(null);
             try {
                 if (null == token) {
-                    token = this.parseFormulaTextExpression(text);
+                    token = this.parseFormulaTextExpression(
+                            text,
+                            cell
+                    );
                     formula = formula
                             .setToken(Optional.of(token));
                 }
@@ -165,7 +168,8 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore imple
     /**
      * Parses the formula text into an {@link SpreadsheetFormulaParserToken}.
      */
-    private SpreadsheetFormulaParserToken parseFormulaTextExpression(final String text) {
+    private SpreadsheetFormulaParserToken parseFormulaTextExpression(final String text,
+                                                                     final SpreadsheetCell cell) {
         final SpreadsheetMetadata metadata = this.metadata;
         final ProviderContext providerContext = this.providerContext;
 
@@ -175,7 +179,10 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStore imple
                 ).orFailIfCursorNotEmpty(ParserReporters.basic())
                 .parse(
                         TextCursors.charSequence(text),
-                        metadata.spreadsheetParserContext(providerContext)
+                        metadata.spreadsheetParserContext(
+                                Optional.of(cell),
+                                providerContext
+                        )
                 ).orElse(null)
                 .cast(SpreadsheetFormulaParserToken.class);
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -618,7 +618,8 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
         this.toExpressionAndCheck(
                 context,
                 context.parseFormula(
-                        TextCursors.charSequence("=1+2")
+                        TextCursors.charSequence("=1+2"),
+                        SpreadsheetEngineContext.NO_CELL
                 ),
                 Expression.add(
                         Expression.value(

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -496,7 +496,8 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
             }
 
             @Override
-            public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
+            public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                              final Optional<SpreadsheetCell> cell) {
                 final TextCursorSavePoint beginning = formula.save();
                 formula.end();
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
@@ -197,7 +197,10 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
     public void testSpreadsheetParserContextAllRequiredPropertiesAbsentFails() {
         final IllegalStateException thrown = assertThrows(
                 IllegalStateException.class,
-                () -> SpreadsheetMetadata.EMPTY.spreadsheetParserContext(LocalDateTime::now)
+                () -> SpreadsheetMetadata.EMPTY.spreadsheetParserContext(
+                        SpreadsheetMetadata.NO_CELL,
+                        LocalDateTime::now
+                )
         );
         this.checkEquals(
                 "Metadata missing: defaultYear, expressionNumberKind, locale, precision, roundingMode, twoDigitYear, valueSeparator",
@@ -211,7 +214,10 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
         final IllegalStateException thrown = assertThrows(
                 IllegalStateException.class,
                 () -> SpreadsheetMetadata.EMPTY
-                        .spreadsheetParserContext(LocalDateTime::now)
+                        .spreadsheetParserContext(
+                                SpreadsheetMetadata.NO_CELL,
+                                LocalDateTime::now
+                        )
         );
         this.checkEquals(
                 "Metadata missing: defaultYear, expressionNumberKind, locale, precision, roundingMode, twoDigitYear, valueSeparator",

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -2015,7 +2015,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 ).parse(
                         cursor,
                         this.metadataWithSpreadsheetParserContext()
-                                .spreadsheetParserContext(NOW)
+                                .spreadsheetParserContext(
+                                        SpreadsheetMetadata.NO_CELL,
+                                        NOW
+                                )
                 ).orElseThrow(() -> new AssertionError("parser failed"));
         this.checkEquals(true, cursor.isEmpty(), () -> cursor + " is not empty");
 
@@ -2042,7 +2045,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
 
         this.checkNotEquals(
                 null,
-                metadata.spreadsheetParserContext(NOW)
+                metadata.spreadsheetParserContext(
+                        SpreadsheetMetadata.NO_CELL,
+                        NOW
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingTest.java
@@ -116,6 +116,9 @@ public final class SpreadsheetMetadataTestingTest implements SpreadsheetMetadata
     @Test
     public void testSpreadsheetParserContext() {
         METADATA_EN_AU
-                .spreadsheetParserContext(LocalDateTime::now);
+                .spreadsheetParserContext(
+                        SpreadsheetMetadata.NO_CELL,
+                        LocalDateTime::now
+                );
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -286,13 +286,17 @@ public final class Sample {
             }
 
             @Override
-            public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula) {
+            public SpreadsheetFormulaParserToken parseFormula(final TextCursor formula,
+                                                              final Optional<SpreadsheetCell> cell) {
                 return Cast.to(
                         SpreadsheetFormulaParsers.expression()
                                 .orFailIfCursorNotEmpty(ParserReporters.basic())
                                 .parse(
                                         formula,
-                                        metadata.spreadsheetParserContext(NOW)
+                                        metadata.spreadsheetParserContext(
+                                                cell,
+                                                NOW
+                                        )
                                 ) // TODO should fetch parse metadata prop
                                 .get()
                 );


### PR DESCRIPTION
- The SpreadsheetCell#dateTimeSymbols/#decimalNumberSymbols properties will be used to create a SpreadsheetParserContext

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6581
- SpreadsheetMetadata.spreadsheetParserContext requires Optional<SpreadsheetCell> parameter