### PR TITLE
BasicSpreadsheetExpressionEvaluationContext: LocaleContext dependency…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -274,7 +274,6 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
             (Optional<SpreadsheetCell> c) -> this.spreadsheetFormatterContext(c),
             this.formHandlerContext,
             this.expressionFunctionProvider,
-            this.localeContext,
             this, // ProviderContext
             this.terminalContext
         );

--- a/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContext.java
@@ -22,8 +22,6 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.CanConvert;
 import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentValueName;
-import walkingkooka.locale.LocaleContext;
-import walkingkooka.locale.LocaleContextDelegator;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.plugin.ProviderContext;
 import walkingkooka.spreadsheet.SpreadsheetCell;
@@ -75,7 +73,6 @@ import java.util.function.Function;
 
 final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetExpressionEvaluationContext,
     FormHandlerContextDelegator<SpreadsheetExpressionReference, SpreadsheetDelta>,
-    LocaleContextDelegator,
     SpreadsheetConverterContextDelegator,
     TerminalContextDelegator {
 
@@ -88,7 +85,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                                                             final Function<Optional<SpreadsheetCell>, SpreadsheetFormatterContext> spreadsheetFormatterContextFactory,
                                                             final FormHandlerContext<SpreadsheetExpressionReference, SpreadsheetDelta> formHandlerContext,
                                                             final ExpressionFunctionProvider<SpreadsheetExpressionEvaluationContext> expressionFunctionProvider,
-                                                            final LocaleContext localeContext,
                                                             final ProviderContext providerContext,
                                                             final TerminalContext terminalContext) {
         Objects.requireNonNull(cell, "cell");
@@ -100,7 +96,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
         Objects.requireNonNull(spreadsheetFormatterContextFactory, "spreadsheetFormatterContextFactory");
         Objects.requireNonNull(formHandlerContext, "formHandlerContext");
         Objects.requireNonNull(expressionFunctionProvider, "expressionFunctionProvider");
-        Objects.requireNonNull(localeContext, "localeContext");
         Objects.requireNonNull(providerContext, "providerContext");
         Objects.requireNonNull(terminalContext, "terminalContext");
 
@@ -114,7 +109,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
             spreadsheetFormatterContextFactory,
             formHandlerContext,
             expressionFunctionProvider,
-            localeContext,
             providerContext,
             terminalContext
         );
@@ -129,7 +123,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                                                         final Function<Optional<SpreadsheetCell>, SpreadsheetFormatterContext> spreadsheetFormatterContextFactory,
                                                         final FormHandlerContext<SpreadsheetExpressionReference, SpreadsheetDelta> formHandlerContext,
                                                         final ExpressionFunctionProvider<SpreadsheetExpressionEvaluationContext> expressionFunctionProvider,
-                                                        final LocaleContext localeContext,
                                                         final ProviderContext providerContext,
                                                         final TerminalContext terminalContext) {
         super();
@@ -144,7 +137,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
 
         this.spreadsheetConverterContext = spreadsheetConverterContext;
         this.expressionFunctionProvider = expressionFunctionProvider;
-        this.localeContext = localeContext;
         this.providerContext = providerContext;
         this.terminalContext = terminalContext;
     }
@@ -220,11 +212,13 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
     public SpreadsheetFormulaParserToken parseFormula(final TextCursor expression) {
         Objects.requireNonNull(expression, "expression");
 
+        final SpreadsheetConverterContext context = this.spreadsheetConverterContext;
+
         final SpreadsheetParserContext parserContext = this.spreadsheetMetadata()
             .spreadsheetParserContext(
                 this.cell,
-                this.localeContext,
-                this.spreadsheetConverterContext
+                context,
+                context
             );
 
         return SpreadsheetFormulaParsers.expression()
@@ -378,28 +372,13 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
         return value;
     }
 
-    // LocaleContextDelegator...........................................................................................
+    // SpreadsheetConverterContextDelegator.............................................................................
 
     @Override
     public SpreadsheetExpressionEvaluationContext setLocale(final Locale locale) {
-        this.localeContext.setLocale(locale);
+        this.spreadsheetConverterContext.setLocale(locale);
         return this;
     }
-
-    @Override
-    public LocaleContext localeContext() {
-        return this.localeContext;
-    }
-
-    @Override
-    public Locale locale() {
-        return this.localeContext()
-            .locale();
-    }
-
-    private final LocaleContext localeContext;
-
-    // SpreadsheetConverterContextDelegator.............................................................................
 
     @Override
     public CanConvert canConvert() {
@@ -465,7 +444,6 @@ final class BasicSpreadsheetExpressionEvaluationContext implements SpreadsheetEx
                 this.spreadsheetFormatterContextFactory,
                 this.formHandlerContext,
                 this.expressionFunctionProvider,
-                this.localeContext,
                 this.providerContext,
                 this.terminalContext
             );

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContexts.java
@@ -19,7 +19,6 @@
 package walkingkooka.spreadsheet.expression;
 
 import walkingkooka.convert.Converter;
-import walkingkooka.locale.LocaleContext;
 import walkingkooka.net.AbsoluteUrl;
 import walkingkooka.plugin.ProviderContext;
 import walkingkooka.reflect.PublicStaticHelper;
@@ -56,7 +55,6 @@ public final class SpreadsheetExpressionEvaluationContexts implements PublicStat
                                                                final Function<Optional<SpreadsheetCell>, SpreadsheetFormatterContext> spreadsheetFormatterContextFactory,
                                                                final FormHandlerContext<SpreadsheetExpressionReference, SpreadsheetDelta> formHandlerContext,
                                                                final ExpressionFunctionProvider<SpreadsheetExpressionEvaluationContext> expressionFunctionProvider,
-                                                               final LocaleContext localeContext,
                                                                final ProviderContext providerContext,
                                                                final TerminalContext terminalContext) {
         return BasicSpreadsheetExpressionEvaluationContext.with(
@@ -69,7 +67,6 @@ public final class SpreadsheetExpressionEvaluationContexts implements PublicStat
             spreadsheetFormatterContextFactory,
             formHandlerContext,
             expressionFunctionProvider,
-            localeContext,
             providerContext,
             terminalContext
         );

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToExpressionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterTextToExpressionTest.java
@@ -112,7 +112,6 @@ public final class SpreadsheetConverterTextToExpressionTest extends SpreadsheetC
                     },
                     FormHandlerContexts.fake(),
                     ExpressionFunctionProviders.fake(),
-                    LOCALE_CONTEXT,
                     ProviderContexts.fake(),
                     TERMINAL_CONTEXT
                 )

--- a/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/BasicSpreadsheetExpressionEvaluationContextTest.java
@@ -114,7 +114,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -135,7 +134,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -156,7 +154,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -177,7 +174,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -198,7 +194,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -219,7 +214,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -240,7 +234,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 null,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -261,7 +254,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 null,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             )
@@ -281,28 +273,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMULA_CONVERTER_CONTEXT,
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
-                null,
-                LOCALE_CONTEXT,
-                PROVIDER_CONTEXT,
-                TERMINAL_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testWithNullLocaleContextFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> BasicSpreadsheetExpressionEvaluationContext.with(
-                CELL,
-                SPREADSHEET_EXPRESSION_REFERENCE_LOADER,
-                SERVER_URL,
-                METADATA,
-                SPREADSHEET_STORE_REPOSITORY,
-                SPREADSHEET_FORMULA_CONVERTER_CONTEXT,
-                SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
-                FORM_HANDLER_CONTEXT,
-                EXPRESSION_FUNCTION_PROVIDER,
                 null,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
@@ -324,7 +294,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 null,
                 TERMINAL_CONTEXT
             )
@@ -345,7 +314,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 null
             )
@@ -432,7 +400,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             ),
@@ -469,7 +436,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
                 SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
                 FORM_HANDLER_CONTEXT,
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             ),
@@ -695,7 +661,6 @@ public final class BasicSpreadsheetExpressionEvaluationContextTest implements Sp
             SPREADSHEET_FORMATTER_CONTEXT_FACTORY,
             FORM_HANDLER_CONTEXT,
             EXPRESSION_FUNCTION_PROVIDER,
-            LOCALE_CONTEXT,
             providerContext,
             TERMINAL_CONTEXT
         );

--- a/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContextTest.java
@@ -595,7 +595,6 @@ public final class ConverterSpreadsheetExpressionEvaluationContextTest implement
                     }
                 },
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 ProviderContexts.basic(
                     ConverterContexts.fake(),
                     EnvironmentContexts.map(

--- a/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegatorTest.java
@@ -201,7 +201,6 @@ public final class SpreadsheetExpressionEvaluationContextDelegatorTest implement
                     }
                 },
                 EXPRESSION_FUNCTION_PROVIDER,
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             );

--- a/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetFormatterTest.java
@@ -221,7 +221,6 @@ public final class ExpressionSpreadsheetFormatterTest implements SpreadsheetForm
                             }
                         )
                     ),
-                    LocaleContexts.fake(),
                     ProviderContexts.fake(),
                     TerminalContexts.fake()
                 ).addLocalVariable(

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
@@ -98,7 +98,6 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
                 }, // spreadsheetFormatterContextFactory
                 FormHandlerContexts.fake(),
                 ExpressionFunctionProviders.fake(),
-                SpreadsheetMetadataTesting.LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             ),

--- a/src/test/java/walkingkooka/spreadsheet/template/SpreadsheetTemplateContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/template/SpreadsheetTemplateContextTest.java
@@ -284,7 +284,6 @@ public final class SpreadsheetTemplateContextTest implements TemplateContextTest
                         );
                     }
                 },
-                LOCALE_CONTEXT,
                 PROVIDER_CONTEXT,
                 TERMINAL_CONTEXT
             ),


### PR DESCRIPTION
… removed

- Unnecessary as other parameter SpreadsheetConverterContext already extends LocaleContext