### PR TITLE
SpreadsheetConverterDateTime: date/dateTime/time string support

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -277,6 +277,11 @@ public class TestGwtTest extends GWTTestCase {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            (ProviderContext p) -> metadata.dateTimeConverter(
+                spreadsheetFormatterProvider,
+                spreadsheetParserProvider,
+                p
+            ),
             (ProviderContext p) -> metadata.generalConverter(
                 spreadsheetFormatterProvider,
                 spreadsheetParserProvider,

--- a/src/it/j2cl-test/src/test/java/test/J2clTest.java
+++ b/src/it/j2cl-test/src/test/java/test/J2clTest.java
@@ -291,6 +291,11 @@ public class J2clTest {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            (ProviderContext p) -> metadata.dateTimeConverter(
+                spreadsheetFormatterProvider,
+                spreadsheetParserProvider,
+                p
+            ),
             (ProviderContext p) -> metadata.generalConverter(
                 spreadsheetFormatterProvider,
                 spreadsheetParserProvider,

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterDateTime.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterDateTime.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.expression.ExpressionNumber;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
 
 /**
  * A {@link Converter} that handles converting {@link Boolean}, {@link LocalDate}, {@link LocalDateTime},
@@ -33,12 +34,39 @@ import java.time.LocalTime;
 final class SpreadsheetConverterDateTime extends SpreadsheetConverter {
 
     /**
-     * Singleton
+     * Factory that creates a {@link SpreadsheetConverterDateTime}.
      */
-    final static SpreadsheetConverterDateTime INSTANCE = new SpreadsheetConverterDateTime();
+    static SpreadsheetConverterDateTime with(final Converter<SpreadsheetConverterContext> dateToString,
+                                             final Converter<SpreadsheetConverterContext> dateTimeToString,
+                                             final Converter<SpreadsheetConverterContext> timeToString,
+                                             final Converter<SpreadsheetConverterContext> stringToDate,
+                                             final Converter<SpreadsheetConverterContext> stringToDateTime,
+                                             final Converter<SpreadsheetConverterContext> stringToTime) {
+        return new SpreadsheetConverterDateTime(
+            Objects.requireNonNull(dateToString, "dateToString"),
+            Objects.requireNonNull(dateTimeToString, "dateTimeToString"),
+            Objects.requireNonNull(timeToString, "timeToString"),
+            Objects.requireNonNull(stringToDate, "stringToDate"),
+            Objects.requireNonNull(stringToDateTime, "stringToDateTime"),
+            Objects.requireNonNull(stringToTime, "stringToTime")
+        );
+    }
 
-    private SpreadsheetConverterDateTime() {
+    private SpreadsheetConverterDateTime(final Converter<SpreadsheetConverterContext> dateToString,
+                                         final Converter<SpreadsheetConverterContext> dateTimeToString,
+                                         final Converter<SpreadsheetConverterContext> timeToString,
+                                         final Converter<SpreadsheetConverterContext> stringToDate,
+                                         final Converter<SpreadsheetConverterContext> stringToDateTime,
+                                         final Converter<SpreadsheetConverterContext> stringToTime) {
         super();
+
+        this.dateToString = dateToString;
+        this.dateTimeToString = dateTimeToString;
+        this.timeToString = timeToString;
+
+        this.stringToDate = stringToDate;
+        this.stringToDateTime = stringToDateTime;
+        this.stringToTime = stringToTime;
     }
 
     @Override
@@ -57,17 +85,21 @@ final class SpreadsheetConverterDateTime extends SpreadsheetConverter {
 
                 can = isDateDateTimeOrTimeClass(type);
             } else {
-                // Date -> DateTime | Number
+                // Date -> DateTime | Number | String
                 if (value instanceof LocalDate) {
-                    can = LocalDate.class == type || LocalDateTime.class == type || ExpressionNumber.isClass(type);
+                    can = LocalDate.class == type || LocalDateTime.class == type || ExpressionNumber.isClass(type) || String.class == type;
                 } else {
-                    // Date | DateTime | Time -> DateTime | Number
+                    // Date | DateTime | Time -> DateTime | Number | String
                     if (value instanceof LocalDateTime) {
-                        can = LocalDate.class == type || LocalDateTime.class == type || LocalTime.class == type || ExpressionNumber.isClass(type);
+                        can = LocalDate.class == type || LocalDateTime.class == type || LocalTime.class == type || ExpressionNumber.isClass(type) || String.class == type;
                     } else {
                         // Time -> Boolean | DateTime | Time | Number | String
                         if (value instanceof LocalTime) {
                             can = Boolean.class == type || LocalDateTime.class == type || LocalTime.class == type || ExpressionNumber.isClass(type) || String.class == type;
+                        } else {
+                            if(value instanceof String) {
+                                can = isDateDateTimeOrTimeClass(type);
+                            }
                         }
                     }
                 }
@@ -88,68 +120,117 @@ final class SpreadsheetConverterDateTime extends SpreadsheetConverter {
                 type
             );
         } else {
-            if (value instanceof LocalDateTime && LocalTime.class == type) {
-                result = this.successfulConversion(
-                    ((LocalDateTime) value).toLocalTime(),
-                    type
+            if (value instanceof LocalDate && String.class == type) {
+                result = this.dateToString.convert(
+                    value,
+                    type,
+                    context
                 );
             } else {
-                Number number = null;
-
-                boolean valueIsBoolean = value instanceof Boolean;
-                boolean valueIsNumber = false;
-
-                // Boolean -> Date | DateTime | Time
-                if (valueIsBoolean) {
-                    number = Boolean.TRUE.equals(value) ?
-                        1 :
-                        0;
-                } else {
-                    valueIsNumber = ExpressionNumber.is(value);
-                    if (valueIsNumber) {
-                        // ExpressionNumber | Number -> Number
-                        number = value instanceof ExpressionNumber ?
-                            ((ExpressionNumber) value).value() :
-                            (Number) value;
-                    } else {
-                        // Date | DateTime | Time -> Number -> Date | DateTime | Time
-                        Converter<SpreadsheetConverterContext> converter;
-                        if (value instanceof LocalDate) {
-                            converter = Converters.localDateToNumber();
-                        } else {
-                            if (value instanceof LocalDateTime) {
-                                converter = Converters.localDateTimeToNumber();
-                            } else {
-                                if (value instanceof LocalTime) {
-                                    converter = Converters.localTimeToNumber();
-                                } else {
-                                    throw new IllegalArgumentException("Unsupported type: " + type);
-                                }
-                            }
-                        }
-
-                        number = converter.convert(
-                            value,
-                            Number.class, // Date | DateTime | Time -> a Number
-                            context
-                        ).orElseLeft(null);
-                    }
-                }
-
-                if (isDateDateTimeOrTimeClass(type)) {
-                    // Boolean | Date | DateTime | Time -> Number -> Date | DateTime | Time
-                    result = this.toDateOrDateTimeOrTime(
-                        number,
+                if (value instanceof LocalDateTime && String.class == type) {
+                    result = this.dateTimeToString.convert(
+                        value,
                         type,
                         context
                     );
                 } else {
-                    // Boolean | Date | DateTime | Time -> Number
-                    if (valueIsBoolean || isDateDateTimeOrTime(value) || valueIsNumber) {
-                        result = context.convert(
-                            number,
-                            type
+                    if (value instanceof LocalTime && String.class == type) {
+                        result = this.timeToString.convert(
+                            value,
+                            type,
+                            context
                         );
+                    } else {
+                        if (value instanceof LocalDateTime && LocalTime.class == type) {
+                            result = this.successfulConversion(
+                                ((LocalDateTime) value).toLocalTime(),
+                                type
+                            );
+                        } else {
+                            if (value instanceof String && LocalDate.class == type) {
+                                result = this.stringToDate.convert(
+                                    value,
+                                    type,
+                                    context
+                                );
+                            } else {
+                                if (value instanceof String && LocalDateTime.class == type) {
+                                    result = this.stringToDateTime.convert(
+                                        value,
+                                        type,
+                                        context
+                                    );
+                                } else {
+                                    if (value instanceof String && LocalTime.class == type) {
+                                        result = this.stringToTime.convert(
+                                            value,
+                                            type,
+                                            context
+                                        );
+                                    } else {
+                                        Number number = null;
+
+                                        boolean valueIsBoolean = value instanceof Boolean;
+                                        boolean valueIsNumber = false;
+
+                                        // Boolean -> Date | DateTime | Time
+                                        if (valueIsBoolean) {
+                                            number = Boolean.TRUE.equals(value) ?
+                                                1 :
+                                                0;
+                                        } else {
+                                            valueIsNumber = ExpressionNumber.is(value);
+                                            if (valueIsNumber) {
+                                                // ExpressionNumber | Number -> Number
+                                                number = value instanceof ExpressionNumber ?
+                                                    ((ExpressionNumber) value).value() :
+                                                    (Number) value;
+                                            } else {
+                                                // Date | DateTime | Time -> Number -> Date | DateTime | Time
+                                                Converter<SpreadsheetConverterContext> converter;
+                                                if (value instanceof LocalDate) {
+                                                    converter = Converters.localDateToNumber();
+                                                } else {
+                                                    if (value instanceof LocalDateTime) {
+                                                        converter = Converters.localDateTimeToNumber();
+                                                    } else {
+                                                        if (value instanceof LocalTime) {
+                                                            converter = Converters.localTimeToNumber();
+                                                        } else {
+                                                            throw new IllegalArgumentException("Unsupported type: " + type);
+                                                        }
+                                                    }
+                                                }
+
+                                                number = converter.convert(
+                                                    value,
+                                                    Number.class, // Date | DateTime | Time -> a Number
+                                                    context
+                                                ).orElseLeft(null);
+                                            }
+                                        }
+
+                                        if (isDateDateTimeOrTimeClass(type)) {
+                                            // Boolean | Date | DateTime | Time -> Number -> Date | DateTime | Time
+                                            result = this.toDateOrDateTimeOrTime(
+                                                number,
+                                                type,
+                                                context
+                                            );
+                                        } else {
+                                            // Boolean | Date | DateTime | Time -> Number
+                                            if (valueIsBoolean || isDateDateTimeOrTime(value) || valueIsNumber) {
+                                                result = context.convert(
+                                                    number,
+                                                    type
+                                                );
+                                            }
+                                            ;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -201,7 +282,46 @@ final class SpreadsheetConverterDateTime extends SpreadsheetConverter {
             LocalTime.class == type;
     }
 
+    private final Converter<SpreadsheetConverterContext> dateToString;
+
+    private final Converter<SpreadsheetConverterContext> dateTimeToString;
+
+    private final Converter<SpreadsheetConverterContext> timeToString;
+
+    private final Converter<SpreadsheetConverterContext> stringToDate;
+
+    private final Converter<SpreadsheetConverterContext> stringToDateTime;
+
+    private final Converter<SpreadsheetConverterContext> stringToTime;
+
     // Object...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            this.dateToString,
+            this.dateTimeToString,
+            this.timeToString,
+            this.stringToDate,
+            this.stringToDateTime,
+            this.stringToTime
+        );
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+            other instanceof SpreadsheetConverterDateTime && this.equals0((SpreadsheetConverterDateTime) other);
+    }
+
+    private boolean equals0(final SpreadsheetConverterDateTime other) {
+        return this.dateToString.equals(other.dateToString) &&
+            this.dateTimeToString.equals(other.dateTimeToString) &&
+            this.timeToString.equals(other.timeToString) &&
+            this.stringToDate.equals(other.stringToDate) &&
+            this.stringToDateTime.equals(other.stringToDateTime) &&
+            this.stringToTime.equals(other.stringToTime);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -171,8 +171,20 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     /**
      * {@link SpreadsheetConverterDateTime()}
      */
-    public static Converter<SpreadsheetConverterContext> dateTime() {
-        return SpreadsheetConverterDateTime.INSTANCE;
+    public static Converter<SpreadsheetConverterContext> dateTime(final Converter<SpreadsheetConverterContext> dateToString,
+                                                                  final Converter<SpreadsheetConverterContext> dateTimeToString,
+                                                                  final Converter<SpreadsheetConverterContext> timeToString,
+                                                                  final Converter<SpreadsheetConverterContext> stringToDate,
+                                                                  final Converter<SpreadsheetConverterContext> stringToDateTime,
+                                                                  final Converter<SpreadsheetConverterContext> stringToTime) {
+        return SpreadsheetConverterDateTime.with(
+            dateToString,
+            dateTimeToString,
+            timeToString,
+            stringToDate,
+            stringToDateTime,
+            stringToTime
+        );
     }
 
     /**
@@ -482,6 +494,30 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
         return SYSTEM_CONVERTER;
     }
 
+    private final static Converter<SpreadsheetConverterContext> SYSTEM_DATE_TIME = dateTime(
+        SpreadsheetPattern.parseDateFormatPattern("yyyy/mm/dd")
+            .formatter()
+            .converter(), // dateToString
+        SpreadsheetPattern.parseDateTimeFormatPattern("yyyy/mm/dd hh:mm:ss")
+            .formatter()
+            .converter(), // dateTimeToString
+        SpreadsheetPattern.parseTimeFormatPattern("hh:mm:ss")
+            .formatter()
+            .converter(), // timeToString
+        SpreadsheetConverters.textToDate(
+            SpreadsheetPattern.parseDateParsePattern("yyyy/mm/dd")
+                .parser()
+        ), // stringToDate
+        SpreadsheetConverters.textToDateTime(
+            SpreadsheetPattern.parseDateTimeParsePattern("yyyy/mm/dd hh:mm:ss")
+                .parser()
+        ), // stringToDateTime
+        SpreadsheetConverters.textToTime(
+            SpreadsheetPattern.parseTimeParsePattern("hh:mm:ss")
+                .parser()
+        ) // stringToTime
+    );
+
     private final static Converter<SpreadsheetConverterContext> SYSTEM_GENERAL = general(
         SpreadsheetPattern.parseDateFormatPattern("yyyy/mm/dd")
             .formatter(),
@@ -513,6 +549,7 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     );
 
     private final static Converter<SpreadsheetConverterContext> SYSTEM_CONVERTER = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+        (ProviderContext context) -> SYSTEM_DATE_TIME,
         (ProviderContext context) -> SYSTEM_GENERAL
     ).converter(
         SYSTEM_CONVERTER_SELECTOR,

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviders.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviders.java
@@ -21,7 +21,6 @@ import walkingkooka.convert.Converter;
 import walkingkooka.convert.provider.ConverterAliasSet;
 import walkingkooka.convert.provider.ConverterProvider;
 import walkingkooka.net.AbsoluteUrl;
-import walkingkooka.net.Url;
 import walkingkooka.plugin.ProviderContext;
 import walkingkooka.reflect.PublicStaticHelper;
 
@@ -36,9 +35,7 @@ public final class SpreadsheetConvertersConverterProviders implements PublicStat
      * This is the base {@link AbsoluteUrl} for all {@link Converter} in this package. The name of each
      * converter will be appended to this base.
      */
-    public final static AbsoluteUrl BASE_URL = Url.parseAbsolute(
-        "https://github.com/mP1/walkingkooka-spreadsheet/" + Converter.class.getSimpleName()
-    );
+    public final static AbsoluteUrl BASE_URL = SpreadsheetConvertersConverterProvider.BASE_URL;
 
     public final static ConverterAliasSet FIND = SpreadsheetConvertersConverterProvider.INFOS.aliasSet()
         .deleteAliasOrName(SpreadsheetConvertersConverterProvider.COLOR_TO_COLOR)
@@ -92,8 +89,12 @@ public final class SpreadsheetConvertersConverterProviders implements PublicStat
     /**
      * {@see SpreadsheetConvertersConverterProvider}
      */
-    public static ConverterProvider spreadsheetConverters(final Function<ProviderContext, Converter<SpreadsheetConverterContext>> general) {
-        return SpreadsheetConvertersConverterProvider.with(general);
+    public static ConverterProvider spreadsheetConverters(final Function<ProviderContext, Converter<SpreadsheetConverterContext>> dateTime,
+                                                          final Function<ProviderContext, Converter<SpreadsheetConverterContext>> general) {
+        return SpreadsheetConvertersConverterProvider.with(
+            dateTime,
+            general
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -550,6 +550,57 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         );
     }
 
+    /**
+     * Returns a general {@link Converter} using the required properties.
+     * <ul>
+     * <li>{@link SpreadsheetMetadataPropertyName#DATE_TIME_OFFSET}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#DATE_FORMATTER}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#DATE_PARSER}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#DATE_TIME_FORMATTER}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#DATE_TIME_PARSER}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#TIME_FORMATTER}</li>
+     * <li>{@link SpreadsheetMetadataPropertyName#TIME_PARSER}</li>
+     * </ul>
+     */
+    public final Converter<SpreadsheetConverterContext> dateTimeConverter(final SpreadsheetFormatterProvider spreadsheetFormatterProvider,
+                                                                          final SpreadsheetParserProvider spreadsheetParserProvider,
+                                                                          final ProviderContext context) {
+        Objects.requireNonNull(spreadsheetFormatterProvider, "spreadsheetFormatterProvider");
+        Objects.requireNonNull(spreadsheetParserProvider, "spreadsheetParserProvider");
+        Objects.requireNonNull(context, "context");
+
+        final SpreadsheetMetadataMissingComponents missing = SpreadsheetMetadataMissingComponents.with(this);
+
+        final SpreadsheetFormatterSelector dateFormat = missing.getOrNull(SpreadsheetMetadataPropertyName.DATE_FORMATTER);
+        final SpreadsheetParserSelector dateParser = missing.getOrNull(SpreadsheetMetadataPropertyName.DATE_PARSER);
+
+        final SpreadsheetFormatterSelector dateTimeFormat = missing.getOrNull(SpreadsheetMetadataPropertyName.DATE_TIME_FORMATTER);
+        final SpreadsheetParserSelector dateTimeParser = missing.getOrNull(SpreadsheetMetadataPropertyName.DATE_TIME_PARSER);
+
+        final SpreadsheetFormatterSelector timeFormat = missing.getOrNull(SpreadsheetMetadataPropertyName.TIME_FORMATTER);
+        final SpreadsheetParserSelector timeParser = missing.getOrNull(SpreadsheetMetadataPropertyName.TIME_PARSER);
+
+        missing.reportIfMissing();
+
+        return SpreadsheetConverters.dateTime(
+            spreadsheetFormatterProvider.spreadsheetFormatter(dateFormat, context)
+                .converter(), // dateToString
+            spreadsheetFormatterProvider.spreadsheetFormatter(dateTimeFormat, context)
+                .converter(), // dateTimeToString
+            spreadsheetFormatterProvider.spreadsheetFormatter(timeFormat, context)
+                .converter(), // timeToString
+            SpreadsheetConverters.textToDate(
+                spreadsheetParserProvider.spreadsheetParser(dateParser, context)
+            ), // stringToDate
+            SpreadsheetConverters.textToDateTime(
+                spreadsheetParserProvider.spreadsheetParser(dateTimeParser, context)
+            ), // stringToDateTime
+            SpreadsheetConverters.textToTime(
+                spreadsheetParserProvider.spreadsheetParser(timeParser, context)
+            ) // stringToTime
+        );
+    }
+
     // DateTimeContext..................................................................................................
 
     /**
@@ -1651,6 +1702,9 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         ).set(
             SpreadsheetMetadataPropertyName.CONVERTERS,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                    (final ProviderContext c) -> {
+                        throw new UnsupportedOperationException();
+                    },
                     (final ProviderContext c) -> {
                         throw new UnsupportedOperationException();
                     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -156,6 +156,12 @@ public interface SpreadsheetMetadataTesting extends Testing {
 
     ConverterProvider CONVERTER_PROVIDER = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
         (final ProviderContext p) ->
+            SpreadsheetMetadataTestingPrivate.CONVERTER_PROVIDER_SPREADSHEET_METADATA.dateTimeConverter(
+                SPREADSHEET_FORMATTER_PROVIDER,
+                SPREADSHEET_PARSER_PROVIDER,
+                p
+            ),
+        (final ProviderContext p) ->
             SpreadsheetMetadataTestingPrivate.CONVERTER_PROVIDER_SPREADSHEET_METADATA.generalConverter(
                 SPREADSHEET_FORMATTER_PROVIDER,
                 SPREADSHEET_PARSER_PROVIDER,

--- a/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
@@ -335,6 +335,11 @@ public final class MissingConverterVerifierTest implements TreePrintableTesting,
     @Test
     public void testVerifyAndMarshall() {
         final Converter<SpreadsheetConverterContext> converter = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            (ProviderContext p) -> SpreadsheetMetadata.EMPTY.dateTimeConverter(
+                SPREADSHEET_FORMATTER_PROVIDER,
+                SPREADSHEET_PARSER_PROVIDER,
+                p
+            ),
             (ProviderContext p) -> SpreadsheetMetadata.EMPTY.generalConverter(
                 SPREADSHEET_FORMATTER_PROVIDER,
                 SPREADSHEET_PARSER_PROVIDER,

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterUnformattedNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterUnformattedNumberTest.java
@@ -191,6 +191,11 @@ public final class SpreadsheetConverterUnformattedNumberTest extends Spreadsheet
             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
             LABEL_NAME_RESOLVER,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (ProviderContext p) -> metadata.dateTimeConverter(
+                    SPREADSHEET_FORMATTER_PROVIDER,
+                    SPREADSHEET_PARSER_PROVIDER,
+                    p
+                ),
                 (ProviderContext p) -> metadata.generalConverter(
                     SPREADSHEET_FORMATTER_PROVIDER,
                     SPREADSHEET_PARSER_PROVIDER,

--- a/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
@@ -524,6 +524,13 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
         };
 
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            (ProviderContext p) -> METADATA.dateTimeConverter(
+                SpreadsheetFormatterProviders.spreadsheetFormatters(),
+                SpreadsheetParserProviders.spreadsheetParsePattern(
+                    SpreadsheetFormatterProviders.fake()
+                ),
+                p
+            ),
             (ProviderContext p) -> METADATA.generalConverter(
                 SpreadsheetFormatterProviders.spreadsheetFormatters(),
                 SpreadsheetParserProviders.spreadsheetParsePattern(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1380,6 +1380,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
         final Converter<SpreadsheetConverterContext> converter = metadata.converter(
             converterSelector,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.dateTimeConverter(
+                    SPREADSHEET_FORMATTER_PROVIDER,
+                    SPREADSHEET_PARSER_PROVIDER,
+                    p
+                ),
                 (final ProviderContext p) -> metadata.generalConverter(
                     SPREADSHEET_FORMATTER_PROVIDER,
                     SPREADSHEET_PARSER_PROVIDER,
@@ -1476,6 +1481,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                    (ProviderContext p) -> metadata.dateTimeConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    ),
                     (ProviderContext p) -> metadata.generalConverter(
                         SPREADSHEET_FORMATTER_PROVIDER,
                         SPREADSHEET_PARSER_PROVIDER,
@@ -2044,6 +2054,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 },
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                    (ProviderContext p) -> metadata.dateTimeConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    ),
                     (ProviderContext p) -> metadata.generalConverter(
                         SPREADSHEET_FORMATTER_PROVIDER,
                         SPREADSHEET_PARSER_PROVIDER,
@@ -2078,6 +2093,11 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 },
                 LABEL_NAME_RESOLVER,
                 SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                    (ProviderContext p) -> metadata.dateTimeConverter(
+                        SPREADSHEET_FORMATTER_PROVIDER,
+                        SPREADSHEET_PARSER_PROVIDER,
+                        p
+                    ),
                     (ProviderContext p) -> metadata.generalConverter(
                         SPREADSHEET_FORMATTER_PROVIDER,
                         SPREADSHEET_PARSER_PROVIDER,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -646,6 +646,11 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         final Converter<SpreadsheetConverterContext> converter = metadata.converter(
             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.dateTimeConverter(
+                    spreadsheetFormatterProvider(),
+                    spreadsheetParserProvider(),
+                    p
+                ),
                 (final ProviderContext p) -> metadata.generalConverter(
                     spreadsheetFormatterProvider(),
                     spreadsheetParserProvider(),
@@ -675,6 +680,11 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         final Converter<SpreadsheetConverterContext> converter = metadata.converter(
             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.dateTimeConverter(
+                    spreadsheetFormatterProvider(),
+                    spreadsheetParserProvider(),
+                    p
+                ),
                 (final ProviderContext p) -> metadata.generalConverter(
                     spreadsheetFormatterProvider(),
                     spreadsheetParserProvider(),
@@ -705,6 +715,11 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         final Converter<SpreadsheetConverterContext> converter = metadata.converter(
             SpreadsheetMetadataPropertyName.FORMATTING_CONVERTER,
             SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+                (final ProviderContext p) -> metadata.dateTimeConverter(
+                    spreadsheetFormatterProvider(),
+                    spreadsheetParserProvider(),
+                    p
+                ),
                 (final ProviderContext p) -> metadata.generalConverter(
                     spreadsheetFormatterProvider(),
                     spreadsheetParserProvider(),
@@ -720,6 +735,69 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
         );
     }
 
+    // DateTimeConverter................................................................................................
+
+    @Test
+    public void testDateTimeConverterWithNullSpreadsheetFormatterProviderFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetMetadata.EMPTY.dateTimeConverter(
+                null,
+                SpreadsheetParserProviders.fake(),
+                PROVIDER_CONTEXT
+            )
+        );
+    }
+
+    @Test
+    public void testDateTimeConverterWithNullSpreadsheetParserProviderFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetMetadata.EMPTY.dateTimeConverter(
+                SpreadsheetFormatterProviders.fake(),
+                null,
+                PROVIDER_CONTEXT
+            )
+        );
+    }
+
+    @Test
+    public void testDateTimeConverterWithMissingPropertyFails() {
+        final IllegalStateException thrown = assertThrows(
+            IllegalStateException.class,
+            () -> SpreadsheetMetadata.EMPTY.dateTimeConverter(
+                SpreadsheetFormatterProviders.fake(),
+                SpreadsheetParserProviders.fake(),
+                PROVIDER_CONTEXT
+            )
+        );
+        this.checkEquals(
+            "Metadata missing: dateFormatter, dateParser, dateTimeFormatter, dateTimeParser, timeFormatter, timeParser",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testDateTimeConverter() {
+        final Locale locale = Locale.forLanguageTag("EN-AU");
+
+        final Converter<SpreadsheetConverterContext> converter = SpreadsheetMetadata.NON_LOCALE_DEFAULTS
+            .set(
+                SpreadsheetMetadataPropertyName.LOCALE,
+                locale
+            ).loadFromLocale(
+                LocaleContexts.jre(locale)
+            ).dateTimeConverter(
+                spreadsheetFormatterProvider(),
+                spreadsheetParserProvider(),
+                PROVIDER_CONTEXT
+            );
+        this.checkNotEquals(
+            null,
+            converter
+        );
+    }
+    
     // ExpressionFunctionProvider.......................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -289,6 +289,11 @@ public final class Sample {
         final SpreadsheetFormatterProvider spreadsheetFormatterProvider = SpreadsheetFormatterProviders.spreadsheetFormatters();
         final SpreadsheetParserProvider spreadsheetParserProvider = SpreadsheetParserProviders.spreadsheetParsePattern(spreadsheetFormatterProvider);
         final ConverterProvider converterProvider = SpreadsheetConvertersConverterProviders.spreadsheetConverters(
+            (ProviderContext p) -> metadata.dateTimeConverter(
+                spreadsheetFormatterProvider,
+                spreadsheetParserProvider,
+                p
+            ),
             (ProviderContext p) -> metadata.generalConverter(
                 spreadsheetFormatterProvider,
                 spreadsheetParserProvider,


### PR DESCRIPTION
- server will need to refresh SpreadsheetEngineContext when the SpreadsheetMetadata "changes".

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7431
- SpreadsheetConverterDateTime: needs to support time -> String

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7430
- SpreadsheetConverterDateTime: needs to support String -> dateTime

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7429
- SpreadsheetConverterDateTime: needs to support String -> date

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7428
- Closes SpreadsheetConverterDateTime: needs to support dateTime -> String

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7427
- SpreadsheetConverterDateTime: needs to support date -> String