### PR TITLE
SpreadsheetSelection.toCell/toCellRange/toCellOrCellRange rewrite

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceOrRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceOrRange.java
@@ -25,4 +25,12 @@ public abstract class SpreadsheetColumnOrRowReferenceOrRange extends Spreadsheet
     SpreadsheetColumnOrRowReferenceOrRange() {
         super();
     }
+
+    /**
+     * Attempts to convert a column or row to a cell will fail.
+     */
+    @Override
+    public final SpreadsheetCellReference toCell() {
+        throw new UnsupportedOperationException(this.toString());
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReference.java
@@ -242,12 +242,6 @@ public final class SpreadsheetColumnRangeReference extends SpreadsheetColumnRefe
     // toXXX............................................................................................................
 
     @Override
-    public SpreadsheetCellReference toCell() {
-        return this.toScalar()
-            .toCell();
-    }
-
-    @Override
     public SpreadsheetColumnReference toColumn() {
         return this.begin();
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReference.java
@@ -292,15 +292,6 @@ public final class SpreadsheetColumnReference extends SpreadsheetColumnReference
         return this.equalsIgnoreReferenceKind(column);
     }
 
-    // toCell............................................................................................................
-
-    @Override
-    public SpreadsheetCellReference toCell() {
-        return this.setRow(
-            SpreadsheetReferenceKind.RELATIVE.firstRow()
-        );
-    }
-
     // toRelative.......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReference.java
@@ -233,12 +233,6 @@ public final class SpreadsheetRowRangeReference extends SpreadsheetRowReferenceO
     // toXXX............................................................................................................
 
     @Override
-    public SpreadsheetCellReference toCell() {
-        return this.toScalar()
-            .toCell();
-    }
-
-    @Override
     public SpreadsheetRowReference toRow() {
         return this.begin();
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReference.java
@@ -334,13 +334,6 @@ public final class SpreadsheetRowReference extends SpreadsheetRowReferenceOrRang
     // toXXX............................................................................................................
 
     @Override
-    public SpreadsheetCellReference toCell() {
-        return this.setColumn(
-            SpreadsheetReferenceKind.RELATIVE.firstColumn()
-        );
-    }
-
-    @Override
     public SpreadsheetRowReference toRow() {
         return this;
     }

--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -1056,8 +1056,8 @@ public abstract class SpreadsheetSelection implements HasText,
     public abstract SpreadsheetCellReference toCell();
 
     /**
-     * Attempts to convert this selection to a {@link SpreadsheetCellRangeReference} throwing a {@link UnsupportedOperationException}
-     * if the selection is a label.
+     * Attempts to convert this selection to a {@link SpreadsheetCellRangeReference}.
+     * {@link SpreadsheetColumnReference} such as "A" will become return a cell range that covers includes "A" and covers all rows.
      */
     public final SpreadsheetCellRangeReference toCellRange() {
         return SpreadsheetSelectionToCellRangeSpreadsheetSelectionVisitor.toCellRange(
@@ -1066,13 +1066,12 @@ public abstract class SpreadsheetSelection implements HasText,
     }
 
     /**
-     * A cell or cell ranges will return this otherwise a {@link UnsupportedOperationException} will be thrown.
+     * If this is a {@link SpreadsheetCellReference} return this otherwise converts this selection to a {@link SpreadsheetCellRangeReference}.
      */
     public final SpreadsheetCellReferenceOrRange toCellOrCellRange() {
-        if (false == this.isCell() && false == this.isCellRange()) {
-            throw new UnsupportedOperationException(this.toString());
-        }
-        return (SpreadsheetCellReferenceOrRange) this;
+        return this.isCell() ?
+            this.toCell() :
+            this.toCellRange();
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionSelect.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionSelect.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetColumnOrRowReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
@@ -53,8 +54,23 @@ abstract class SpreadsheetViewportNavigationSelectionSelect<T extends Spreadshee
     @Override //
     final Optional<SpreadsheetCellReference> updateHome(final SpreadsheetCellReference home,
                                                         final SpreadsheetViewportNavigationContext context) {
+        SpreadsheetSelection selection = this.selection;
+
+        if (selection.isColumn()) {
+            selection = selection.toColumn()
+                .setRow(
+                    SpreadsheetColumnOrRowReferenceKind.ROW.firstRelative().toRow()
+                );
+        }
+        if (selection.isRow()) {
+            selection = selection.toRow()
+                .setColumn(
+                    SpreadsheetColumnOrRowReferenceKind.COLUMN.firstRelative().toColumn()
+                );
+        }
+
         return Optional.of(
-            this.selection.toCell()
+            selection.toCell()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -258,7 +258,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
         );
     }
 
-    // toCellRangeResolvingLabels........................................................................................
+    // toCellRange......................................................................................................
 
     @Test
     public void testToCellRange() {
@@ -282,7 +282,7 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetCellReference
     public void testToColumn() {
         this.toColumnAndCheck(
             SpreadsheetSelection.A1,
-            SpreadsheetSelection.parseColumn("A")
+            SpreadsheetSelection.A1.toColumn()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
@@ -70,13 +70,6 @@ public abstract class SpreadsheetColumnOrRowRangeReferenceTestCase<S extends Spr
         );
     }
 
-    // toCellOrCellRange................................................................................................
-
-    @Test
-    public final void testToCellOrCellRangeFails() {
-        this.toCellOrCellRangeFails();
-    }
-
     // toExpressionReference............................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -1309,18 +1309,43 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
     // toCell...........................................................................................................
 
     @Test
-    public void testToCell() {
-        this.toCellAndCheck(
-            "A:B",
-            "A1"
+    public void testToCellFails() {
+        this.toCellFails();
+    }
+
+    // toCellRange......................................................................................................
+
+    @Test
+    public void testToCellRange() {
+        this.toCellRangeAndCheck(
+            "A",
+            "A1:A" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
         );
     }
 
     @Test
-    public void testToCell2() {
-        this.toCellAndCheck(
-            "B:C",
-            "B1"
+    public void testToCellRange2() {
+        this.toCellRangeAndCheck(
+            "B",
+            "B1:B" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
+        );
+    }
+
+    // toCellOrCellRange................................................................................................
+
+    @Test
+    public void testToCellOrCellRange() {
+        this.toCellOrCellRangeAndCheck(
+            "A",
+            "A1:A" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
+        );
+    }
+
+    @Test
+    public void testToCellOrCellRange2() {
+        this.toCellRangeAndCheck(
+            "B",
+            "B1:B" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -712,18 +712,35 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     // toCell...........................................................................................................
 
     @Test
-    public void testToCell() {
-        this.toCellAndCheck(
+    public void testToCellFails() {
+        this.toCellFails();
+    }
+
+    // toCellRange......................................................................................................
+
+    @Test
+    public void testToCellRange() {
+        this.toCellRangeAndCheck(
             "A",
-            "A1"
+            "A1:A" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
         );
     }
 
     @Test
-    public void testToCell2() {
-        this.toCellAndCheck(
+    public void testToCellRange2() {
+        this.toCellRangeAndCheck(
             "B",
-            "B1"
+            "B1:B" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
+        );
+    }
+
+    // toCellOrCellRange................................................................................................
+
+    @Test
+    public void testToCellOrCellRange() {
+        this.toCellOrCellRangeAndCheck(
+            "B",
+            "B1:B" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -1318,18 +1318,43 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
     // toCell...........................................................................................................
 
     @Test
-    public void testToCell() {
-        this.toCellAndCheck(
-            "1:2",
-            "A1"
+    public void testToCellFails() {
+        this.toCellFails();
+    }
+
+    // toCellRange......................................................................................................
+
+    @Test
+    public void testToCellRange() {
+        this.toCellRangeAndCheck(
+            "1",
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "1"
         );
     }
 
     @Test
-    public void testToCell2() {
-        this.toCellAndCheck(
+    public void testToCellRange2() {
+        this.toCellRangeAndCheck(
             "2:3",
-            "A2"
+            "A2:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "3"
+        );
+    }
+
+    // toCellOrCellRange................................................................................................
+
+    @Test
+    public void testToCellOrCellRange() {
+        this.toCellRangeAndCheck(
+            "1:1",
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "1"
+        );
+    }
+
+    @Test
+    public void testToCellOrCellRange2() {
+        this.toCellRangeAndCheck(
+            "2:3",
+            "A2:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "3"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -710,18 +710,35 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     // toCell...........................................................................................................
 
     @Test
-    public void testToCell() {
-        this.toCellAndCheck(
+    public void testToCellFails() {
+        this.toCellFails();
+    }
+
+    // toCellRange......................................................................................................
+
+    @Test
+    public void testToCellRange() {
+        this.toCellRangeAndCheck(
             "1",
-            "A1"
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "1"
         );
     }
 
     @Test
-    public void testToCell2() {
-        this.toCellAndCheck(
+    public void testToCellRange2() {
+        this.toCellRangeAndCheck(
             "2",
-            "A2"
+            "A2:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "2"
+        );
+    }
+
+    // toCellOrCellRange................................................................................................
+
+    @Test
+    public void testToCellOrCellRange() {
+        this.toCellOrCellRangeAndCheck(
+            "1",
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "1"
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -263,6 +263,14 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
 
     // toCell...........................................................................................................
 
+    final void toCellFails() {
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> this.createSelection()
+                .toCell()
+        );
+    }
+
     final void toCellAndCheck(final String selection,
                               final String expected) {
         this.toCellAndCheck(
@@ -313,6 +321,25 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         this.checkEquals(
             expected,
             selection.toCellRange(),
+            selection::toString
+        );
+    }
+
+    // toCellOrCellRange................................................................................................
+
+    final void toCellOrCellRangeAndCheck(final String selection,
+                                         final String expected) {
+        this.toCellOrCellRangeAndCheck(
+            this.parseString(selection),
+            SpreadsheetSelection.parseCellRange(expected)
+        );
+    }
+
+    final void toCellOrCellRangeAndCheck(final SpreadsheetSelection selection,
+                                         final SpreadsheetCellRangeReference expected) {
+        this.checkEquals(
+            expected,
+            selection.toCellOrCellRange(),
             selection::toString
         );
     }


### PR DESCRIPTION
- SpreadsheetColumnOrRowReferenceOrRange.toCell now throws UOE.
- SpreadsheetViewportNavigationSelectionSelect.updateHome selects first column/row for row/column.
- SpreadsheetSelection#toCellRange for types like "A" will return a cell-range with all rows, previously it would throw UOE for column/row.