### PR TITLE
SpreadsheetConverterTextToSpreadsheetMetadataColor Color sub-class ta…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToSpreadsheetMetadataColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToSpreadsheetMetadataColor.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.spreadsheet.convert;
 
+import walkingkooka.Cast;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatParserContexts;
@@ -43,22 +44,29 @@ final class SpreadsheetConverterTextToSpreadsheetMetadataColor extends Spreadshe
     public boolean isTargetType(final Object value,
                                 final Class<?> type,
                                 final SpreadsheetConverterContext context) {
-        return Color.class == type;
+        return Color.isColorClass(type);
     }
 
     @Override
     public Color parseText(final String text,
                            final Class<?> type,
                            final SpreadsheetConverterContext context) {
-        return SpreadsheetConverterTextToSpreadsheetMetadataColorSpreadsheetFormatParserTokenVisitor.color(
-            SpreadsheetFormatParsers.color()
-                .parseText(
-                    text,
-                    SpreadsheetFormatParserContexts.basic(
-                        InvalidCharacterExceptionFactory.POSITION
-                    )
+        // convert to probably an RgbColor using the visitor then convert to the target Color type
+
+        return Cast.to(
+            context.convertOrFail(
+                SpreadsheetConverterTextToSpreadsheetMetadataColorSpreadsheetFormatParserTokenVisitor.color(
+                    SpreadsheetFormatParsers.color()
+                        .parseText(
+                            text,
+                            SpreadsheetFormatParserContexts.basic(
+                                InvalidCharacterExceptionFactory.POSITION
+                            )
+                        ),
+                    context
                 ),
-            context
+                type
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToSpreadsheetMetadataColorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToSpreadsheetMetadataColorTest.java
@@ -19,8 +19,10 @@ package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.color.Color;
 import walkingkooka.convert.Converter;
+import walkingkooka.convert.Converters;
 import walkingkooka.spreadsheet.format.SpreadsheetColorName;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
@@ -82,6 +84,22 @@ public final class SpreadsheetConverterTextToSpreadsheetMetadataColorTest extend
         );
     }
 
+    @Test
+    public void testConvertStringColorNumberToRgbColor() {
+        this.convertAndCheck(
+            "[color10]",
+            COLOR
+        );
+    }
+
+    @Test
+    public void testConvertStringColorNumberToHsvColor() {
+        this.convertAndCheck(
+            "[color10]",
+            COLOR.toHsv()
+        );
+    }
+
     @Override
     public SpreadsheetConverterTextToSpreadsheetMetadataColor createConverter() {
         return SpreadsheetConverterTextToSpreadsheetMetadataColor.INSTANCE;
@@ -111,7 +129,12 @@ public final class SpreadsheetConverterTextToSpreadsheetMetadataColorTest extend
                 );
             }
 
-            private final Converter<SpreadsheetConverterContext> converter = SpreadsheetConverters.textToText();
+            private final Converter<SpreadsheetConverterContext> converter = Converters.collection(
+                Lists.of(
+                    SpreadsheetConverters.textToText(),
+                    SpreadsheetConverters.colorToColor()
+                )
+            );
 
             @Override
             public SpreadsheetMetadata spreadsheetMetadata() {


### PR DESCRIPTION
…rget support

- Previously it only accepted Color.class as the target, now sub-classes are supported and converted as required.