### PR TITLE
SpreadsheetConverterToNumber ignoreDecimalNumberContextSymbols parame…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumber.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumber.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.spreadsheet.convert;
 
-import walkingkooka.Cast;
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.tree.expression.ExpressionNumber;
@@ -39,19 +38,10 @@ final class SpreadsheetConverterToNumber extends SpreadsheetConverter {
      * used instead, so formulas will always only accept "." as the decimal point.
      * The function numberValue however must be able to pass custom decimal-point and group-separator.
      */
-    static SpreadsheetConverterToNumber with(final boolean ignoreDecimalNumberContextSymbols) {
-        return ignoreDecimalNumberContextSymbols ?
-            TRUE :
-            FALSE;
-    }
+    final static SpreadsheetConverterToNumber INSTANCE = new SpreadsheetConverterToNumber();
 
-    private final static SpreadsheetConverterToNumber TRUE = new SpreadsheetConverterToNumber(true);
-
-    private final static SpreadsheetConverterToNumber FALSE = new SpreadsheetConverterToNumber(false);
-
-    private SpreadsheetConverterToNumber(final boolean ignoreDecimalNumberContextSymbols) {
+    private SpreadsheetConverterToNumber() {
         super();
-        this.ignoreDecimalNumberContextSymbols = ignoreDecimalNumberContextSymbols;
     }
 
     @Override
@@ -69,10 +59,7 @@ final class SpreadsheetConverterToNumber extends SpreadsheetConverter {
     public <T> Either<T, String> doConvert(final Object value,
                                            final Class<T> type,
                                            final SpreadsheetConverterContext context) {
-        final Converter<SpreadsheetConverterContext> converter = SpreadsheetConverterToNumberSpreadsheetValueVisitor.converter(
-            value,
-            this.ignoreDecimalNumberContextSymbols
-        );
+        final Converter<SpreadsheetConverterContext> converter = SpreadsheetConverterToNumberSpreadsheetValueVisitor.converter(value);
         if(null == converter) {
             throw new IllegalArgumentException("Converter missing for " + value);
         }
@@ -83,25 +70,7 @@ final class SpreadsheetConverterToNumber extends SpreadsheetConverter {
         );
     }
 
-    private final boolean ignoreDecimalNumberContextSymbols;
-
     // Object...........................................................................................................
-
-    @Override
-    public int hashCode() {
-        return System.identityHashCode(this);
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        return this == other ||
-            other instanceof SpreadsheetConverterToNumber &&
-                this.equals0(Cast.to(other));
-    }
-
-    private boolean equals0(final SpreadsheetConverterToNumber other) {
-        return this.ignoreDecimalNumberContextSymbols == other.ignoreDecimalNumberContextSymbols;
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitor.java
@@ -30,17 +30,15 @@ import java.time.LocalDateTime;
  */
 final class SpreadsheetConverterToNumberSpreadsheetValueVisitor extends SpreadsheetValueVisitor {
 
-    static Converter<SpreadsheetConverterContext> converter(final Object value,
-                                                            final boolean ignoreDecimalNumberContextSymbols) {
-        final SpreadsheetConverterToNumberSpreadsheetValueVisitor visitor = new SpreadsheetConverterToNumberSpreadsheetValueVisitor(ignoreDecimalNumberContextSymbols);
+    static Converter<SpreadsheetConverterContext> converter(final Object value) {
+        final SpreadsheetConverterToNumberSpreadsheetValueVisitor visitor = new SpreadsheetConverterToNumberSpreadsheetValueVisitor();
         visitor.accept(value);
         return visitor.converter;
     }
 
     // @VisibleForTesting
-    SpreadsheetConverterToNumberSpreadsheetValueVisitor(final boolean ignoreDecimalNumberContextSymbols) {
+    SpreadsheetConverterToNumberSpreadsheetValueVisitor() {
         super();
-        this.string = SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.with(ignoreDecimalNumberContextSymbols);
     }
 
     @Override
@@ -66,10 +64,8 @@ final class SpreadsheetConverterToNumberSpreadsheetValueVisitor extends Spreadsh
 
     @Override
     protected void visit(final String value) {
-        this.converter = string;
+        this.converter = SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.INSTANCE;
     }
-
-    private final Converter<SpreadsheetConverterContext> string;
 
     private Converter<SpreadsheetConverterContext> converter;
 

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
@@ -21,8 +21,6 @@ import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
 import walkingkooka.datetime.DateTimeContexts;
-import walkingkooka.math.DecimalNumberContext;
-import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.text.cursor.parser.BigDecimalParserToken;
 import walkingkooka.text.cursor.parser.InvalidCharacterExceptionFactory;
 import walkingkooka.text.cursor.parser.Parser;
@@ -42,21 +40,10 @@ final class SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter e
     /**
      * Singleton
      */
-    static SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter with(final boolean ignoreDecimalNumberContextSymbols) {
-        return ignoreDecimalNumberContextSymbols ?
-            TRUE :
-            FALSE;
-    }
+    final static SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter INSTANCE = new SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter();
 
-    private final static SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter TRUE = new SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter(
-        (SpreadsheetConverterContext c) -> DecimalNumberContexts.american(c.mathContext())
-    );
 
-    private final static SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter FALSE = new SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter(
-        (SpreadsheetConverterContext c) -> c // DecimalNumberContext
-    );
-
-    private SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter(final Function<SpreadsheetConverterContext, DecimalNumberContext> decimalNumberContextProvider) {
+    private SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter() {
         super();
         this.parser = Converters.parser(
             BigDecimal.class,
@@ -64,7 +51,7 @@ final class SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter e
             (final SpreadsheetConverterContext c) -> ParserContexts.basic(
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
-                decimalNumberContextProvider.apply(c)
+                c
             ),
             (ParserToken t, SpreadsheetConverterContext c) -> t.cast(BigDecimalParserToken.class).value()
         );

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -361,9 +361,7 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
         "number",
         nullToNumber(),
         numberToNumber(),
-        toNumber(
-            true // ignoreDecimalNumberContextSymbols
-        ),
+        toNumber(),
         numberToText(
             true // ignoreDecimalNumberContextSymbols
         )
@@ -817,8 +815,8 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     /**
      * A {@link Converter} that handles converting from or to a {@link Number} values
      */
-    public static Converter<SpreadsheetConverterContext> toNumber(final boolean ignoreDecimalNumberContextSymbols) {
-        return SpreadsheetConverterToNumber.with(ignoreDecimalNumberContextSymbols);
+    public static Converter<SpreadsheetConverterContext> toNumber() {
+        return SpreadsheetConverterToNumber.INSTANCE;
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProvider.java
@@ -440,9 +440,7 @@ final class SpreadsheetConvertersConverterProvider implements ConverterProvider 
             case TO_NUMBER_STRING:
                 noParameterCheck(copy);
 
-                converter = SpreadsheetConverters.toNumber(
-                    true // ignoreDecimalNumberContextSymbols
-                );
+                converter = SpreadsheetConverters.toNumber();
                 break;
             case TO_STYLEABLE_STRING:
                 noParameterCheck(copy);

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToBooleanTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToBooleanTest.java
@@ -574,8 +574,33 @@ public final class SpreadsheetConverterToBooleanTest extends SpreadsheetConverte
             );
 
             @Override
+            public char decimalSeparator() {
+                return '.';
+            }
+
+            @Override
+            public String exponentSymbol() {
+                return "E";
+            }
+
+            @Override
             public MathContext mathContext() {
                 return MathContext.DECIMAL32;
+            }
+
+            @Override
+            public char negativeSign() {
+                return '-';
+            }
+
+            @Override
+            public char positiveSign() {
+                return '+';
+            }
+
+            @Override
+            public char zeroDigit() {
+                return '0';
             }
         };
     }

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorTest.java
@@ -23,7 +23,7 @@ import walkingkooka.spreadsheet.SpreadsheetValueVisitorTesting;
 public final class SpreadsheetConverterToNumberSpreadsheetValueVisitorTest implements SpreadsheetValueVisitorTesting<SpreadsheetConverterToNumberSpreadsheetValueVisitor> {
     @Override
     public SpreadsheetConverterToNumberSpreadsheetValueVisitor createVisitor() {
-        return new SpreadsheetConverterToNumberSpreadsheetValueVisitor(false);
+        return new SpreadsheetConverterToNumberSpreadsheetValueVisitor();
     }
 
     // class............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet.convert;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Either;
-import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
@@ -34,8 +33,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverterTestCase<SpreadsheetConverterToNumber>
-    implements HashCodeEqualsDefinedTesting2<SpreadsheetConverterToNumber> {
+public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverterTestCase<SpreadsheetConverterToNumber> {
 
     private final static ExpressionNumberKind EXPRESSION_NUMBER_KIND = ExpressionNumberKind.BIG_DECIMAL;
 
@@ -563,86 +561,9 @@ public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverter
         );
     }
 
-    @Test
-    public void testConvertStringToExpressionNumberWhenIgnoreDecimalNumberContextSymbolsFalse() {
-        this.convertAndCheck(
-            SpreadsheetConverterToNumber.with(
-                false // ignoreDecimalNumberContextSymbols
-            ),
-            "123*5",
-            ExpressionNumber.class,
-            new FakeSpreadsheetConverterContext() {
-                @Override
-                public boolean canConvert(final Object value,
-                                          final Class<?> type) {
-                    return this.converter.canConvert(
-                        value,
-                        type,
-                        this
-                    );
-                }
-
-                @Override
-                public <T> Either<T, String> convert(final Object value,
-                                                     final Class<T> target) {
-                    return this.converter.convert(
-                        value,
-                        target,
-                        this
-                    );
-                }
-
-                private final Converter<SpreadsheetConverterContext> converter = SpreadsheetConverters.collection(
-                    Lists.of(
-                        SpreadsheetConverters.text(),
-                        SpreadsheetConverters.numberToNumber()
-                    )
-                );
-
-                @Override
-                public char decimalSeparator() {
-                    return '*';
-                }
-
-                @Override
-                public ExpressionNumberKind expressionNumberKind() {
-                    return EXPRESSION_NUMBER_KIND;
-                }
-
-                @Override
-                public String exponentSymbol() {
-                    return "E";
-                }
-
-                @Override
-                public MathContext mathContext() {
-                    return MathContext.DECIMAL32;
-                }
-
-                @Override
-                public char negativeSign() {
-                    return '-';
-                }
-
-                @Override
-                public char positiveSign() {
-                    return '+';
-                }
-
-                @Override
-                public char zeroDigit() {
-                    return '0';
-                }
-            },
-            EXPRESSION_NUMBER_KIND.create(123.5)
-        );
-    }
-    
     @Override
     public SpreadsheetConverterToNumber createConverter() {
-        return SpreadsheetConverterToNumber.with(
-            true // ignoreDecimalNumberContextSymbols
-        );
+        return SpreadsheetConverterToNumber.INSTANCE;
     }
 
     @Override
@@ -686,24 +607,35 @@ public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverter
             );
 
             @Override
+            public char decimalSeparator() {
+                return '.';
+            }
+
+            @Override
+            public String exponentSymbol() {
+                return "E";
+            }
+
+            @Override
             public MathContext mathContext() {
                 return MathContext.DECIMAL32;
             }
+
+            @Override
+            public char negativeSign() {
+                return '-';
+            }
+
+            @Override
+            public char positiveSign() {
+                return '+';
+            }
+
+            @Override
+            public char zeroDigit() {
+                return '0';
+            }
         };
-    }
-
-    // hashCode/equals..................................................................................................
-
-    @Test
-    public void testEqualsDifferentIgnoreDecimalNumberContextSymbols() {
-        this.checkNotEquals(
-            SpreadsheetConverterToNumber.with(false)
-        );
-    }
-
-    @Override
-    public SpreadsheetConverterToNumber createObject() {
-        return SpreadsheetConverterToNumber.with(true);
     }
 
     // class............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
@@ -692,9 +692,7 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
         this.converterAndCheck(
             "to-number",
             PROVIDER_CONTEXT,
-            SpreadsheetConverters.toNumber(
-                true // ignoreDecimalNumberContextSymbols
-            )
+            SpreadsheetConverters.toNumber()
         );
     }
 


### PR DESCRIPTION
…ter removed

- First step before introducing SpreadsheetConverterContext.isGroupSeparatorWithinNumbersSupported which will help function: numberValue support a custom group-separator within text holding a number value.