### PR TITLE
SpreadsheetConverterNumberToText.ignoreDecimalNumberContextSymbols

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToText.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToText.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.convert;
 
+import walkingkooka.Cast;
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatters;
@@ -28,12 +29,25 @@ import walkingkooka.tree.expression.ExpressionNumber;
 final class SpreadsheetConverterNumberToText extends SpreadsheetConverter {
 
     /**
-     * Singleton
+     * Gets an instance of {@link SpreadsheetConverterNumberToText}.
+     * Note the boolean flag is used to control whether {@link walkingkooka.math.DecimalNumberContext} symbols are ignored.
+     * The default text to number behaviour requires the decimal point etc from the context to be ignored and "defaults"
+     * used instead, so formulas will always only accept "." as the decimal point.
+     * The function numberValue however must be able to pass custom decimal-point and group-separator.
      */
-    final static SpreadsheetConverterNumberToText INSTANCE = new SpreadsheetConverterNumberToText();
+    static SpreadsheetConverterNumberToText with(final boolean ignoreDecimalNumberContextSymbols) {
+        return ignoreDecimalNumberContextSymbols ?
+            TRUE :
+            FALSE;
+    }
 
-    private SpreadsheetConverterNumberToText() {
+    private final static SpreadsheetConverterNumberToText TRUE = new SpreadsheetConverterNumberToText(true);
+
+    private final static SpreadsheetConverterNumberToText FALSE = new SpreadsheetConverterNumberToText(false);
+
+    private SpreadsheetConverterNumberToText(final boolean ignoreDecimalNumberContextSymbols) {
         super();
+        this.ignoreDecimalNumberContextSymbols = ignoreDecimalNumberContextSymbols;
     }
 
     @Override
@@ -51,14 +65,34 @@ final class SpreadsheetConverterNumberToText extends SpreadsheetConverter {
         return GENERAL_FORMATTER.convert(
             value,
             type,
-            SpreadsheetConverterNumberToTextSpreadsheetConverterContext.with(context)
+            this.ignoreDecimalNumberContextSymbols ?
+                SpreadsheetConverterNumberToTextSpreadsheetConverterContext.with(context) :
+                context
         );
     }
+
+    private final boolean ignoreDecimalNumberContextSymbols;
 
     private final static Converter<SpreadsheetConverterContext> GENERAL_FORMATTER = SpreadsheetFormatters.general()
         .converter();
 
     // Object...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+            other instanceof SpreadsheetConverterNumberToText &&
+                this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final SpreadsheetConverterNumberToText other) {
+        return this.ignoreDecimalNumberContextSymbols == other.ignoreDecimalNumberContextSymbols;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -312,7 +312,9 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
         nullToNumber(),
         numberToNumber(),
         toNumber(),
-        numberToText()
+        numberToText(
+            true // ignoreDecimalNumberContextSymbols
+        )
     );
     
     /**
@@ -332,8 +334,8 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     /**
      * {@see SpreadsheetConverterNumberToText}
      */
-    public static Converter<SpreadsheetConverterContext> numberToText() {
-        return SpreadsheetConverterNumberToText.INSTANCE;
+    public static Converter<SpreadsheetConverterContext> numberToText(final boolean ignoreDecimalNumberContextSymbols) {
+        return SpreadsheetConverterNumberToText.with(ignoreDecimalNumberContextSymbols);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
@@ -211,7 +211,9 @@ final class SpreadsheetConvertersConverterProvider implements ConverterProvider 
             case NUMBER_TO_TEXT_STRING:
                 noParameterCheck(copy);
 
-                converter = SpreadsheetConverters.numberToText();
+                converter = SpreadsheetConverters.numberToText(
+                    true // ignoreDecimalNumberContextSymbols
+                );
                 break;
             case NULL_TO_NUMBER_STRING:
                 noParameterCheck(copy);

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
+import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
@@ -26,7 +27,8 @@ import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.math.MathContext;
 
-public final class SpreadsheetConverterNumberToTextTest extends SpreadsheetConverterTestCase<SpreadsheetConverterNumberToText> {
+public final class SpreadsheetConverterNumberToTextTest extends SpreadsheetConverterTestCase<SpreadsheetConverterNumberToText>
+    implements HashCodeEqualsDefinedTesting2<SpreadsheetConverterNumberToText> {
 
     private final static ExpressionNumberKind KIND = ExpressionNumberKind.BIG_DECIMAL;
 
@@ -46,9 +48,66 @@ public final class SpreadsheetConverterNumberToTextTest extends SpreadsheetConve
         );
     }
 
+    @Test
+    public void testConvertNumberWithDecimalPlacesToTextAndCustomDecimalPoint() {
+        this.convertAndCheck(
+            SpreadsheetConverterNumberToText.with(
+                false
+            ),
+            KIND.create(45.75),
+            String.class,
+            new FakeSpreadsheetConverterContext() {
+                @Override
+                public ExpressionNumberKind expressionNumberKind() {
+                    return KIND;
+                }
+
+                @Override
+                public char decimalSeparator() {
+                    return '*';
+                }
+
+                @Override
+                public MathContext mathContext() {
+                    return MathContext.DECIMAL32;
+                }
+
+                @Override
+                public char zeroDigit() {
+                    return '0';
+                }
+
+
+                @Override
+                public boolean canConvert(final Object value,
+                                          final Class<?> type) {
+                    return type.isInstance(value);
+                }
+
+                @Override
+                public <T> Either<T, String> convert(final Object value,
+                                                     final Class<T> target) {
+                    return this.successfulConversion(
+                        target.cast(value),
+                        target
+                    );
+                }
+
+                @Override
+                public SpreadsheetMetadata spreadsheetMetadata() {
+                    return SpreadsheetMetadata.EMPTY.set(
+                        SpreadsheetMetadataPropertyName.GENERAL_NUMBER_FORMAT_DIGIT_COUNT,
+                        SpreadsheetFormatterContext.DEFAULT_GENERAL_FORMAT_NUMBER_DIGIT_COUNT
+                    );
+                }
+            },
+            "45*75"
+        );
+    }
+
     @Override
     public SpreadsheetConverterNumberToText createConverter() {
-        return SpreadsheetConverterNumberToText.INSTANCE;
+        return SpreadsheetConverterNumberToText.with(true);
     }
 
     @Override
@@ -88,6 +147,21 @@ public final class SpreadsheetConverterNumberToTextTest extends SpreadsheetConve
             }
         };
     }
+
+    // Object...........................................................................................................
+
+    @Test
+    public void testEqualsDifferentIgnoreDecimalNumberContextSymbols() {
+        this.checkNotEquals(
+            SpreadsheetConverterNumberToText.with(false)
+        );
+    }
+
+    @Override
+    public SpreadsheetConverterNumberToText createObject() {
+        return SpreadsheetConverterNumberToText.with(true);
+    }
+
 
     // class............................................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
@@ -342,7 +342,9 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
         this.converterAndCheck(
             "number-to-text",
             PROVIDER_CONTEXT,
-            SpreadsheetConverters.numberToText()
+            SpreadsheetConverters.numberToText(
+                true // ignoreDecimalNumberContextSymbols
+            )
         );
     }
 


### PR DESCRIPTION
- Fixes numberValue honouring the given decimal-separator and grouping-separator.