### PR TITLE
EmptySpreadsheetLabelNameResolver

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/EmptySpreadsheetLabelNameResolver.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/EmptySpreadsheetLabelNameResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link SpreadsheetLabelNameResolver} that never succeeds, all lookups fail.
+ */
+final class EmptySpreadsheetLabelNameResolver implements SpreadsheetLabelNameResolver {
+
+    final static EmptySpreadsheetLabelNameResolver INSTANCE = new EmptySpreadsheetLabelNameResolver();
+
+    private EmptySpreadsheetLabelNameResolver() {
+        super();
+    }
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName labelName) {
+        Objects.requireNonNull(labelName, "labelName");
+        return Optional.empty();
+    }
+
+    // Object...........................................................................................................
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameResolvers.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetLabelNameResolvers.java
@@ -26,6 +26,13 @@ import walkingkooka.spreadsheet.store.SpreadsheetLabelStore;
 public final class SpreadsheetLabelNameResolvers implements PublicStaticHelper {
 
     /**
+     * {@see EmptySpreadsheetLabelNameResolver}
+     */
+    public static SpreadsheetLabelNameResolver empty() {
+        return EmptySpreadsheetLabelNameResolver.INSTANCE;
+    }
+
+    /**
      * {@see FakeSpreadsheetLabelNameResolver}
      */
     public static SpreadsheetLabelNameResolver fake() {

--- a/src/test/java/walkingkooka/spreadsheet/reference/EmptySpreadsheetLabelNameResolverTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/EmptySpreadsheetLabelNameResolverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class EmptySpreadsheetLabelNameResolverTest implements SpreadsheetLabelNameResolverTesting<EmptySpreadsheetLabelNameResolver>,
+    ToStringTesting<EmptySpreadsheetLabelNameResolver>,
+    ClassTesting<EmptySpreadsheetLabelNameResolver> {
+
+    @Test
+    public void testL() {
+        this.resolveIfLabelAndCheck(
+            EmptySpreadsheetLabelNameResolver.INSTANCE,
+            SpreadsheetSelection.labelName("Label123")
+        );
+    }
+
+    @Override
+    public EmptySpreadsheetLabelNameResolver createSpreadsheetLabelNameResolver() {
+        return EmptySpreadsheetLabelNameResolver.INSTANCE;
+    }
+
+    // toString.........................................................................................................
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(
+            EmptySpreadsheetLabelNameResolver.INSTANCE,
+            EmptySpreadsheetLabelNameResolver.class.getSimpleName()
+        );
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<EmptySpreadsheetLabelNameResolver> type() {
+        return EmptySpreadsheetLabelNameResolver.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7136
- SpreadsheetLabelNameResolver.empty label lookups always fail