### PR TITLE
SpreadsheetMetadata.converter Converter.toString prefixed with Spread…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -525,22 +525,27 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Creates a {@link Converter} using the {@link SpreadsheetMetadataPropertyName} along with requiring other metadata properties.
      */
     // @VisibleForTesting
-    final Converter<SpreadsheetConverterContext> converter(final SpreadsheetMetadataPropertyName<ConverterSelector> converterSelector,
+    final Converter<SpreadsheetConverterContext> converter(final SpreadsheetMetadataPropertyName<ConverterSelector> converterSelectorPropertyName,
                                                            final ConverterProvider converterProvider,
                                                            final ProviderContext context) {
-        Objects.requireNonNull(converterSelector, "converterSelector");
+        Objects.requireNonNull(converterSelectorPropertyName, "converterSelectorPropertyName");
         Objects.requireNonNull(converterProvider, "converterProvider");
         Objects.requireNonNull(context, "context");
 
         final SpreadsheetMetadataMissingComponents missing = SpreadsheetMetadataMissingComponents.with(this);
 
-        final ConverterSelector converter = missing.getOrNull(converterSelector);
+        final ConverterSelector converterSelector = missing.getOrNull(converterSelectorPropertyName);
 
         missing.reportIfMissing();
 
-        return converter.evaluateValueText(
+        final Converter<SpreadsheetConverterContext> converter = converterSelector.evaluateValueText(
             converterProvider,
             context
+        );
+
+        // prefix toString with property name
+        return converter.setToString(
+            converterSelectorPropertyName + ": " + converterSelector
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -700,6 +700,76 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         );
     }
 
+    @Test
+    public void testConverterToStringPrefixedByPropertyNameWithFormulaConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
+            .set(
+                SpreadsheetMetadataPropertyName.LOCALE,
+                locale
+            ).loadFromLocale(
+                LocaleContexts.jre(locale)
+            );
+
+        final Converter<SpreadsheetConverterContext> converter = metadata.converter(
+            SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
+            SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.generalConverter(
+                    spreadsheetFormatterProvider(),
+                    spreadsheetParserProvider(),
+                    p
+                )
+            ),
+            PROVIDER_CONTEXT
+        );
+
+        this.toStringAndCheck(
+            converter,
+            "formulaConverter: collection(null-to-number, simple, number-to-number, text-to-text, " +
+                "error-to-number, error-throwing, text-to-error, text-to-selection, selection-to-selection, " +
+                "selection-to-text, text-to-expression, text-to-locale, text-to-template-value-name, text-to-url, " +
+                "general)"
+        );
+    }
+
+    @Test
+    public void testConverterToStringPrefixedByPropertyNameWithFormatterConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
+        final SpreadsheetMetadata metadata = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
+            .set(
+                SpreadsheetMetadataPropertyName.LOCALE,
+                locale
+            ).loadFromLocale(
+                LocaleContexts.jre(locale)
+            );
+
+        final Converter<SpreadsheetConverterContext> converter = metadata.converter(
+            SpreadsheetMetadataPropertyName.FORMATTING_CONVERTER,
+            SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.generalConverter(
+                    spreadsheetFormatterProvider(),
+                    spreadsheetParserProvider(),
+                    p
+                )
+            ),
+            PROVIDER_CONTEXT
+        );
+
+        this.toStringAndCheck(
+            converter,
+            "formattingConverter: collection(null-to-number, simple, number-to-number, text-to-text, " +
+                "error-to-number, error-throwing, text-to-error, text-to-expression, text-to-locale, " +
+                "text-to-template-value-name, text-to-url, text-to-selection, selection-to-selection, " +
+                "selection-to-text, spreadsheet-cell-to, has-style-to-style, text-to-color, color-to-number, " +
+                "number-to-color, color-to-color, text-to-spreadsheet-color-name, " +
+                "text-to-spreadsheet-formatter-selector, text-to-spreadsheet-metadata-color, text-to-spreadsheet-text, " +
+                "text-to-text-node, text-to-text-style, text-to-text-style-property-name, to-styleable, to-text-node, " +
+                "url-to-hyperlink, url-to-image, general)"
+        );
+    }
+
     // ExpressionFunctionProvider.......................................................................................
 
     @Test


### PR DESCRIPTION
…sheetMetadataPropertyName

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7273
- SpreadsheetMetadata.converter Converter#toString should include property name as prefix before wrapped Converter:toString