### PR TITLE
SpreadsheetNumberParsePattern supports multiple percent symbols

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentPercentTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternComponentPercentTest.java
@@ -41,19 +41,29 @@ public final class SpreadsheetNumberParsePatternComponentPercentTest extends Spr
     @Test
     public void testTokenTwice() {
         this.parseAndCheck2(
-            PERCENT,
-            PERCENT + "!"
+            "" + PERCENT + PERCENT,
+             "!"
         );
     }
 
-    void parseAndCheck2(final char c,
-                        final String textAfter) {
-        final String textString = "" + c;
+    private void parseAndCheck2(final char c,
+                                final String textAfter) {
         this.parseAndCheck2(
-            textString,
+            String.valueOf(c),
+            textAfter
+        );
+    }
+
+    private void parseAndCheck2(final String text,
+                                final String textAfter) {
+        this.parseAndCheck2(
+            text,
             textAfter,
             NEXT_CALLED,
-            SpreadsheetFormulaParserToken.percentSymbol(textString, textString)
+            SpreadsheetFormulaParserToken.percentSymbol(
+                text,
+                text
+            )
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
@@ -1033,9 +1033,40 @@ public final class SpreadsheetNumberParsePatternTest extends SpreadsheetParsePat
 
     @Test
     public void testConvertPatternHashDecimalPercentBigDecimalDigitDigitDigitPercent() {
-        this.parsePatternConvertAndCheck("#.#%",
-            "45" + DECIMAL + "6" + PERCENT,
-            BigDecimal.valueOf(0.456));
+        this.parsePatternConvertAndCheck(
+            "#.#%",
+            "123" + DECIMAL + "5" + PERCENT,
+            BigDecimal.valueOf(123.5)
+                .divide(
+                    BigDecimal.valueOf(100)
+                )
+        );
+    }
+
+    @Test
+    public void testConvertPatternHashDecimalPercentBigDecimalDigitDigitDigitPercentPercent() {
+        this.parsePatternConvertAndCheck(
+            "#.#%",
+            "123" + DECIMAL + "5" + PERCENT + PERCENT,
+            BigDecimal.valueOf(
+                123.5
+            ).divide(
+                BigDecimal.valueOf(100 * 100)
+            )
+        );
+    }
+
+    @Test
+    public void testConvertPatternHashDecimalPercentBigDecimalDigitDigitDigitPercentPercentPercent() {
+        this.parsePatternConvertAndCheck(
+            "#.#%",
+            "123" + DECIMAL + "5" + PERCENT + PERCENT + PERCENT,
+            BigDecimal.valueOf(
+                123.5
+            ).divide(
+                BigDecimal.valueOf(100 * 100 * 100)
+            )
+        );
     }
 
     // several patterns.................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaTest.java
@@ -1484,6 +1484,96 @@ public final class SpreadsheetFormulaTest implements ClassTesting2<SpreadsheetFo
     }
 
     @Test
+    public void testParseExpressionWithNumberPercent() {
+        final String text = "=1+200%";
+
+        this.parseAndCheck(
+            text,
+            SpreadsheetFormulaParsers.valueOrExpression(
+                SpreadsheetParsers.parser(
+                    Parsers.never(),
+                    Optional.empty()
+                )
+            ),
+            SpreadsheetFormula.EMPTY.setText(text)
+                .setToken(
+                    Optional.of(
+                        SpreadsheetFormulaParserToken.expression(
+                            Lists.of(
+                                SpreadsheetFormulaParserToken.equalsSymbol("=", "="),
+                                SpreadsheetFormulaParserToken.addition(
+                                    Lists.of(
+                                        SpreadsheetFormulaParserToken.number(
+                                            Lists.of(
+                                                SpreadsheetFormulaParserToken.digits("1", "1")
+                                            ),
+                                            "1"
+                                        ),
+                                        SpreadsheetFormulaParserToken.plusSymbol("+", "+"),
+                                        SpreadsheetFormulaParserToken.number(
+                                            Lists.of(
+                                                SpreadsheetFormulaParserToken.digits("200", "200"),
+                                                SpreadsheetFormulaParserToken.percentSymbol("%", "%")
+                                            ),
+                                            "200%"
+                                        )
+                                    ),
+                                    "1+200%"
+                                )
+                            ),
+                            text
+                        )
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testParseExpressionWithNumberPercentPercent() {
+        final String text = "=100%%+2";
+
+        this.parseAndCheck(
+            text,
+            SpreadsheetFormulaParsers.valueOrExpression(
+                SpreadsheetParsers.parser(
+                    Parsers.never(),
+                    Optional.empty()
+                )
+            ),
+            SpreadsheetFormula.EMPTY.setText(text)
+                .setToken(
+                    Optional.of(
+                        SpreadsheetFormulaParserToken.expression(
+                            Lists.of(
+                                SpreadsheetFormulaParserToken.equalsSymbol("=", "="),
+                                SpreadsheetFormulaParserToken.addition(
+                                    Lists.of(
+                                        SpreadsheetFormulaParserToken.number(
+                                            Lists.of(
+                                                SpreadsheetFormulaParserToken.digits("100", "100"),
+                                                SpreadsheetFormulaParserToken.percentSymbol("%%", "%%")
+                                            ),
+                                            "100%%"
+                                        ),
+                                        SpreadsheetFormulaParserToken.plusSymbol("+", "+"),
+                                        SpreadsheetFormulaParserToken.number(
+                                            Lists.of(
+                                                SpreadsheetFormulaParserToken.digits("2", "2")
+                                            ),
+                                            "2"
+                                        )
+                                    ),
+                                    "100%%+2"
+                                )
+                            ),
+                            text
+                        )
+                    )
+                )
+        );
+    }
+
+    @Test
     public void testParseExpressionWithNumbersWithDecimalsAndCustomDecimalSeparator() {
         final String text = "=1@5+2";
 

--- a/src/test/java/walkingkooka/spreadsheet/formula/parser/NumberSpreadsheetFormulaParserTokenTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/parser/NumberSpreadsheetFormulaParserTokenTest.java
@@ -301,6 +301,27 @@ public final class NumberSpreadsheetFormulaParserTokenTest extends ValueSpreadsh
     }
 
     @Test
+    public void testToExpressionNumber50PercentPercent() {
+        this.toExpressionAndCheck2(
+            0.5 / 100,
+            digit("50"),
+            percent(),
+            percent()
+        );
+    }
+
+    @Test
+    public void testToExpressionNumber50PercentPercentPercent() {
+        this.toExpressionAndCheck2(
+            0.5 / 100 / 100,
+            digit("50"),
+            percent(),
+            percent(),
+            percent()
+        );
+    }
+
+    @Test
     public void testToExpressionNumber200Percent() {
         this.toExpressionAndCheck2(
             2.0,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7546
- SpreadsheetFormula numbers should support more than one percent symbol and scale value to match