### PR TITLE
SpreadsheetMetadata.shouldViewsRefresh viewport.home check true

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1468,7 +1468,10 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                     case "modified-by":
                     case "modified-timestamp":
                     case "spreadsheet-name":
+                        break;
                     case "viewport":
+                        should = false == this.home()
+                            .equalsIgnoreReferenceKind(metadata.home());
                         break;
                     default:
                         should = false == this.get(name).equals(metadata.get(name));
@@ -1483,6 +1486,15 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         }
 
         return should;
+    }
+
+    /**
+     * Assumes a viewport will always be present and returns the {@link SpreadsheetCellReference home}.
+     */
+    private SpreadsheetCellReference home() {
+        return this.getOrFail(SpreadsheetMetadataPropertyName.VIEWPORT)
+            .rectangle()
+            .home();
     }
 
     // Object...........................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -70,6 +70,7 @@ import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
 import walkingkooka.spreadsheet.provider.SpreadsheetProviders;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewportRectangle;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.tree.expression.ExpressionFunctionName;
 import walkingkooka.tree.expression.ExpressionNumberKind;
@@ -364,10 +365,18 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
 
     @Test
     public void testShouldViewsRefreshSameIdPresent() {
-        final SpreadsheetMetadata metadata = this.metadata().set(
+        final SpreadsheetMetadata metadata = this.metadata()
+            .set(
             SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
             SpreadsheetId.with(1)
-        );
+        ).set(
+            SpreadsheetMetadataPropertyName.VIEWPORT,
+                SpreadsheetViewportRectangle.with(
+                    SpreadsheetSelection.A1,
+                    100,
+                    200
+                ).viewport()
+            );
 
         this.checkNotEquals(
             Optional.empty(),
@@ -423,6 +432,40 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
             different,
             metadata,
             false
+        );
+    }
+
+    @Test
+    public void testShouldViewsRefreshSameDifferentHome() {
+        final SpreadsheetId id = SpreadsheetId.with(1);
+
+        final SpreadsheetMetadata metadata = this.metadata()
+            .set(SpreadsheetMetadataPropertyName.SPREADSHEET_ID, id)
+            .set(
+                SpreadsheetMetadataPropertyName.VIEWPORT,
+                SpreadsheetSelection.A1
+                    .viewportRectangle(100, 40)
+                    .viewport()
+            );
+        final SpreadsheetMetadata different = metadata.set(
+            SpreadsheetMetadataPropertyName.SPREADSHEET_ID,
+            id
+        ).set(
+            SpreadsheetMetadataPropertyName.VIEWPORT,
+            SpreadsheetSelection.parseCell("Z99")
+                .viewportRectangle(100, 40)
+                .viewport()
+        );
+
+        this.checkNotEquals(
+            metadata,
+            different
+        );
+
+        this.shouldViewRefreshAndCheck(
+            different,
+            metadata,
+            true
         );
     }
 


### PR DESCRIPTION
- This fixes the browser-app which would not refresh the viewport if an incoming SpreadsheetMetadata had a new home, such as after a load cells with navigations.