### PR TITLE
SpreadsheetColumnOrRowReference.toColumn/toRow

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReference.java
@@ -35,4 +35,19 @@ public interface SpreadsheetColumnOrRowReference {
     default boolean isRow() {
         return this instanceof SpreadsheetRowReference;
     }
+
+
+    default SpreadsheetColumnReference toColumn() {
+        return this.toSelection()
+            .toColumn();
+    }
+
+    default SpreadsheetRowReference toRow() {
+        return this.toSelection()
+            .toRow();
+    }
+
+    private SpreadsheetSelection toSelection() {
+        return (SpreadsheetSelection) this;
+    }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.reference;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class SpreadsheetColumnOrRowReferenceTest implements ClassTesting<SpreadsheetColumnOrRowReference> {
+
+    @Test
+    public void testToColumnWithSpreadsheetColumnReference() {
+        final SpreadsheetColumnOrRowReference column = SpreadsheetSelection.A1.toColumn();
+
+        assertSame(
+            column,
+            column.toColumn()
+        );
+    }
+
+    @Test
+    public void testToRowWithSpreadsheetRowReference() {
+        final SpreadsheetColumnOrRowReference row = SpreadsheetSelection.A1.toRow();
+
+        assertSame(
+            row,
+            row.toRow()
+        );
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetColumnOrRowReference> type() {
+        return SpreadsheetColumnOrRowReference.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7245
- SpreadsheetColumnOrRowReference.toColumn/toRow