### PR TITLE
MissingConverterVerifier verify removed StringBuilder

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/MissingConverterVerifier.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/MissingConverterVerifier.java
@@ -101,6 +101,10 @@ final class MissingConverterVerifier {
         BigDecimal.class
     );
 
+    /**
+     * Note no tests actually involve converting {@link CharSequence} to something else, because marshalling
+     * does not support the {@link CharSequence} interface types like {@link StringBuilder} etc.
+     */
     static Set<MissingConverter> verify(final Converter<SpreadsheetConverterContext> converter,
                                         final SpreadsheetMetadataPropertyName<ConverterSelector> propertyName,
                                         final SpreadsheetConverterContext context) {
@@ -556,7 +560,6 @@ final class MissingConverterVerifier {
         // text-to-text.................................................................................................
         finder.addIfConversionFail(
             Lists.of(
-                new StringBuilder("CharacterSequence"),
                 "Text"
             ),
             String.class,
@@ -567,7 +570,6 @@ final class MissingConverterVerifier {
         if (formatting) {
             finder.addIfConversionFail(
                 Lists.of(
-                    new StringBuilder("CharacterSequence"),
                     "Text"
                 ),
                 TextNode.class,
@@ -649,7 +651,6 @@ final class MissingConverterVerifier {
         if (formatting) {
             finder.addIfConversionFail(
                 Lists.of(
-                    new StringBuilder("Text123"),
                     "Text123",
                     TextNode.text("Text123")
                 ),

--- a/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
@@ -315,6 +315,26 @@ public final class MissingConverterVerifierTest implements TreePrintableTesting,
         );
     }
 
+    @Test
+    public void testVerifyAndMarshall() {
+        final Converter<SpreadsheetConverterContext> converter = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            SpreadsheetMetadata.EMPTY,
+            SPREADSHEET_FORMATTER_PROVIDER,
+            SPREADSHEET_PARSER_PROVIDER
+        ).converter(
+            ConverterSelector.parse("simple"),
+            PROVIDER_CONTEXT
+        );
+
+        final Set<MissingConverter> missing = MissingConverterVerifier.verify(
+            converter,
+            SpreadsheetMetadataPropertyName.VALIDATION_CONVERTER,
+            new TestSpreadsheetConverterContext(converter)
+        );
+
+        JSON_NODE_MARSHALL_CONTEXT.marshall(missing);
+    }
+
     // class............................................................................................................
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7035
- MissingConverterVerifier: include test that marshalls a MissingConverterSet when all converts fail.