### PR TITLE
SpreadsheetMetadata.set VIEWPORT with navigations fails

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -91,6 +91,7 @@ import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.validation.SpreadsheetValidatorContext;
 import walkingkooka.spreadsheet.validation.SpreadsheetValidatorContexts;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewport;
 import walkingkooka.text.cursor.parser.InvalidCharacterExceptionFactory;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.Parsers;
@@ -341,12 +342,26 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      */
     public final <V> SpreadsheetMetadata set(final SpreadsheetMetadataPropertyName<V> propertyName,
                                              final V value) {
+        Objects.requireNonNull(
+            propertyName,
+            "propertyName"
+        );
+        final V typedValue = propertyName.checkValue(value); // necessary because absolute references values are made relative
+        if (typedValue instanceof SpreadsheetViewport) {
+            // https://github.com/mP1/walkingkooka-spreadsheet/issues/7246
+            final SpreadsheetViewport viewport = (SpreadsheetViewport) typedValue;
+
+            if (viewport.navigations().isNotEmpty()) {
+                throw new SpreadsheetMetadataPropertyValueException(
+                    "Navigations not empty",
+                    propertyName,
+                    viewport
+                );
+            }
+        }
         return this.set0(
-            Objects.requireNonNull(
-                propertyName,
-                "propertyName"
-            ),
-            propertyName.checkValue(value) // necessary because absolute references values are made relative
+            propertyName,
+            typedValue
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -70,6 +70,7 @@ import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
 import walkingkooka.spreadsheet.provider.SpreadsheetProviders;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.viewport.SpreadsheetViewportNavigationList;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportRectangle;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.tree.expression.ExpressionFunctionName;
@@ -324,6 +325,32 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         this.checkEquals(
             locale,
             context.locale()
+        );
+    }
+
+    // set..............................................................................................................
+
+    @Test
+    public void testSetWithSpreadsheetViewportWithoutNavigations() {
+        SpreadsheetMetadata.EMPTY
+            .set(
+                SpreadsheetMetadataPropertyName.VIEWPORT,
+                SpreadsheetViewportRectangle.parse("A1:100:200")
+                    .viewport()
+            );
+    }
+
+    @Test
+    public void testSetWithSpreadsheetViewportWithNavigationsFails() {
+        assertThrows(
+            SpreadsheetMetadataPropertyValueException.class,
+            () -> SpreadsheetMetadata.EMPTY
+                .set(
+                    SpreadsheetMetadataPropertyName.VIEWPORT,
+                    SpreadsheetViewportRectangle.parse("A1:100:200")
+                        .viewport()
+                        .setNavigations(SpreadsheetViewportNavigationList.parse("left 1px"))
+                )
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7246
- SpreadsheetMetadata.set(VIEWPORT) should fail if SpreadsheetViewport has non empty navigations