### PR TITLE
SpreadsheetCellQuery.PARSER_CONTEXT POSITION not column/row partial FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetCellQuery.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetCellQuery.java
@@ -102,7 +102,7 @@ public final class SpreadsheetCellQuery implements HasUrlFragment,
     final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.BIG_DECIMAL;
 
     private final static SpreadsheetParserContext PARSER_CONTEXT = SpreadsheetParserContexts.basic(
-        InvalidCharacterExceptionFactory.COLUMN_AND_LINE_EXPECTED,
+        InvalidCharacterExceptionFactory.POSITION_EXPECTED,
         DateTimeContexts.fake(),
         ExpressionNumberContexts.basic(
             EXPRESSION_NUMBER_KIND,


### PR DESCRIPTION
- Incomplete because of #399
- https://github.com/mP1/walkingkooka-text-cursor-parser/issues/399
- BasicParserReporter.endOfText message always reports column/row, should use ParserContext.endOfText(Parser)