### PR TITLE
SpreadsheetCellValueKind.DECIMAL_NUMBER_SYMBOLS, VALIDATOR

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellValueKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellValueKind.java
@@ -38,6 +38,13 @@ public enum SpreadsheetCellValueKind {
         }
     },
 
+    DECIMAL_NUMBER_SYMBOLS {
+        @Override
+        public Object cellValue(final SpreadsheetCell cell) {
+            return cell.decimalNumberSymbols();
+        }
+    },
+
     FORMULA {
         @Override
         public Object cellValue(final SpreadsheetCell cell) {
@@ -63,6 +70,13 @@ public enum SpreadsheetCellValueKind {
         @Override
         public Object cellValue(final SpreadsheetCell cell) {
             return cell.style();
+        }
+    },
+
+    VALIDATOR {
+        @Override
+        public Object cellValue(final SpreadsheetCell cell) {
+            return cell.validator();
         }
     },
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6613
- SpreadsheetCellValueKind missing DECIMAL_NUMBER_SYMBOLS

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6614
- SpreadsheetCellValueKind missing VALIDATOR