### PR TITLE
SpreadsheetSelection.toExpressionReference column/row supported

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/reference/SpreadsheetSelection.java
@@ -1121,14 +1121,18 @@ public abstract class SpreadsheetSelection implements HasText,
     }
 
     /**
-     * A cell or cell ranges or label will return a {@link SpreadsheetExpressionReference} otherwise a
-     * {@link UnsupportedOperationException} will be thrown.
+     * A {@link SpreadsheetCellReference} or {@link SpreadsheetLabelName} will return this, while other types
+     * will be converted to a {@link SpreadsheetCellRangeReference}.
+     * <pre>
+     * A -> A1:A1048576 replacing the missing rows with all rows.
+     * </pre>
      */
     public final SpreadsheetExpressionReference toExpressionReference() {
-        if (false == this.isCell() && false == this.isCellRange() && false == this.isLabelName()) {
-            throw new UnsupportedOperationException(this.toString());
-        }
-        return (SpreadsheetExpressionReference) this;
+        return this.isLabelName() ?
+            this.toLabelName() :
+            this.isCell() ?
+                this.toCell() :
+                this.toCellRange();
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowRangeReferenceTestCase.java
@@ -70,13 +70,6 @@ public abstract class SpreadsheetColumnOrRowRangeReferenceTestCase<S extends Spr
         );
     }
 
-    // toExpressionReference............................................................................................
-
-    @Test
-    public final void testToExpressionReferenceFails() {
-        this.toExpressionReferenceFails();
-    }
-
     // toRange.........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnOrRowReferenceTestCase.java
@@ -120,13 +120,6 @@ public abstract class SpreadsheetColumnOrRowReferenceTestCase<R extends Spreadsh
         assertNotSame(reference, this.createReference(value));
     }
 
-    // toExpressionReference............................................................................................
-
-    @Test
-    public final void testToExpressionReferenceFails() {
-        this.toExpressionReferenceFails();
-    }
-
     // toRange.........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnRangeReferenceTest.java
@@ -1357,6 +1357,16 @@ public final class SpreadsheetColumnRangeReferenceTest extends SpreadsheetColumn
         );
     }
 
+    // toExpressionReference............................................................................................
+
+    @Test
+    public void testToExpressionReference() {
+        this.toCellOrCellRangeAndCheck(
+            "A:B",
+            "A1:B" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
+        );
+    }
+
     // IterableTesting..................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -744,6 +744,16 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
         );
     }
 
+    // toExpressionReference............................................................................................
+
+    @Test
+    public void testToExpressionReference() {
+        this.toCellOrCellRangeAndCheck(
+            "A",
+            "A1:A" + SpreadsheetColumnOrRowReferenceKind.ROW.lastRelative()
+        );
+    }
+
     // columnRange...................................................................................................,,,
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowRangeReferenceTest.java
@@ -1358,6 +1358,16 @@ public final class SpreadsheetRowRangeReferenceTest extends SpreadsheetColumnOrR
         );
     }
 
+    // toExpressionReference............................................................................................
+
+    @Test
+    public void testToExpressionReference() {
+        this.toCellOrCellRangeAndCheck(
+            "1:2",
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "2"
+        );
+    }
+
     // toColumn.........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -742,6 +742,24 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
         );
     }
 
+    // toExpressionReference............................................................................................
+
+    @Test
+    public void testToExpressionReference() {
+        this.toCellOrCellRangeAndCheck(
+            "1",
+            "A1:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "1"
+        );
+    }
+
+    @Test
+    public void testToExpressionReference2() {
+        this.toCellOrCellRangeAndCheck(
+            "2",
+            "A2:" + SpreadsheetColumnOrRowReferenceKind.COLUMN.lastRelative() + "2"
+        );
+    }
+
     // toColumn.........................................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -408,6 +408,23 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
         );
     }
 
+    final void toExpressionReferenceAndCheck(final String selection,
+                                             final String expected) {
+        this.toExpressionReferenceAndCheck(
+            this.parseString(selection),
+            SpreadsheetSelection.parseExpressionReference(expected)
+        );
+    }
+
+    final void toExpressionReferenceAndCheck(final SpreadsheetSelection selection,
+                                             final SpreadsheetExpressionReference expected) {
+        this.checkEquals(
+            expected,
+            selection.toExpressionReference(),
+            selection::toString
+        );
+    }
+
     final void toExpressionReferenceFails() {
         assertThrows(
             UnsupportedOperationException.class,


### PR DESCRIPTION
- Previously cell/rows would throw UOE, now they return the same as #toCellRange.