### PR TITLE
SpreadsheetFormatterProvider.spreadsheetFormatterSamples includeSamples

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/AliasesSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/AliasesSpreadsheetFormatterProvider.java
@@ -103,6 +103,7 @@ final class AliasesSpreadsheetFormatterProvider implements SpreadsheetFormatterP
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "name");
         Objects.requireNonNull(context, "context");
@@ -114,6 +115,7 @@ final class AliasesSpreadsheetFormatterProvider implements SpreadsheetFormatterP
             .map(
                 n -> this.provider.spreadsheetFormatterSamples(
                     selector.setName(n),
+                    includeSamples,
                     context
                 )
             ).orElse(Lists.empty())

--- a/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/EmptySpreadsheetFormatterProvider.java
@@ -67,6 +67,7 @@ final class EmptySpreadsheetFormatterProvider implements SpreadsheetFormatterPro
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");

--- a/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FakeSpreadsheetFormatterProvider.java
@@ -44,6 +44,7 @@ public class FakeSpreadsheetFormatterProvider implements SpreadsheetFormatterPro
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");

--- a/src/main/java/walkingkooka/spreadsheet/format/FilteredMappedSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FilteredMappedSpreadsheetFormatterProvider.java
@@ -91,6 +91,7 @@ final class FilteredMappedSpreadsheetFormatterProvider implements SpreadsheetFor
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
@@ -99,6 +100,7 @@ final class FilteredMappedSpreadsheetFormatterProvider implements SpreadsheetFor
 
         return this.provider.spreadsheetFormatterSamples(
                 this.mapper.name(name).setValueText(selector.valueText()),
+                includeSamples,
                 context
             ).stream()
             .map(s -> s.setSelector(

--- a/src/main/java/walkingkooka/spreadsheet/format/FilteredSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/FilteredSpreadsheetFormatterProvider.java
@@ -84,12 +84,14 @@ final class FilteredSpreadsheetFormatterProvider implements SpreadsheetFormatter
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
 
         return this.provider.spreadsheetFormatterSamples(
             this.guard.selector(selector),
+            includeSamples,
             context
         );
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/MergedMappedSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/MergedMappedSpreadsheetFormatterProvider.java
@@ -92,6 +92,7 @@ final class MergedMappedSpreadsheetFormatterProvider implements SpreadsheetForma
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
@@ -103,6 +104,7 @@ final class MergedMappedSpreadsheetFormatterProvider implements SpreadsheetForma
                     .setValueText(
                         selector.valueText()
                     ),
+                includeSamples,
                 context
             ).stream()
             .map(

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProvider.java
@@ -61,12 +61,18 @@ public interface SpreadsheetFormatterProvider extends Provider {
      */
     List<SpreadsheetFormatterSample> NO_SPREADSHEET_FORMATTER_SAMPLES = Lists.empty();
 
+    boolean SKIP_SAMPLES = false;
+
+    boolean INCLUDE_SAMPLES = true;
+
     /**
      * Returns {@link SpreadsheetFormatterSample samples} for the given {@link SpreadsheetFormatterName}.
      * Note this method is not defined on {@link SpreadsheetFormatter} because the generation of samples does not
      * actually require a {@link SpreadsheetFormatter} instance.
+     * When generating menus, includeSamples should be false.
      */
     List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                 final boolean includeSamples,
                                                                  final SpreadsheetFormatterProviderSamplesContext context);
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderCollection.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderCollection.java
@@ -104,6 +104,7 @@ final class SpreadsheetFormatterProviderCollection implements SpreadsheetFormatt
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderDelegator.java
@@ -52,10 +52,12 @@ public interface SpreadsheetFormatterProviderDelegator extends SpreadsheetFormat
 
     @Override
     default List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                         final boolean includeSamples,
                                                                          final SpreadsheetFormatterProviderSamplesContext context) {
         return this.spreadsheetFormatterProvider()
             .spreadsheetFormatterSamples(
                 selector,
+                includeSamples,
                 context
             );
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderTesting.java
@@ -330,6 +330,7 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
             () -> this.createSpreadsheetFormatterProvider()
                 .spreadsheetFormatterSamples(
                     null,
+                    SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
                     new FakeSpreadsheetFormatterProviderSamplesContext()
                 )
         );
@@ -342,27 +343,32 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
             () -> this.createSpreadsheetFormatterProvider()
                 .spreadsheetFormatterSamples(
                     SpreadsheetFormatterSelector.DEFAULT_TEXT_FORMAT,
+                    SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
                     null
                 )
         );
     }
 
     default void spreadsheetFormatterSamplesAndCheck(final SpreadsheetFormatterName name,
+                                                     final boolean includeSamples,
                                                      final SpreadsheetFormatterProviderSamplesContext context,
                                                      final SpreadsheetFormatterSample... expected) {
         this.spreadsheetFormatterSamplesAndCheck(
             name.setValueText(""),
+            includeSamples,
             context,
             expected
         );
     }
 
     default void spreadsheetFormatterSamplesAndCheck(final SpreadsheetFormatterSelector selector,
+                                                     final boolean includeSamples,
                                                      final SpreadsheetFormatterProviderSamplesContext context,
                                                      final SpreadsheetFormatterSample... expected) {
         this.spreadsheetFormatterSamplesAndCheck(
             this.createSpreadsheetFormatterProvider(),
             selector,
+            includeSamples,
             context,
             expected
         );
@@ -375,6 +381,7 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
         this.spreadsheetFormatterSamplesAndCheck(
             provider,
             name.setValueText(""),
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
             context,
             expected
         );
@@ -382,11 +389,13 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
 
     default void spreadsheetFormatterSamplesAndCheck(final SpreadsheetFormatterProvider provider,
                                                      final SpreadsheetFormatterSelector selector,
+                                                     final boolean includeSamples,
                                                      final SpreadsheetFormatterProviderSamplesContext context,
                                                      final SpreadsheetFormatterSample... expected) {
         this.spreadsheetFormatterSamplesAndCheck(
             provider,
             selector,
+            includeSamples,
             context,
             Lists.of(
                 expected
@@ -396,15 +405,17 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
 
     default void spreadsheetFormatterSamplesAndCheck(final SpreadsheetFormatterProvider provider,
                                                      final SpreadsheetFormatterSelector selector,
+                                                     final boolean includeSamples,
                                                      final SpreadsheetFormatterProviderSamplesContext context,
                                                      final List<SpreadsheetFormatterSample> expected) {
         this.checkEquals(
             expected,
             provider.spreadsheetFormatterSamples(
                 selector,
+                includeSamples,
                 context
             ),
-            selector + " samples"
+            selector + " includeSamples=" + includeSamples
         );
     }
 
@@ -412,26 +423,31 @@ public interface SpreadsheetFormatterProviderTesting<T extends SpreadsheetFormat
                                                   final SpreadsheetFormatterProviderSamplesContext context) {
         this.spreadsheetFormatterSamplesFails(
             name.setValueText(""),
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
             context
         );
     }
 
     default void spreadsheetFormatterSamplesFails(final SpreadsheetFormatterSelector selector,
+                                                  final boolean includeSamples,
                                                   final SpreadsheetFormatterProviderSamplesContext context) {
         this.spreadsheetFormatterSamplesFails(
             this.createSpreadsheetFormatterProvider(),
             selector,
+            includeSamples,
             context
         );
     }
 
     default void spreadsheetFormatterSamplesFails(final SpreadsheetFormatterProvider provider,
                                                   final SpreadsheetFormatterSelector selector,
+                                                  final boolean includeSamples,
                                                   final SpreadsheetFormatterProviderSamplesContext context) {
         assertThrows(
             IllegalArgumentException.class,
             () -> provider.spreadsheetFormatterSamples(
                 selector,
+                includeSamples,
                 context
             )
         );

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProvider.java
@@ -338,6 +338,7 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
 
     @Override
     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                        final boolean includeSamples,
                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
         Objects.requireNonNull(selector, "selector");
         Objects.requireNonNull(context, "context");
@@ -378,14 +379,16 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         context
                     )
                 );
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.dateValue(context),
-                        context
-                    )
-                );
+                if(includeSamples) {
+                    samples.add(
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.dateValue(context),
+                            context
+                        )
+                    );
+                }
                 break;
             case SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN_STRING:
                 samples.add(
@@ -416,14 +419,16 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         context
                     )
                 );
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.dateTimeValue(context),
-                        context
-                    )
-                );
+                if(includeSamples) {
+                    samples.add(
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.dateTimeValue(context),
+                            context
+                        )
+                    );
+                }
                 break;
             case SpreadsheetFormatterName.DEFAULT_TEXT_STRING:
                 samples.add(
@@ -433,14 +438,16 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         TextNode.text("Hello 123")
                     )
                 );
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.textValue(context),
-                        context
-                    )
-                );
+                if(includeSamples) {
+                    samples.add(
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.textValue(context),
+                            context
+                        )
+                    );
+                }
                 break;
             case SpreadsheetFormatterName.EXPRESSION_STRING:
                 break;
@@ -463,21 +470,23 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         context
                     )
                 );
-                final Object value = cellValueOr(
-                    context,
-                    () -> null
-                );
-                if (null != value) {
-                    samples.add(
-                        generalSample(
-                            context.cell()
-                                .get()
-                                .reference()
-                                .text(),
-                            value,
-                            context
-                        )
+                if(includeSamples) {
+                    final Object value = cellValueOr(
+                        context,
+                        () -> null
                     );
+                    if (null != value) {
+                        samples.add(
+                            generalSample(
+                                context.cell()
+                                    .get()
+                                    .reference()
+                                    .text(),
+                                value,
+                                context
+                            )
+                        );
+                    }
                 }
                 break;
             }
@@ -578,14 +587,16 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         context
                     )
                 );
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.numberValue(context),
-                        context
-                    )
-                );
+                if(includeSamples) {
+                    samples.add(
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.numberValue(context),
+                            context
+                        )
+                    );
+                }
                 break;
             case SpreadsheetFormatterName.TEXT_FORMAT_PATTERN_STRING: {
                 final Object value = cellValueOr(
@@ -601,27 +612,29 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                     )
                 );
 
-                if (null != value) {
+                if(includeSamples) {
+                    if (null != value) {
+                        samples.add(
+                            sample(
+                                context.cell()
+                                    .get()
+                                    .reference()
+                                    .text(),
+                                SpreadsheetFormatterSelector.DEFAULT_TEXT_FORMAT,
+                                value,
+                                context
+                            )
+                        );
+                    }
                     samples.add(
-                        sample(
-                            context.cell()
-                                .get()
-                                .reference()
-                                .text(),
-                            SpreadsheetFormatterSelector.DEFAULT_TEXT_FORMAT,
-                            value,
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.textValue(context),
                             context
                         )
                     );
                 }
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.textValue(context),
-                        context
-                    )
-                );
                 break;
             }
             case SpreadsheetFormatterName.TIME_FORMAT_PATTERN_STRING:
@@ -639,14 +652,16 @@ final class SpreadsheetFormattersSpreadsheetFormatterProvider implements Spreads
                         context
                     )
                 );
-                samples.add(
-                    this.sample(
-                        "Sample",
-                        selector,
-                        this.timeValue(context),
-                        context
-                    )
-                );
+                if(includeSamples) {
+                    samples.add(
+                        this.sample(
+                            "Sample",
+                            selector,
+                            this.timeValue(context),
+                            context
+                        )
+                    );
+                }
                 break;
             default:
                 throw new IllegalArgumentException("Unknown formatter " + name);

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -48,6 +48,7 @@ import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContex
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionFunctions;
 import walkingkooka.spreadsheet.format.FakeSpreadsheetFormatterProviderSamplesContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterName;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterProvider;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSample;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.format.SpreadsheetText;
@@ -895,6 +896,7 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             new FakeSpreadsheetFormatterProviderSamplesContext() {
                 @Override
                 public Optional<SpreadsheetCell> cell() {

--- a/src/test/java/walkingkooka/spreadsheet/format/AliasesSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/AliasesSpreadsheetFormatterProviderTest.java
@@ -275,6 +275,7 @@ public final class AliasesSpreadsheetFormatterProviderTest implements Spreadshee
                 new FakeSpreadsheetFormatterProvider() {
                     @Override
                     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                                        final boolean includeSamples,
                                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
                         final SpreadsheetFormatterName name = selector.name();
 
@@ -314,6 +315,7 @@ public final class AliasesSpreadsheetFormatterProviderTest implements Spreadshee
                 new FakeSpreadsheetFormatterProvider() {
                     @Override
                     public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                                        final boolean includeSamples,
                                                                                         final SpreadsheetFormatterProviderSamplesContext context) {
                         final SpreadsheetFormatterName name = selector.name();
 

--- a/src/test/java/walkingkooka/spreadsheet/format/FilteredMappedSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/FilteredMappedSpreadsheetFormatterProviderTest.java
@@ -215,11 +215,43 @@ public final class FilteredMappedSpreadsheetFormatterProviderTest implements Spr
     //    "dddd, d mmmm yyyy"
     //  Text "Friday, 31 December 1999"
     @Test
-    public void testSpreadsheetFormatterSamples() {
+    public void testSpreadsheetFormatterSamplesSkipSamples() {
         final SpreadsheetFormatterName name = SpreadsheetFormatterName.with(NEW_FORMATTER_NAME);
 
         this.spreadsheetFormatterSamplesAndCheck(
             name,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
+            SpreadsheetFormatterSample.with(
+                "Short",
+                name.setValueText("d/m/yy"),
+                TextNode.text("31/12/99")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Medium",
+                name.setValueText("d mmm yyyy"),
+                TextNode.text("31 Dec. 1999")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Long",
+                name.setValueText("d mmmm yyyy"),
+                TextNode.text("31 December 1999")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Full",
+                name.setValueText("dddd, d mmmm yyyy"),
+                TextNode.text("Friday, 31 December 1999")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesIncludeSamples() {
+        final SpreadsheetFormatterName name = SpreadsheetFormatterName.with(NEW_FORMATTER_NAME);
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            name.setValueText(""),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Short",

--- a/src/test/java/walkingkooka/spreadsheet/format/MergedMappedSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/MergedMappedSpreadsheetFormatterProviderTest.java
@@ -223,6 +223,7 @@ public final class MergedMappedSpreadsheetFormatterProviderTest implements Sprea
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Short",

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderCollectionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderCollectionTest.java
@@ -113,6 +113,7 @@ public final class SpreadsheetFormatterProviderCollectionTest implements Spreads
     public void testSpreadsheetFormatterSamples() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.TEXT_FORMAT_PATTERN.setValueText(""),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SpreadsheetFormatterProviderSamplesContexts.fake()
         );
     }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderTestingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterProviderTestingTest.java
@@ -75,6 +75,7 @@ public final class SpreadsheetFormatterProviderTestingTest implements Spreadshee
         this.spreadsheetFormatterSamplesAndCheck(
             SAMPLE.selector()
                 .name(),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SAMPLE
         );
@@ -86,11 +87,13 @@ public final class SpreadsheetFormatterProviderTestingTest implements Spreadshee
             new FakeSpreadsheetFormatterProvider() {
                 @Override
                 public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                                    final boolean includeSamples,
                                                                                     final SpreadsheetFormatterProviderSamplesContext context) {
                     throw new IllegalArgumentException("Unknown " + selector.name());
                 }
             },
             SAMPLE.selector(),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT
         );
     }
@@ -140,6 +143,7 @@ public final class SpreadsheetFormatterProviderTestingTest implements Spreadshee
 
         @Override
         public List<SpreadsheetFormatterSample> spreadsheetFormatterSamples(final SpreadsheetFormatterSelector selector,
+                                                                            final boolean includeSamples,
                                                                             final SpreadsheetFormatterProviderSamplesContext context) {
             Objects.requireNonNull(selector, "selector");
             Objects.requireNonNull(context, "context");

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
@@ -849,6 +849,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesAutomatic() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.AUTOMATIC,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SpreadsheetFormatterProviderSamplesContexts.fake()
         );
     }
@@ -857,6 +858,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesCollection() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.COLLECTION,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SpreadsheetFormatterProviderSamplesContexts.fake()
         );
     }
@@ -881,9 +883,39 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     //    "dddd, d mmmm yyyy"
     //  Text "Friday, 31 December 1999"
     @Test
-    public void testSpreadsheetFormatterSamplesDateFormatPatternWithoutCell() {
+    public void testSpreadsheetFormatterSamplesDateFormatPatternWithoutCellSkipSamples() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.DATE_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
+            SpreadsheetFormatterSample.with(
+                "Short",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d/m/yy"),
+                TextNode.text("31/12/99")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Medium",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d mmm yyyy"),
+                TextNode.text("31 Dec. 1999")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Long",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d mmmm yyyy"),
+                TextNode.text("31 December 1999")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Full",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("dddd, d mmmm yyyy"),
+                TextNode.text("Friday, 31 December 1999")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesDateFormatPatternWithoutCellIncludeSamples() {
+        this.spreadsheetFormatterSamplesAndCheck(
+            SpreadsheetFormatterName.DATE_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Short",
@@ -914,7 +946,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesDateFormatPatternWithCellValue() {
+    public void testSpreadsheetFormatterSamplesDateFormatPatternWithCellValueSkipSamples() {
         final LocalDate date = LocalDate.of(
             2000,
             1,
@@ -927,7 +959,50 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
         );
 
         this.spreadsheetFormatterSamplesAndCheck(
-            SpreadsheetFormatterName.DATE_FORMAT_PATTERN,
+            SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText(""),
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of(date)
+            ),
+            SpreadsheetFormatterSample.with(
+                "Short",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d/m/yy"),
+                TextNode.text("2/1/00")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Medium",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d mmm yyyy"),
+                TextNode.text("2 Jan. 2000")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Long",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("d mmmm yyyy"),
+                TextNode.text("2 January 2000")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Full",
+                SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText("dddd, d mmmm yyyy"),
+                TextNode.text("Sunday, 2 January 2000")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesDateFormatPatternWithCellValueIncludeSamples() {
+        final LocalDate date = LocalDate.of(
+            2000,
+            1,
+            2
+        );
+        this.checkNotEquals(
+            date,
+            NOW.now(),
+            "date must be different to now"
+        );
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            SpreadsheetFormatterName.DATE_FORMAT_PATTERN.setValueText(""),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(date)
             ),
@@ -976,6 +1051,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(date)
             ),
@@ -1027,9 +1103,39 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     //    "dddd, d mmmm yyyy \\a\\t h:mm:ss AM/PM"
     //  Text "Friday, 31 December 1999 at 12:58:00 PM"
     @Test
-    public void testSpreadsheetFormatterSamplesDateTimeFormatPattern() {
+    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternSkipSamples() {
         this.spreadsheetFormatterSamplesAndCheck(
-            SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN,
+            SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText(""),
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
+            SpreadsheetFormatterSample.with(
+                "Short",
+                SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText("d/m/yy, h:mm AM/PM"),
+                TextNode.text("31/12/99, 12:58 PM")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Medium",
+                SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText("d mmm yyyy, h:mm:ss AM/PM"),
+                TextNode.text("31 Dec. 1999, 12:58:00 PM")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Long",
+                SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText("d mmmm yyyy \\a\\t h:mm:ss AM/PM"),
+                TextNode.text("31 December 1999 at 12:58:00 PM")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Full",
+                SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText("dddd, d mmmm yyyy \\a\\t h:mm:ss AM/PM"),
+                TextNode.text("Friday, 31 December 1999 at 12:58:00 PM")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternIncludeSamples() {
+        this.spreadsheetFormatterSamplesAndCheck(
+            SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText(""),
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Short",
@@ -1060,7 +1166,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternWithCellValueDateTime() {
+    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternWithCellValueDateTimeSkipSamples() {
         final LocalDateTime value = LocalDateTime.of(
             2000,
             1,
@@ -1076,6 +1182,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
 
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),
@@ -1098,17 +1205,12 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
                 "Full",
                 SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText("dddd, d mmmm yyyy \\a\\t h:mm:ss AM/PM"),
                 TextNode.text("Sunday, 2 January 2000 at 6:30:00 PM")
-            ),
-            SpreadsheetFormatterSample.with(
-                "Sample",
-                SpreadsheetFormatterName.DATE_TIME_FORMAT_PATTERN.setValueText(""),
-                TextNode.text("Empty \"text\"")
             )
         );
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternNotEmptyWithCellValueDateTime() {
+    public void testSpreadsheetFormatterSamplesDateTimeFormatPatternNotEmptyWithCellValueDateTimeIncludeSamples() {
         final LocalDateTime value = LocalDateTime.of(
             2000,
             1,
@@ -1126,6 +1228,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),
@@ -1161,6 +1264,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesExpression() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.EXPRESSION,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT
         );
     }
@@ -1180,6 +1284,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesGeneral() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.GENERAL,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "General",
@@ -1200,11 +1305,40 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesGeneralAndCellWithValue() {
+    public void testSpreadsheetFormatterSamplesGeneralAndCellWithValueSkipSamples() {
         final Object value = 999;
 
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.GENERAL,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of(value)
+            ),
+            SpreadsheetFormatterSample.with(
+                "General",
+                SpreadsheetFormatterName.GENERAL.setValueText(""),
+                TextNode.text("123.5")
+            ),
+            SpreadsheetFormatterSample.with(
+                "General",
+                SpreadsheetFormatterName.GENERAL.setValueText(""),
+                TextNode.text("-123.5")
+            ),
+            SpreadsheetFormatterSample.with(
+                "General",
+                SpreadsheetFormatterName.GENERAL.setValueText(""),
+                TextNode.text("0")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesGeneralAndCellWithValueIncludeSamples() {
+        final Object value = 999;
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            SpreadsheetFormatterName.GENERAL,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),
@@ -1294,6 +1428,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesNumberFormatPattern() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Number",
@@ -1354,23 +1489,94 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
                 "Currency",
                 SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("$#,##0.00"),
                 TextNode.text("$0.00")
-            ),
-            SpreadsheetFormatterSample.with(
-                "Sample",
-                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText(""),
-                TextNode.text("Empty \"text\"")
             )
         );
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesNumberFormatPatternNotEmpty() {
+    public void testSpreadsheetFormatterSamplesNumberFormatPatternNotEmptySkipSamples() {
         final SpreadsheetFormatterSelector selector = SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("\"Hello\" $000.000");
 
         final Number value = 1234.56;
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of(value)
+            ),
+            SpreadsheetFormatterSample.with(
+                "Number",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0.###"),
+                TextNode.text("123.5")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Number",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0.###"),
+                TextNode.text("-123.5")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Number",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0.###"),
+                TextNode.text("0.")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Integer",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0"),
+                TextNode.text("124")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Integer",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0"),
+                TextNode.text("-124")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Integer",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0"),
+                TextNode.text("0")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Percent",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0%"),
+                TextNode.text("12,350%")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Percent",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0%"),
+                TextNode.text("-12,350%")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Percent",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("#,##0%"),
+                TextNode.text("0%")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Currency",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("$#,##0.00"),
+                TextNode.text("$123.50")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Currency",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("$#,##0.00"),
+                TextNode.text("$-123.50")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Currency",
+                SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("$#,##0.00"),
+                TextNode.text("$0.00")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesNumberFormatPatternNotEmptyIncludeSamples() {
+        final SpreadsheetFormatterSelector selector = SpreadsheetFormatterName.NUMBER_FORMAT_PATTERN.setValueText("\"Hello\" $000.000");
+
+        final Number value = 1234.56;
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),
@@ -1446,6 +1652,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesTextFormatPattern() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.TEXT_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Default",
@@ -1461,9 +1668,26 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesTextFormatPatternWithCellValue() {
+    public void testSpreadsheetFormatterSamplesTextFormatPatternWithCellValueSkipSamples() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.TEXT_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of("Cell Value 123")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Default",
+                SpreadsheetFormatterName.TEXT_FORMAT_PATTERN.setValueText("@"),
+                TextNode.text("Hello 123")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesTextFormatPatternWithCellValueIncludeSamples() {
+        this.spreadsheetFormatterSamplesAndCheck(
+            SpreadsheetFormatterName.TEXT_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of("Cell Value 123")
             ),
@@ -1486,11 +1710,30 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesTextFormatPatternNotEmptyWithCellValue() {
+    public void testSpreadsheetFormatterSamplesTextFormatPatternNotEmptyWithCellValueSkipSamples() {
         final SpreadsheetFormatterSelector selector = SpreadsheetFormatterName.TEXT_FORMAT_PATTERN.setValueText("\"Hello\" @@");
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of("Cell Value 123")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Default",
+                SpreadsheetFormatterName.TEXT_FORMAT_PATTERN.setValueText("@"),
+                TextNode.text("Hello 123")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesTextFormatPatternNotEmptyWithCellValueIncludeSamples() {
+        final SpreadsheetFormatterSelector selector = SpreadsheetFormatterName.TEXT_FORMAT_PATTERN.setValueText("\"Hello\" @@");
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of("Cell Value 123")
             ),
@@ -1525,6 +1768,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     public void testSpreadsheetFormatterSamplesTimeFormatPattern() {
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.TIME_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT,
             SpreadsheetFormatterSample.with(
                 "Short",
@@ -1545,7 +1789,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesTimeFormatPatternWithCellValue() {
+    public void testSpreadsheetFormatterSamplesTimeFormatPatternWithCellValueIncludeSamples() {
         final LocalTime value = LocalTime.of(
             15,
             28,
@@ -1559,6 +1803,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
 
         this.spreadsheetFormatterSamplesAndCheck(
             SpreadsheetFormatterName.TIME_FORMAT_PATTERN,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),
@@ -1581,7 +1826,7 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
     }
 
     @Test
-    public void testSpreadsheetFormatterSamplesTimeFormatPatternNotEmptyWithCellValue() {
+    public void testSpreadsheetFormatterSamplesTimeFormatPatternNotEmptyWithCellValueSkipSamples() {
         final LocalTime value = LocalTime.of(
             15,
             28,
@@ -1597,6 +1842,41 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
 
         this.spreadsheetFormatterSamplesAndCheck(
             selector,
+            SpreadsheetFormatterProvider.SKIP_SAMPLES,
+            spreadsheetFormatterSamplesAndCheck(
+                Optional.of(value)
+            ),
+            SpreadsheetFormatterSample.with(
+                "Short",
+                SpreadsheetFormatterName.TIME_FORMAT_PATTERN.setValueText("h:mm AM/PM"),
+                TextNode.text("3:28 PM")
+            ),
+            SpreadsheetFormatterSample.with(
+                "Long",
+                SpreadsheetFormatterName.TIME_FORMAT_PATTERN.setValueText("h:mm:ss AM/PM"),
+                TextNode.text("3:28:29 PM")
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetFormatterSamplesTimeFormatPatternNotEmptyWithCellValueIncludeSamples() {
+        final LocalTime value = LocalTime.of(
+            15,
+            28,
+            29
+        );
+        this.checkNotEquals(
+            value,
+            NOW.now().toLocalTime(),
+            "value must be different to now"
+        );
+
+        final SpreadsheetFormatterSelector selector = SpreadsheetFormatterName.TIME_FORMAT_PATTERN.setValueText("\"Hello\" hh:mm");
+
+        this.spreadsheetFormatterSamplesAndCheck(
+            selector,
+            SpreadsheetFormatterProvider.INCLUDE_SAMPLES,
             spreadsheetFormatterSamplesAndCheck(
                 Optional.of(value)
             ),


### PR DESCRIPTION
- server can now request for sample values to be omitted with the new includeSamples parameter.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7120
- SpreadsheetFormattersSpreadsheetFormatterProvider menus should not include samples