### PR TITLE
BasicSpreadsheetEngineContext.formatValueAndStyle formatter not found…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -4809,7 +4809,12 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                 SpreadsheetError.validationErrors(validationError)
                         )
         ).setFormattedValue(
-                Optional.of(TextNode.EMPTY_TEXT)
+                Optional.of(
+                        TextNode.text(
+                            SpreadsheetError.formatterNotFound(value)
+                                    .text()
+                        )
+                )
         );
 
         this.saveCellAndCheck(
@@ -4955,7 +4960,12 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                 SpreadsheetError.validationErrors(converterOutput)
                         )
         ).setFormattedValue(
-                Optional.of(TextNode.EMPTY_TEXT)
+                Optional.of(
+                        TextNode.text(
+                                SpreadsheetError.formatterNotFound(value)
+                                        .text()
+                        )
+                )
         );
 
         this.saveCellAndCheck(


### PR DESCRIPTION
… Error was emptytext FIX 2/2

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6765
- BasicSpreadsheetEngine.formatValueAndStyle returns TextNode.EMPTY_TEXT if unable to find a formatter that can format value.