### PR TITLE
SpreadsheetConvertersConverterProvider.with-Function general replaces…

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -277,9 +277,11 @@ public class TestGwtTest extends GWTTestCase {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                metadata,
+            (ProviderContext p) -> metadata.generalConverter(
                 spreadsheetFormatterProvider,
-                spreadsheetParserProvider
+                spreadsheetParserProvider,
+                p
+            )
         );
 
         return new FakeSpreadsheetEngineContext() {

--- a/src/it/j2cl-test/src/test/java/test/J2clTest.java
+++ b/src/it/j2cl-test/src/test/java/test/J2clTest.java
@@ -291,9 +291,11 @@ public class J2clTest {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                metadata,
+            (ProviderContext p) -> metadata.generalConverter(
                 spreadsheetFormatterProvider,
-                spreadsheetParserProvider
+                spreadsheetParserProvider,
+                p
+            )
         );
 
         return new FakeSpreadsheetEngineContext() {

--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -3,4 +3,5 @@
 #
 **/*Testing.*
 **/*Testing2.*
+**/SpreadsheetMetadataTestingPrivate.*
 

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviders.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviders.java
@@ -22,10 +22,10 @@ import walkingkooka.convert.provider.ConverterAliasSet;
 import walkingkooka.convert.provider.ConverterProvider;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.net.Url;
+import walkingkooka.plugin.ProviderContext;
 import walkingkooka.reflect.PublicStaticHelper;
-import walkingkooka.spreadsheet.format.SpreadsheetFormatterProvider;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.parser.SpreadsheetParserProvider;
+
+import java.util.function.Function;
 
 /**
  * A {@link ConverterProvider} for {@link SpreadsheetConverters}.
@@ -90,14 +90,8 @@ public final class SpreadsheetConvertersConverterProviders implements PublicStat
     /**
      * {@see SpreadsheetConvertersConverterProvider}
      */
-    public static ConverterProvider spreadsheetConverters(final SpreadsheetMetadata metadata,
-                                                          final SpreadsheetFormatterProvider spreadsheetFormatterProvider,
-                                                          final SpreadsheetParserProvider spreadsheetParserProvider) {
-        return SpreadsheetConvertersConverterProvider.with(
-            metadata,
-            spreadsheetFormatterProvider,
-            spreadsheetParserProvider
-        );
+    public static ConverterProvider spreadsheetConverters(final Function<ProviderContext, Converter<SpreadsheetConverterContext>> general) {
+        return SpreadsheetConvertersConverterProvider.with(general);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1603,9 +1603,9 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         ).set(
             SpreadsheetMetadataPropertyName.CONVERTERS,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                    SpreadsheetMetadata.EMPTY,
-                    SpreadsheetFormatterProviders.fake(),
-                    SpreadsheetParserProviders.fake()
+                    (final ProviderContext c) -> {
+                        throw new UnsupportedOperationException();
+                    }
                 ).converterInfos()
                 .aliasSet()
         ).set(

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -151,18 +151,12 @@ public interface SpreadsheetMetadataTesting extends Testing {
     );
 
     ConverterProvider CONVERTER_PROVIDER = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-        SpreadsheetMetadata.EMPTY
-            .set(SpreadsheetMetadataPropertyName.DATE_FORMATTER, SpreadsheetPattern.parseDateFormatPattern("yyyy/mm/dd").spreadsheetFormatterSelector())
-            .set(SpreadsheetMetadataPropertyName.DATE_PARSER, SpreadsheetPattern.parseDateParsePattern("yyyy/mm/dd").spreadsheetParserSelector())
-            .set(SpreadsheetMetadataPropertyName.DATE_TIME_FORMATTER, SpreadsheetPattern.parseDateTimeFormatPattern("yyyy/mm/dd hh:mm").spreadsheetFormatterSelector())
-            .set(SpreadsheetMetadataPropertyName.DATE_TIME_PARSER, SpreadsheetPattern.parseDateTimeParsePattern("yyyy/mm/dd hh:mm").spreadsheetParserSelector())
-            .set(SpreadsheetMetadataPropertyName.NUMBER_FORMATTER, SpreadsheetPattern.parseNumberFormatPattern("0.#").spreadsheetFormatterSelector())
-            .set(SpreadsheetMetadataPropertyName.NUMBER_PARSER, SpreadsheetPattern.parseNumberParsePattern("0.#").spreadsheetParserSelector())
-            .set(SpreadsheetMetadataPropertyName.TEXT_FORMATTER, SpreadsheetPattern.parseTextFormatPattern("@").spreadsheetFormatterSelector())
-            .set(SpreadsheetMetadataPropertyName.TIME_FORMATTER, SpreadsheetPattern.parseTimeFormatPattern("hh:mm:ss").spreadsheetFormatterSelector())
-            .set(SpreadsheetMetadataPropertyName.TIME_PARSER, SpreadsheetPattern.parseTimeParsePattern("hh:mm:ss").spreadsheetParserSelector()),
-        SPREADSHEET_FORMATTER_PROVIDER,
-        SPREADSHEET_PARSER_PROVIDER
+        (final ProviderContext p) ->
+            SpreadsheetMetadataTestingPrivate.CONVERTER_PROVIDER_SPREADSHEET_METADATA.generalConverter(
+                SPREADSHEET_FORMATTER_PROVIDER,
+                SPREADSHEET_PARSER_PROVIDER,
+                p
+            )
     );
 
     DateTimeSymbols DATE_TIME_SYMBOLS = DateTimeSymbols.fromDateFormatSymbols(

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingPrivate.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingPrivate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
+
+final class SpreadsheetMetadataTestingPrivate {
+
+    final static SpreadsheetMetadata CONVERTER_PROVIDER_SPREADSHEET_METADATA = SpreadsheetMetadata.EMPTY
+        .set(SpreadsheetMetadataPropertyName.DATE_FORMATTER, SpreadsheetPattern.parseDateFormatPattern("yyyy/mm/dd").spreadsheetFormatterSelector())
+        .set(SpreadsheetMetadataPropertyName.DATE_PARSER, SpreadsheetPattern.parseDateParsePattern("yyyy/mm/dd").spreadsheetParserSelector())
+        .set(SpreadsheetMetadataPropertyName.DATE_TIME_FORMATTER, SpreadsheetPattern.parseDateTimeFormatPattern("yyyy/mm/dd hh:mm").spreadsheetFormatterSelector())
+        .set(SpreadsheetMetadataPropertyName.DATE_TIME_PARSER, SpreadsheetPattern.parseDateTimeParsePattern("yyyy/mm/dd hh:mm").spreadsheetParserSelector())
+        .set(SpreadsheetMetadataPropertyName.NUMBER_FORMATTER, SpreadsheetPattern.parseNumberFormatPattern("0.#").spreadsheetFormatterSelector())
+        .set(SpreadsheetMetadataPropertyName.NUMBER_PARSER, SpreadsheetPattern.parseNumberParsePattern("0.#").spreadsheetParserSelector())
+        .set(SpreadsheetMetadataPropertyName.TEXT_FORMATTER, SpreadsheetPattern.parseTextFormatPattern("@").spreadsheetFormatterSelector())
+        .set(SpreadsheetMetadataPropertyName.TIME_FORMATTER, SpreadsheetPattern.parseTimeFormatPattern("hh:mm:ss").spreadsheetFormatterSelector())
+        .set(SpreadsheetMetadataPropertyName.TIME_PARSER, SpreadsheetPattern.parseTimeParsePattern("hh:mm:ss").spreadsheetParserSelector());
+
+    /**
+     * Provider context
+     */
+    private SpreadsheetMetadataTestingPrivate() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
@@ -29,6 +29,7 @@ import walkingkooka.locale.LocaleContext;
 import walkingkooka.locale.LocaleContextDelegator;
 import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContextDelegator;
+import walkingkooka.plugin.ProviderContext;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
@@ -140,9 +141,11 @@ public final class MissingConverterVerifierTest implements TreePrintableTesting,
 
         this.verifyAndCheck(
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                metadata,
-                SPREADSHEET_FORMATTER_PROVIDER,
-                SPREADSHEET_PARSER_PROVIDER
+                (ProviderContext p) -> metadata.generalConverter(
+                    SPREADSHEET_FORMATTER_PROVIDER,
+                    SPREADSHEET_PARSER_PROVIDER,
+                    p
+                )
             ).converter(
                 selector,
                 PROVIDER_CONTEXT
@@ -318,9 +321,11 @@ public final class MissingConverterVerifierTest implements TreePrintableTesting,
     @Test
     public void testVerifyAndMarshall() {
         final Converter<SpreadsheetConverterContext> converter = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-            SpreadsheetMetadata.EMPTY,
-            SPREADSHEET_FORMATTER_PROVIDER,
-            SPREADSHEET_PARSER_PROVIDER
+            (ProviderContext p) -> SpreadsheetMetadata.EMPTY.generalConverter(
+                SPREADSHEET_FORMATTER_PROVIDER,
+                SPREADSHEET_PARSER_PROVIDER,
+                p
+            )
         ).converter(
             ConverterSelector.parse("simple"),
             PROVIDER_CONTEXT

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterUnformattedNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterUnformattedNumberTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.plugin.ProviderContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPattern;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
@@ -190,9 +191,11 @@ public final class SpreadsheetConverterUnformattedNumberTest extends Spreadsheet
             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
             LABEL_NAME_RESOLVER,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                metadata,
-                SPREADSHEET_FORMATTER_PROVIDER,
-                SPREADSHEET_PARSER_PROVIDER
+                (ProviderContext p) -> metadata.generalConverter(
+                    SPREADSHEET_FORMATTER_PROVIDER,
+                    SPREADSHEET_PARSER_PROVIDER,
+                    p
+                )
             ),
             LOCALE_CONTEXT,
             PROVIDER_CONTEXT

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
@@ -28,6 +28,7 @@ import walkingkooka.convert.provider.ConverterProviderTesting;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.math.DecimalNumberContexts;
+import walkingkooka.plugin.ProviderContext;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataTesting;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
@@ -488,9 +489,11 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
     @Override
     public SpreadsheetConvertersConverterProvider createConverterProvider() {
         return SpreadsheetConvertersConverterProvider.with(
-            SpreadsheetMetadataTesting.METADATA_EN_AU,
-            SPREADSHEET_FORMATTER_PROVIDER,
-            SPREADSHEET_PARSER_PROVIDER
+            (final ProviderContext context) -> SpreadsheetMetadataTesting.METADATA_EN_AU.generalConverter(
+                SPREADSHEET_FORMATTER_PROVIDER,
+                SPREADSHEET_PARSER_PROVIDER,
+                context
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
@@ -519,10 +519,12 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
         };
 
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-            METADATA,
-            SpreadsheetFormatterProviders.spreadsheetFormatters(),
-            SpreadsheetParserProviders.spreadsheetParsePattern(
-                SpreadsheetFormatterProviders.fake()
+            (ProviderContext p) -> METADATA.generalConverter(
+                SpreadsheetFormatterProviders.spreadsheetFormatters(),
+                SpreadsheetParserProviders.spreadsheetParsePattern(
+                    SpreadsheetFormatterProviders.fake()
+                ),
+                p
             )
         );
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -46,6 +46,7 @@ import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.math.DecimalNumberSymbols;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.plugin.PluginNameSet;
+import walkingkooka.plugin.ProviderContext;
 import walkingkooka.spreadsheet.SpreadsheetColors;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.SpreadsheetName;
@@ -1378,9 +1379,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         final Converter<SpreadsheetConverterContext> converter = metadata.converter(
             converterSelector,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                metadata,
-                SPREADSHEET_FORMATTER_PROVIDER,
-                SPREADSHEET_PARSER_PROVIDER
+                (final ProviderContext p) -> metadata.generalConverter(
+                    SPREADSHEET_FORMATTER_PROVIDER,
+                    SPREADSHEET_PARSER_PROVIDER,
+                    p
+                )
             ),
             PROVIDER_CONTEXT
         );
@@ -1471,9 +1474,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                    metadata,
-                    SPREADSHEET_FORMATTER_PROVIDER,
-                    SPREADSHEET_PARSER_PROVIDER
+                    (ProviderContext p) -> metadata.generalConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    )
                 ),
                 LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
@@ -2037,9 +2042,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 },
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                    metadata,
-                    SPREADSHEET_FORMATTER_PROVIDER,
-                    SPREADSHEET_PARSER_PROVIDER
+                    (ProviderContext p) -> metadata.generalConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    )
                 ),
                 SPREADSHEET_FORMATTER_PROVIDER,
                 LOCALE_CONTEXT,
@@ -2069,9 +2076,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 },
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                    metadata,
-                    SPREADSHEET_FORMATTER_PROVIDER,
-                    SPREADSHEET_PARSER_PROVIDER
+                    (ProviderContext p) -> metadata.generalConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    )
                 ),
                 SPREADSHEET_FORMATTER_PROVIDER,
                 LOCALE_CONTEXT,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -605,16 +605,17 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
                 LocaleContexts.jre(locale)
             );
 
-        final Converter<SpreadsheetConverterContext> converter = metadata
-            .converter(
-                SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
-                SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-                    metadata,
+        final Converter<SpreadsheetConverterContext> converter = metadata.converter(
+            SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
+            SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.generalConverter(
                     spreadsheetFormatterProvider(),
-                    spreadsheetParserProvider()
-                ),
-                PROVIDER_CONTEXT
-            );
+                    spreadsheetParserProvider(),
+                    p
+                )
+            ),
+            PROVIDER_CONTEXT
+        );
         this.checkNotEquals(
             null,
             converter

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingPrivateTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingPrivateTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class SpreadsheetMetadataTestingPrivateTest implements ClassTesting<SpreadsheetMetadataTestingPrivate> {
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetMetadataTestingPrivate> type() {
+        return SpreadsheetMetadataTestingPrivate.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -289,9 +289,11 @@ public final class Sample {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
-            metadata,
-            spreadsheetFormatterProvider,
-            spreadsheetParserProvider
+            (ProviderContext p) -> metadata.generalConverter(
+                spreadsheetFormatterProvider,
+                spreadsheetParserProvider,
+                p
+            )
         );
 
         return new FakeSpreadsheetEngineContext() {


### PR DESCRIPTION
… SpreadsheetMetadata etc

- This refactoring is necessary to support creation without a SpreadsheetMetadata instance such as the creation of a system Converter.