### PR TITLE
SpreadsheetPatternSpreadsheetFormatterDateTime valueType predicate re…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterDateTime.java
@@ -70,8 +70,7 @@ final class SpreadsheetPatternSpreadsheetFormatterDateTime implements Spreadshee
 
         final Object valueOrNull = value.orElse(null);
 
-        final Either<LocalDateTime, String> valueAsDateTime = null != valueOrNull &&
-            valueOrNull.getClass() == this.valueType ?
+        final Either<LocalDateTime, String> valueAsDateTime = null != valueOrNull ?
             context.convert(
                 valueOrNull,
                 LocalDateTime.class


### PR DESCRIPTION
…moved

- The check was breaking the ability to format dates with a date/time pattern because the valueType check fails.