### PR TITLE
LocaleContext.dateTimeSymbolsForLocale replaces new DateFormatSymbol(…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -810,13 +810,19 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Date, DateTime and Time defaults are loaded parse {@link java.text.DateFormat} using the provided locale, formats pick the FULL style,
      * while parse pattern will include all patterns with all styles.
      */
-    public final SpreadsheetMetadata loadFromLocale() {
-        final Locale locale = this.getOrFail(SpreadsheetMetadataPropertyName.LOCALE);
+    public final SpreadsheetMetadata loadFromLocale(final LocaleContext context) {
+        return loadFromLocale0(
+                this.localeContext(
+                        Objects.requireNonNull(context, "context")
+                )
+        );
+    }
 
+    private SpreadsheetMetadata loadFromLocale0(final LocaleContext context) {
         SpreadsheetMetadata updated = this;
 
         for (final SpreadsheetMetadataPropertyName<?> propertyName : SpreadsheetMetadataPropertyName.CONSTANTS.values()) {
-            final Optional<?> localeAwareValue = propertyName.extractLocaleAwareValue(locale);
+            final Optional<?> localeAwareValue = propertyName.extractLocaleAwareValue(context);
             if (localeAwareValue.isPresent()) {
                 updated = updated.set(
                         propertyName,

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -26,6 +26,7 @@ import walkingkooka.convert.provider.ConverterName;
 import walkingkooka.convert.provider.ConverterSelector;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.environment.AuditInfo;
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.math.DecimalNumberSymbols;
 import walkingkooka.naming.Name;
 import walkingkooka.net.HasUrlFragment;
@@ -551,7 +552,7 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     /**
      * Some properties support providing a value for the given Locale for the parent {@link SpreadsheetMetadata} to be updated.
      */
-    abstract Optional<T> extractLocaleAwareValue(final Locale locale);
+    abstract Optional<T> extractLocaleAwareValue(final LocaleContext context);
 
     // SpreadsheetMetadataVisitor.......................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfo.java
@@ -18,8 +18,8 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.environment.AuditInfo;
+import walkingkooka.locale.LocaleContext;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -61,7 +61,7 @@ final class SpreadsheetMetadataPropertyNameAuditInfo extends SpreadsheetMetadata
     }
 
     @Override
-    Optional<AuditInfo> extractLocaleAwareValue(final Locale locale) {
+    Optional<AuditInfo> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
@@ -17,7 +17,8 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import java.util.Locale;
+import walkingkooka.locale.LocaleContext;
+
 import java.util.Optional;
 
 /**
@@ -43,7 +44,7 @@ abstract class SpreadsheetMetadataPropertyNameBoolean extends SpreadsheetMetadat
     }
 
     @Override
-    final Optional<Boolean> extractLocaleAwareValue(final Locale locale) {
+    final Optional<Boolean> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // always empty
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
@@ -17,10 +17,10 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.text.CharSequences;
 
 import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -50,8 +50,14 @@ abstract class SpreadsheetMetadataPropertyNameCharacter extends SpreadsheetMetad
     }
 
     @Override
-    final Optional<Character> extractLocaleAwareValue(final Locale locale) {
-        return Optional.of(this.extractLocaleValueCharacter(DecimalFormatSymbols.getInstance(locale)));
+    final Optional<Character> extractLocaleAwareValue(final LocaleContext context) {
+        return Optional.of(
+                this.extractLocaleValueCharacter(
+                        DecimalFormatSymbols.getInstance(
+                                context.locale()
+                        )
+                )
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterAliasSet.java
@@ -18,8 +18,8 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.convert.provider.ConverterAliasSet;
+import walkingkooka.locale.LocaleContext;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameConverterAliasSet extends Spreadsh
     }
 
     @Override
-    final Optional<ConverterAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<ConverterAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterSelector.java
@@ -18,8 +18,8 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.convert.provider.ConverterSelector;
+import walkingkooka.locale.LocaleContext;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameConverterSelector extends Spreadsh
     }
 
     @Override
-    final Optional<ConverterSelector> extractLocaleAwareValue(final Locale locale) {
+    final Optional<ConverterSelector> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
@@ -17,7 +17,8 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import java.util.Locale;
+import walkingkooka.locale.LocaleContext;
+
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMetadataPropertyName<Long> {
@@ -54,7 +55,7 @@ final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMet
     }
 
     @Override
-    Optional<Long> extractLocaleAwareValue(final Locale locale) {
+    Optional<Long> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // Unrelated to Locales
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbols.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbols.java
@@ -19,9 +19,8 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.datetime.DateTimeSymbols;
+import walkingkooka.locale.LocaleContext;
 
-import java.text.DateFormatSymbols;
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -63,11 +62,9 @@ final class SpreadsheetMetadataPropertyNameDateTimeSymbols extends SpreadsheetMe
     }
 
     @Override
-    Optional<DateTimeSymbols> extractLocaleAwareValue(final Locale locale) {
-        return Optional.of(
-                DateTimeSymbols.fromDateFormatSymbols(
-                        new DateFormatSymbols(locale)
-                )
+    Optional<DateTimeSymbols> extractLocaleAwareValue(final LocaleContext context) {
+        return context.dateTimeSymbolsForLocale(
+                context.locale()
         );
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbols.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbols.java
@@ -17,10 +17,10 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.math.DecimalNumberSymbols;
 
 import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameDecimalNumberSymbols extends SpreadsheetMetadataPropertyName<DecimalNumberSymbols> {
@@ -57,11 +57,13 @@ final class SpreadsheetMetadataPropertyNameDecimalNumberSymbols extends Spreadsh
     }
 
     @Override
-    Optional<DecimalNumberSymbols> extractLocaleAwareValue(final Locale locale) {
+    Optional<DecimalNumberSymbols> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.of(
                 DecimalNumberSymbols.fromDecimalFormatSymbols(
                         '+',
-                        new DecimalFormatSymbols(locale)
+                        new DecimalFormatSymbols(
+                                context.locale()
+                        )
                 )
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet.java
@@ -17,10 +17,10 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionFunctions;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ abstract class SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet extends
     }
 
     @Override
-    final Optional<ExpressionFunctionAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<ExpressionFunctionAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
-import java.util.Locale;
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends SpreadsheetMetadataPropertyName<ExpressionNumberKind> {
@@ -56,7 +56,7 @@ final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends Spreadsh
     }
 
     @Override
-    Optional<ExpressionNumberKind> extractLocaleAwareValue(final Locale locale) {
+    Optional<ExpressionNumberKind> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // ExpressionNumberKind have nothing todo with Locales
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQuery.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQuery.java
@@ -18,9 +18,9 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetCellQuery;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -57,7 +57,7 @@ final class SpreadsheetMetadataPropertyNameFindQuery extends SpreadsheetMetadata
     }
 
     @Override
-    Optional<SpreadsheetCellQuery> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetCellQuery> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerAliasSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameFormHandlerAliasSet extends Spread
     }
 
     @Override
-    final Optional<FormHandlerAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<FormHandlerAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.validation.form.provider.FormHandlerSelector;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameFormHandlerSelector extends Spread
     }
 
     @Override
-    final Optional<FormHandlerSelector> extractLocaleAwareValue(final Locale locale) {
+    final Optional<FormHandlerSelector> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
@@ -18,10 +18,10 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -61,7 +61,7 @@ final class SpreadsheetMetadataPropertyNameFrozenColumns extends SpreadsheetMeta
     }
 
     @Override
-    Optional<SpreadsheetColumnRangeReference> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetColumnRangeReference> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
@@ -19,10 +19,10 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -62,7 +62,7 @@ final class SpreadsheetMetadataPropertyNameFrozenRows extends SpreadsheetMetadat
     }
 
     @Override
-    Optional<SpreadsheetRowRangeReference> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetRowRangeReference> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
@@ -17,7 +17,8 @@
 
 package walkingkooka.spreadsheet.meta;
 
-import java.util.Locale;
+import walkingkooka.locale.LocaleContext;
+
 import java.util.Optional;
 
 abstract class SpreadsheetMetadataPropertyNameInteger extends SpreadsheetMetadataPropertyName<Integer> {
@@ -39,7 +40,7 @@ abstract class SpreadsheetMetadataPropertyNameInteger extends SpreadsheetMetadat
     }
 
     @Override
-    final Optional<Integer> extractLocaleAwareValue(final Locale locale) {
+    final Optional<Integer> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // Dont think width/precison/twoYearDigit are locale aware.
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
+
 import java.util.Locale;
 import java.util.Optional;
 
@@ -54,7 +56,7 @@ final class SpreadsheetMetadataPropertyNameLocale extends SpreadsheetMetadataPro
     }
 
     @Override
-    Optional<Locale> extractLocaleAwareValue(final Locale locale) {
+    Optional<Locale> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
@@ -18,11 +18,11 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.color.Color;
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.naming.Name;
 import walkingkooka.spreadsheet.SpreadsheetColors;
 import walkingkooka.text.CharSequences;
 
-import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -90,7 +90,7 @@ final class SpreadsheetMetadataPropertyNameNumberedColor extends SpreadsheetMeta
     }
 
     @Override
-    Optional<Color> extractLocaleAwareValue(final Locale locale) {
+    Optional<Color> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // colours are not Locale aware
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePluginNameSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePluginNameSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.plugin.PluginNameSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -55,7 +55,7 @@ final class SpreadsheetMetadataPropertyNamePluginNameSet extends SpreadsheetMeta
     }
 
     @Override
-    Optional<PluginNameSet> extractLocaleAwareValue(final Locale locale) {
+    Optional<PluginNameSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
@@ -17,8 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
+
 import java.math.RoundingMode;
-import java.util.Locale;
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetadataPropertyName<RoundingMode> {
@@ -55,7 +56,7 @@ final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetad
     }
 
     @Override
-    Optional<RoundingMode> extractLocaleAwareValue(final Locale locale) {
+    Optional<RoundingMode> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty(); // RoundingMode have nothing todo with Locales
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorNameList;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -62,7 +62,7 @@ final class SpreadsheetMetadataPropertyNameSortComparators extends SpreadsheetMe
     }
 
     @Override
-    Optional<SpreadsheetComparatorNameList> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetComparatorNameList> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet.java
@@ -18,9 +18,9 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet exte
     }
 
     @Override
-    final Optional<SpreadsheetComparatorAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<SpreadsheetComparatorAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.export.SpreadsheetExporterAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet extend
     }
 
     @Override
-    final Optional<SpreadsheetExporterAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<SpreadsheetExporterAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet exten
     }
 
     @Override
-    final Optional<SpreadsheetFormatterAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<SpreadsheetFormatterAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
@@ -55,8 +56,8 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector exten
     }
 
     @Override
-    final Optional<SpreadsheetFormatterSelector> extractLocaleAwareValue(final Locale locale) {
-        return this.extractLocaleAwareValueSpreadsheetFormatPattern(locale)
+    final Optional<SpreadsheetFormatterSelector> extractLocaleAwareValue(final LocaleContext context) {
+        return this.extractLocaleAwareValueSpreadsheetFormatPattern(context)
                 .map(SpreadsheetFormatPattern::spreadsheetFormatterSelector);
     }
 
@@ -64,7 +65,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector exten
      * For the given {@link Locale} return the default {@link SpreadsheetFormatPattern}, this will then be
      * converted into its {@link SpreadsheetFormatterSelector} equivalent.
      */
-    abstract Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale);
+    abstract Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context);
 
     @Override
     public final Class<SpreadsheetFormatterSelector> type() {

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDate.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDate.java
@@ -17,12 +17,12 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -54,9 +54,11 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDate exte
     }
 
     @Override
-    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale) {
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
         return Optional.of(
-                SpreadsheetPattern.dateFormatPatternLocale(locale)
+                SpreadsheetPattern.dateFormatPatternLocale(
+                        context.locale()
+                )
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTime.java
@@ -17,12 +17,12 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -54,9 +54,11 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTime 
     }
 
     @Override
-    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale) {
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
         return Optional.of(
-                SpreadsheetPattern.dateTimeFormatPatternLocale(locale)
+                SpreadsheetPattern.dateTimeFormatPatternLocale(
+                        context.locale()
+                )
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumber.java
@@ -17,13 +17,13 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 
 import java.text.DecimalFormat;
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -55,10 +55,12 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumber ex
     }
 
     @Override
-    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale) {
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
         return Optional.of(
                 SpreadsheetPattern.decimalFormat(
-                        (DecimalFormat) DecimalFormat.getInstance(locale)
+                        (DecimalFormat) DecimalFormat.getInstance(
+                                context.locale()
+                        )
                 ).toFormat()
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorText.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorText.java
@@ -17,11 +17,11 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -53,7 +53,7 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorText exte
     }
 
     @Override
-    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale) {
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
         return Optional.empty();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTime.java
@@ -17,12 +17,12 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -54,9 +54,11 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTime exte
     }
 
     @Override
-    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final Locale locale) {
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
         return Optional.of(
-                SpreadsheetPattern.timeFormatPatternLocale(locale)
+                SpreadsheetPattern.timeFormatPatternLocale(
+                        context.locale()
+                )
         );
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
@@ -18,9 +18,9 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.SpreadsheetId;
 
-import java.util.Locale;
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMetadataPropertyName<SpreadsheetId> {
@@ -57,7 +57,7 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMeta
     }
 
     @Override
-    Optional<SpreadsheetId> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetId> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet.java
@@ -18,9 +18,9 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.importer.SpreadsheetImporterAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -49,7 +49,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet extend
     }
 
     @Override
-    final Optional<SpreadsheetImporterAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<SpreadsheetImporterAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
@@ -18,9 +18,9 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.SpreadsheetName;
 
-import java.util.Locale;
 import java.util.Optional;
 
 final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMetadataPropertyName<SpreadsheetName> {
@@ -57,7 +57,7 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMe
     }
 
     @Override
-    Optional<SpreadsheetName> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetName> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParser.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
@@ -55,9 +56,10 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetParser extends Spreadsh
     }
 
     @Override
-    final Optional<SpreadsheetParserSelector> extractLocaleAwareValue(final Locale locale) {
-        return this.extractLocaleAwareValueSpreadsheetParsePattern(locale)
-                .map(SpreadsheetParsePattern::spreadsheetParserSelector);
+    final Optional<SpreadsheetParserSelector> extractLocaleAwareValue(final LocaleContext context) {
+        return this.extractLocaleAwareValueSpreadsheetParsePattern(
+                context.locale()
+        ).map(SpreadsheetParsePattern::spreadsheetParserSelector);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet extends 
     }
 
     @Override
-    final Optional<SpreadsheetParserAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<SpreadsheetParserAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
@@ -17,8 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
+
 import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.Optional;
 
 abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadataPropertyName<String> {
@@ -51,8 +52,14 @@ abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadata
     }
 
     @Override
-    final Optional<String> extractLocaleAwareValue(final Locale locale) {
-        return Optional.of(this.extractLocaleValueString(DecimalFormatSymbols.getInstance(locale)));
+    final Optional<String> extractLocaleAwareValue(final LocaleContext context) {
+        return Optional.of(
+                this.extractLocaleValueString(
+                        DecimalFormatSymbols.getInstance(
+                                context.locale()
+                        )
+                )
+        );
     }
 
     abstract String extractLocaleValueString(final DecimalFormatSymbols symbols);

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.tree.text.TextStyle;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -57,7 +57,7 @@ final class SpreadsheetMetadataPropertyNameStyle extends SpreadsheetMetadataProp
     }
 
     @Override
-    Optional<TextStyle> extractLocaleAwareValue(final Locale locale) {
+    Optional<TextStyle> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameValidatorAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameValidatorAliasSet.java
@@ -17,9 +17,9 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -48,7 +48,7 @@ abstract class SpreadsheetMetadataPropertyNameValidatorAliasSet extends Spreadsh
     }
 
     @Override
-    final Optional<ValidatorAliasSet> extractLocaleAwareValue(final Locale locale) {
+    final Optional<ValidatorAliasSet> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewport.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewport.java
@@ -18,10 +18,10 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewport;
 
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -58,7 +58,7 @@ final class SpreadsheetMetadataPropertyNameViewport extends SpreadsheetMetadataP
     }
 
     @Override
-    Optional<SpreadsheetViewport> extractLocaleAwareValue(final Locale locale) {
+    Optional<SpreadsheetViewport> extractLocaleAwareValue(final LocaleContext context) {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -188,6 +188,8 @@ public interface SpreadsheetMetadataTesting extends Testing {
 
     ValidatorProvider VALIDATOR_PROVIDER = ValidatorProviders.validators();
 
+    LocaleContext LOCALE_CONTEXT = LocaleContexts.jre(LOCALE);
+
     /**
      * Creates a {@link SpreadsheetMetadata} with Locale=EN-AU and standard patterns and other sensible defaults.
      */
@@ -195,7 +197,7 @@ public interface SpreadsheetMetadataTesting extends Testing {
             .set(
                     SpreadsheetMetadataPropertyName.LOCALE,
                     LOCALE
-            ).loadFromLocale()
+            ).loadFromLocale(LOCALE_CONTEXT)
             .set(
                     SpreadsheetMetadataPropertyName.AUDIT_INFO,
                     AuditInfo.with(
@@ -360,8 +362,6 @@ public interface SpreadsheetMetadataTesting extends Testing {
             NOW,
             Optional.of(USER)
     );
-
-    LocaleContext LOCALE_CONTEXT = LocaleContexts.fake();
 
     // https://github.com/mP1/walkingkooka-spreadsheet/issues/6223
     // SpreadsheetMetadataTesting.PROVIDER_CONTEXT requires real CanConvert

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -26,6 +26,7 @@ import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.datetime.FakeDateTimeContext;
 import walkingkooka.locale.FakeLocaleContext;
 import walkingkooka.locale.LocaleContext;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.math.DecimalNumberSymbols;
@@ -289,8 +290,9 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
 
     private final static SpreadsheetMetadata METADATA = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
             .set(SpreadsheetMetadataPropertyName.LOCALE, LOCALE)
-            .loadFromLocale()
-            .set(SpreadsheetMetadataPropertyName.DATE_TIME_PARSER, SpreadsheetPattern.parseDateTimeParsePattern("dd/mm/yyyy hh:mm").spreadsheetParserSelector())
+            .loadFromLocale(
+                    LocaleContexts.jre(LOCALE)
+            ).set(SpreadsheetMetadataPropertyName.DATE_TIME_PARSER, SpreadsheetPattern.parseDateTimeParsePattern("dd/mm/yyyy hh:mm").spreadsheetParserSelector())
             .set(SpreadsheetMetadataPropertyName.TEXT_FORMATTER, SpreadsheetPattern.parseTextFormatPattern("@").spreadsheetFormatterSelector())
             .set(
                     SpreadsheetMetadataPropertyName.DECIMAL_NUMBER_SYMBOLS,

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetMetadataStampingSpreadsheetEngineTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.environment.AuditInfo;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.plugin.ProviderContext;
 import walkingkooka.spreadsheet.SpreadsheetCell;
@@ -79,10 +80,12 @@ public final class SpreadsheetMetadataStampingSpreadsheetEngineTest implements S
         ToStringTesting<SpreadsheetMetadataStampingSpreadsheetEngine> {
 
     private final static SpreadsheetId ID = SpreadsheetId.parse("123");
+
     private final static SpreadsheetMetadata BEFORE = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
             .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"))
-            .loadFromLocale()
-            .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, ID)
+            .loadFromLocale(
+                    LocaleContexts.jre(Locale.forLanguageTag("EN-AU"))
+            ).set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, ID)
             .set(
                     SpreadsheetMetadataPropertyName.AUDIT_INFO,
                     AuditInfo.with(

--- a/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
@@ -27,6 +27,7 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.provider.ConverterProvider;
 import walkingkooka.convert.provider.ConverterSelector;
 import walkingkooka.environment.EnvironmentValueName;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContextDelegator;
 import walkingkooka.math.DecimalNumberContexts;
@@ -103,8 +104,9 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
 
     private final static SpreadsheetMetadata METADATA = SpreadsheetMetadata.EMPTY
             .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-US"))
-            .loadFromLocale()
-            .set(SpreadsheetMetadataPropertyName.PRECISION, DECIMAL_NUMBER_CONTEXT.mathContext().getPrecision())
+            .loadFromLocale(
+                    LocaleContexts.jre(Locale.forLanguageTag("EN-US"))
+            ).set(SpreadsheetMetadataPropertyName.PRECISION, DECIMAL_NUMBER_CONTEXT.mathContext().getPrecision())
             .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, DECIMAL_NUMBER_CONTEXT.mathContext().getRoundingMode())
             .set(SpreadsheetMetadataPropertyName.DATE_TIME_OFFSET, 0L)
             .set(SpreadsheetMetadataPropertyName.DEFAULT_YEAR, 20)

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfoTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfoTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.environment.AuditInfo;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.net.email.EmailAddress;
 
 import java.time.LocalDateTime;
@@ -29,7 +30,7 @@ public final class SpreadsheetMetadataPropertyNameAuditInfoTest extends Spreadsh
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 null
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacterValueSeparatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacterValueSeparatorTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 
 import java.util.Locale;
 
@@ -25,7 +26,12 @@ public final class SpreadsheetMetadataPropertyNameCharacterValueSeparatorTest ex
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.forLanguageTag("EN-AU"), ',');
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(
+                        Locale.forLanguageTag("EN-AU")
+                ),
+                ','
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbolsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbolsTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.datetime.DateTimeSymbols;
+import walkingkooka.locale.LocaleContexts;
 
 import java.text.DateFormatSymbols;
 import java.util.Locale;
@@ -37,7 +38,7 @@ public final class SpreadsheetMetadataPropertyNameDateTimeSymbolsTest extends Sp
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 this.propertyValue()
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbolsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbolsTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberSymbols;
 
 import java.text.DecimalFormatSymbols;
@@ -37,7 +38,7 @@ public final class SpreadsheetMetadataPropertyNameDecimalNumberSymbolsTest exten
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 this.propertyValue()
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKindTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.util.Locale;
@@ -35,7 +36,10 @@ public final class SpreadsheetMetadataPropertyNameExpressionNumberKindTest exten
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQueryTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQueryTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.engine.SpreadsheetCellQuery;
 
 import java.util.Locale;
@@ -37,7 +38,10 @@ public final class SpreadsheetMetadataPropertyNameFindQueryTest extends Spreadsh
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     // parseUrlFragmentSaveValue........................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumnsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumnsTest.java
@@ -19,6 +19,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
@@ -36,7 +37,10 @@ public final class SpreadsheetMetadataPropertyNameFrozenColumnsTest extends Spre
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     // parseUrlFragmentSaveValue........................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRowsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRowsTest.java
@@ -20,6 +20,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
@@ -37,7 +38,10 @@ public final class SpreadsheetMetadataPropertyNameFrozenRowsTest extends Spreads
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     // parseUrlFragmentSaveValue........................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameIntegerTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameIntegerTestCase.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 
 import java.util.Locale;
 
@@ -29,7 +30,10 @@ public abstract class SpreadsheetMetadataPropertyNameIntegerTestCase<N extends S
 
     @Test
     public final void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocaleTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocaleTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 
 import java.util.Locale;
 
@@ -25,7 +26,10 @@ public final class SpreadsheetMetadataPropertyNameLocaleTest extends Spreadsheet
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColorTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.color.Color;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.SpreadsheetColors;
 
 import java.util.Locale;
@@ -86,7 +87,10 @@ public final class SpreadsheetMetadataPropertyNameNumberedColorTest extends Spre
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingModeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingModeTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 
 import java.math.RoundingMode;
 import java.util.Locale;
@@ -35,7 +36,10 @@ public final class SpreadsheetMetadataPropertyNameRoundingModeTest extends Sprea
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparatorsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparatorsTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparatorNameList;
 
 import java.util.Locale;
@@ -35,7 +36,7 @@ public final class SpreadsheetMetadataPropertyNameSortComparatorsTest extends Sp
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 null
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
@@ -37,8 +38,9 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDa
     public void testExtractLocaleAwareValue() {
         final Locale locale = Locale.ENGLISH;
         final SpreadsheetFormatPattern pattern = SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDate.instance()
-                .extractLocaleAwareValue(locale)
-                .get()
+                .extractLocaleAwareValue(
+                        LocaleContexts.jre(locale)
+                ).get()
                 .spreadsheetFormatPattern()
                 .get();
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTimeTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeFormatPattern;
@@ -33,7 +34,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDa
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 SpreadsheetDateParsePattern.parseDateTimeFormatPattern("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM")
                         .spreadsheetFormatterSelector()
         );
@@ -43,8 +44,9 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDa
     public void testExtractLocaleAwareValueAndFormat() {
         final Locale locale = Locale.ENGLISH;
         final SpreadsheetFormatPattern pattern = SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorDateTime.instance()
-                .extractLocaleAwareValue(locale)
-                .get()
+                .extractLocaleAwareValue(
+                        LocaleContexts.jre(locale)
+                ).get()
                 .spreadsheetFormatPattern()
                 .get();
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
@@ -24,6 +24,7 @@ import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverter;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
@@ -69,8 +70,9 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNu
                                             final String expected) {
         final Locale locale = Locale.ENGLISH;
         final SpreadsheetFormatPattern pattern = SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumber.instance()
-                .extractLocaleAwareValue(locale)
-                .get()
+                .extractLocaleAwareValue(
+                        LocaleContexts.jre(locale)
+                ).get()
                 .spreadsheetFormatPattern()
                 .get();
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTextTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTextFormatPattern;
 
@@ -27,7 +28,10 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTe
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTimeTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeFormatPattern;
@@ -33,7 +34,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTi
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 SpreadsheetTimeParsePattern.parseTimeFormatPattern("h:mm:ss AM/PM")
                         .spreadsheetFormatterSelector()
         );
@@ -43,8 +44,9 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTi
     public void testExtractLocaleAwareValueAndFormat() {
         final Locale locale = Locale.ENGLISH;
         final SpreadsheetFormatPattern pattern = SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTime.instance()
-                .extractLocaleAwareValue(locale)
-                .get()
+                .extractLocaleAwareValue(
+                        LocaleContexts.jre(locale)
+                ).get()
                 .spreadsheetFormatPattern()
                 .get();
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetIdTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetIdTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.SpreadsheetId;
 
 import java.util.Locale;
@@ -35,7 +36,10 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetIdTest extends Spre
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetNameTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.SpreadsheetName;
 
 import java.util.Locale;
@@ -35,7 +36,10 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetNameTest extends Sp
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserDateTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserDateTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePattern;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
 
@@ -28,7 +29,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserDateTest exte
     @Test
     public void testExtractLocaleAwareValueUS() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 SpreadsheetDateParsePattern.parseDateParsePattern("dddd, mmmm d, yyyy;dddd, mmmm d, yy;dddd, mmmm d;mmmm d, yyyy;mmmm d, yy;mmmm d;mmm d, yyyy;mmm d, yy;mmm d;m/d/yy;m/d/yyyy;m/d")
                         .spreadsheetParserSelector()
         );
@@ -37,7 +38,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserDateTest exte
     @Test
     public void testExtractLocaleAwareValueAu() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.forLanguageTag("EN-AU"),
+                LocaleContexts.jre(Locale.forLanguageTag("EN-AU")),
                 SpreadsheetDateParsePattern.parseDateParsePattern("dddd, d mmmm yyyy;dddd, d mmmm yy;dddd, d mmmm;d mmmm yyyy;d mmmm yy;d mmmm;d mmm yyyy;d mmm yy;d mmm;d/m/yy;d/m/yyyy;d/m")
                         .spreadsheetParserSelector()
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserDateTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserDateTimeTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetDateTimeParsePattern;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
@@ -29,7 +30,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserDateTimeTest 
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 SpreadsheetDateParsePattern.parseDateTimeParsePattern("dddd, mmmm d, yyyy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yy \\a\\t h:mm:ss AM/PM;dddd, mmmm d, yy \\a\\t h:mm:ss;dddd, mmmm d, yy \\a\\t h:mm AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss.0 AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm:ss.0;dddd, mmmm d, yyyy \\a\\t h:mm:ss;dddd, mmmm d, yyyy \\a\\t h:mm AM/PM;dddd, mmmm d, yyyy \\a\\t h:mm;dddd, mmmm d, yyyy, h:mm:ss AM/PM;dddd, mmmm d, yy, h:mm:ss AM/PM;dddd, mmmm d, yy, h:mm:ss;dddd, mmmm d, yy, h:mm AM/PM;dddd, mmmm d, yyyy, h:mm:ss.0 AM/PM;dddd, mmmm d, yyyy, h:mm:ss.0;dddd, mmmm d, yyyy, h:mm:ss;dddd, mmmm d, yyyy, h:mm AM/PM;dddd, mmmm d, yyyy, h:mm;dddd, mmmm d, yy, h:mm;mmmm d, yyyy \\a\\t h:mm:ss AM/PM;mmmm d, yy \\a\\t h:mm:ss AM/PM;mmmm d, yy \\a\\t h:mm:ss;mmmm d, yy \\a\\t h:mm AM/PM;mmmm d, yyyy \\a\\t h:mm:ss.0 AM/PM;mmmm d, yyyy \\a\\t h:mm:ss.0;mmmm d, yyyy \\a\\t h:mm:ss;mmmm d, yyyy \\a\\t h:mm AM/PM;mmmm d, yyyy \\a\\t h:mm;mmmm d, yyyy, h:mm:ss AM/PM;mmmm d, yy, h:mm:ss AM/PM;mmmm d, yy, h:mm:ss;mmmm d, yy, h:mm AM/PM;mmmm d, yyyy, h:mm:ss.0 AM/PM;mmmm d, yyyy, h:mm:ss.0;mmmm d, yyyy, h:mm:ss;mmmm d, yyyy, h:mm AM/PM;mmmm d, yyyy, h:mm;mmmm d, yy, h:mm;mmm d, yyyy, h:mm:ss AM/PM;mmm d, yy, h:mm:ss AM/PM;mmm d, yy, h:mm:ss;mmm d, yy, h:mm AM/PM;mmm d, yyyy, h:mm:ss.0 AM/PM;mmm d, yyyy, h:mm:ss.0;mmm d, yyyy, h:mm:ss;mmm d, yyyy, h:mm AM/PM;mmm d, yyyy, h:mm;mmm d, yy, h:mm;m/d/yy, h:mm:ss AM/PM;m/d/yy, h:mm:ss;m/d/yy, h:mm AM/PM;m/d/yyyy, h:mm:ss AM/PM;m/d/yyyy, h:mm:ss.0 AM/PM;m/d/yyyy, h:mm:ss.0;m/d/yyyy, h:mm:ss;m/d/yyyy, h:mm AM/PM;m/d/yy, h:mm:ss.0;m/d/yy, h:mm;m/d/yyyy, h:mm")
                         .spreadsheetParserSelector()
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest.java
@@ -22,6 +22,7 @@ import walkingkooka.convert.ConverterContexts;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContexts;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverters;
@@ -69,8 +70,9 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest ex
                                              final ExpressionNumberKind kind) throws ParseException {
         final Locale locale = Locale.ENGLISH;
         final SpreadsheetParserSelector parserSelector = SpreadsheetMetadataPropertyNameSpreadsheetParserNumber.instance()
-                .extractLocaleAwareValue(locale)
-                .get();
+                .extractLocaleAwareValue(
+                        LocaleContexts.jre(locale)
+                ).get();
 
         final ExpressionNumber value = SpreadsheetConverters.textToNumber(
                 SPREADSHEET_PARSER_PROVIDER.spreadsheetParser(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserTimeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserTimeTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetTimeParsePattern;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserSelector;
 
@@ -28,7 +29,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserTimeTest exte
     @Test
     public void testExtractLocaleAwareValue() {
         this.extractLocaleValueAwareAndCheck(
-                Locale.ENGLISH,
+                LocaleContexts.jre(Locale.ENGLISH),
                 SpreadsheetTimeParsePattern.parseTimeParsePattern("h:mm:ss AM/PM;h:mm:ss;h:mm:ss.0;h:mm AM/PM;h:mm")
                         .spreadsheetParserSelector()
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
+import walkingkooka.locale.LocaleContext;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.reflect.JavaVisibility;
@@ -35,7 +36,6 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContexts;
 import walkingkooka.tree.text.TextStylePropertyName;
 
 import java.math.MathContext;
-import java.util.Locale;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -165,13 +165,13 @@ public abstract class SpreadsheetMetadataPropertyNameTestCase<N extends Spreadsh
 
     // extractLocaleAwareValue...............................................................................................
 
-    final void extractLocaleValueAwareAndCheck(final Locale locale,
+    final void extractLocaleValueAwareAndCheck(final LocaleContext context,
                                                final V value) {
         final N propertyName = this.createName();
         this.checkEquals(
                 Optional.ofNullable(value),
-                propertyName.extractLocaleAwareValue(locale),
-                propertyName + " extractLocaleAwareValue for locale " + locale
+                propertyName.extractLocaleAwareValue(context),
+                propertyName + " extractLocaleAwareValue for locale " + context.locale()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.reference.SpreadsheetViewport;
@@ -97,7 +98,10 @@ public final class SpreadsheetMetadataPropertyNameViewportTest extends Spreadshe
 
     @Test
     public void testExtractLocaleAwareValue() {
-        this.extractLocaleValueAwareAndCheck(Locale.ENGLISH, null);
+        this.extractLocaleValueAwareAndCheck(
+                LocaleContexts.jre(Locale.ENGLISH),
+                null
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -235,10 +235,10 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     // loadFromLocale...................................................................................................
 
     @Test
-    public void testLoadFromLocaleNullFails() {
+    public void testLoadFromLocaleWithNullLocaleContextFails() {
         assertThrows(
-                SpreadsheetMetadataPropertyValueException.class,
-                SpreadsheetMetadata.EMPTY::loadFromLocale
+                NullPointerException.class,
+                () -> SpreadsheetMetadata.EMPTY.loadFromLocale(null)
         );
     }
 
@@ -282,7 +282,9 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
                 SpreadsheetMetadata.EMPTY.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         locale
-                ).loadFromLocale()
+                ).loadFromLocale(
+                        LocaleContexts.jre(locale)
+                )
         );
     }
 
@@ -290,10 +292,13 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
 
     @Test
     public void testNonLocaleDefaultsGeneralConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
         SpreadsheetMetadata.NON_LOCALE_DEFAULTS
-                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"))
-                .loadFromLocale()
-                .set(SpreadsheetMetadataPropertyName.TEXT_FORMATTER, SpreadsheetPattern.parseTextFormatPattern("@").spreadsheetFormatterSelector())
+                .set(SpreadsheetMetadataPropertyName.LOCALE, locale)
+                .loadFromLocale(
+                        LocaleContexts.jre(locale)
+                ).set(SpreadsheetMetadataPropertyName.TEXT_FORMATTER, SpreadsheetPattern.parseTextFormatPattern("@").spreadsheetFormatterSelector())
                 .generalConverter(
                         spreadsheetFormatterProvider(),
                         spreadsheetParserProvider(),
@@ -588,11 +593,15 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
 
     @Test
     public void testConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
         final SpreadsheetMetadata metadata = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
                 .set(
                         SpreadsheetMetadataPropertyName.LOCALE,
-                        Locale.forLanguageTag("EN-AU")
-                ).loadFromLocale();
+                        locale
+                ).loadFromLocale(
+                        LocaleContexts.jre(locale)
+                );
 
         final Converter<SpreadsheetConverterContext> converter = metadata
                 .converter(
@@ -694,12 +703,15 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
 
     @Test
     public void testGeneralConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
         final Converter<SpreadsheetConverterContext> converter = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
                 .set(
                         SpreadsheetMetadataPropertyName.LOCALE,
-                        Locale.forLanguageTag("EN-AU")
-                ).loadFromLocale()
-                .generalConverter(
+                        locale
+                ).loadFromLocale(
+                        LocaleContexts.jre(locale)
+                ).generalConverter(
                         spreadsheetFormatterProvider(),
                         spreadsheetParserProvider(),
                         PROVIDER_CONTEXT
@@ -851,8 +863,9 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         final SpreadsheetMetadata metadata = SpreadsheetMetadata.EMPTY.set(
                         SpreadsheetMetadataPropertyName.LOCALE,
                         locale
-                ).loadFromLocale()
-                .set(
+                ).loadFromLocale(
+                        LocaleContexts.jre(locale)
+                ).set(
                         SpreadsheetMetadataPropertyName.DATE_TIME_OFFSET,
                         Converters.EXCEL_1900_DATE_SYSTEM_OFFSET
                 ).set(


### PR DESCRIPTION
…Locale)

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/6915
- Replace new DateFormatSymbol(Locale) with LocaleContext.dateTimeSymbolsForLocale(Locale)