### PR TITLE
BasicSpreadsheetExpressionEvaluationContext.reference EnvironmentValu…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
@@ -363,6 +363,16 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                     this
                 );
             }
+        } else {
+            if (reference instanceof EnvironmentValueName) {
+                value = Optional.ofNullable(
+                    Cast.to(
+                        this.environmentValue(
+                            (EnvironmentValueName<?>) reference
+                        )
+                    )
+                );
+            }
         }
 
         return value;

--- a/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
@@ -637,6 +637,27 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
         );
     }
 
+    @Test
+    public void testReferenceWithEnvironmentValueName() {
+        final EnvironmentContext environmentContext = EnvironmentContexts.map(
+            ENVIRONMENT_CONTEXT
+        );
+
+        final EnvironmentValueName<String> name = EnvironmentValueName.with("Hello");
+        final String value = "Hello World123";
+
+        environmentContext.setEnvironmentValue(
+            name,
+            value
+        );
+
+        this.referenceAndCheck(
+            this.createContext(environmentContext),
+            name,
+            value
+        );
+    }
+
     // ExpressionEvaluationContextTesting................................................................................
 
     @Override


### PR DESCRIPTION
…eName support

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7277
- BasicSpreadsheetExpressionEvaluationContext.reference should handle EnvironmentValueName