### PR TITLE
https://github.com/mP1/walkingkooka-convert/pull/307 ConverterContext…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContext.java
@@ -84,6 +84,11 @@ final class SpreadsheetConverterNumberToTextSpreadsheetConverterContext implemen
     }
 
     @Override
+    public boolean canNumbersHaveGroupSeparator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public long dateOffset() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTesting.java
@@ -2881,6 +2881,7 @@ public interface SpreadsheetEngineTesting<E extends SpreadsheetEngine> extends C
         return ExpressionNumberConverterContexts.basic(
             this.converter(),
             ConverterContexts.basic(
+                false, // canNumbersHaveGroupSeparator
                 Converters.JAVA_EPOCH_OFFSET,
                 Converters.fake(),
                 this.dateTimeContext(),

--- a/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/ConverterSpreadsheetExpressionEvaluationContext.java
@@ -183,6 +183,11 @@ final class ConverterSpreadsheetExpressionEvaluationContext implements Spreadshe
     final Converter<SpreadsheetExpressionEvaluationContext> converter;
 
     @Override
+    public boolean canNumbersHaveGroupSeparator() {
+        return this.context.canNumbersHaveGroupSeparator();
+    }
+
+    @Override
     public long dateOffset() {
         return this.context.dateOffset();
     }

--- a/src/main/java/walkingkooka/spreadsheet/expression/LocalReferencesSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/LocalReferencesSpreadsheetExpressionEvaluationContext.java
@@ -300,6 +300,11 @@ final class LocalReferencesSpreadsheetExpressionEvaluationContext implements Spr
     }
 
     @Override
+    public boolean canNumbersHaveGroupSeparator() {
+        return this.context.canNumbersHaveGroupSeparator();
+    }
+
+    @Override
     public long dateOffset() {
         return this.context.dateOffset();
     }

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContext.java
@@ -74,6 +74,11 @@ final class SpreadsheetFormatterConverterSpreadsheetFormatterContext implements 
     }
 
     @Override
+    public boolean canNumbersHaveGroupSeparator() {
+        return this.context.canNumbersHaveGroupSeparator();
+    }
+
+    @Override
     public Optional<SpreadsheetCell> cell() {
         return HasSpreadsheetCell.NO_CELL;
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1128,6 +1128,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         dateOffset,
                         Converters.fake(),
                         dateTimeContext,

--- a/src/main/java/walkingkooka/spreadsheet/provider/BasicProviderContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/provider/BasicProviderContext.java
@@ -84,6 +84,7 @@ final class BasicProviderContext implements ProviderContext,
                 ExpressionNumberConverterContexts.basic(
                     converter.cast(ExpressionNumberConverterContext.class),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.EXCEL_1904_DATE_SYSTEM_OFFSET, // dateTimeOffset
                         converter.cast(ConverterContext.class),
                         DateTimeContexts.basic(

--- a/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpressionEvaluationContext.java
@@ -130,6 +130,11 @@ final class SpreadsheetFormulaSpreadsheetMetadataAwareSpreadsheetCellStoreExpres
     }
 
     @Override
+    public boolean canNumbersHaveGroupSeparator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public long dateOffset() {
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/walkingkooka/spreadsheet/compare/BasicSpreadsheetComparatorContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/BasicSpreadsheetComparatorContextTest.java
@@ -100,6 +100,7 @@ public final class BasicSpreadsheetComparatorContextTest implements SpreadsheetC
             ExpressionNumberConverterContexts.basic(
                 Converters.fake(),
                 ConverterContexts.basic(
+                    false, // canNumbersHaveGroupSeparator
                     Converters.JAVA_EPOCH_OFFSET, // dateOffset
                     Converters.objectToString(),
                     DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContextTest.java
@@ -179,6 +179,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
             ExpressionNumberConverterContexts.basic(
                 Converters.fake(),
                 ConverterContexts.basic(
+                    false, // canNumbersHaveGroupSeparator
                     Converters.JAVA_EPOCH_OFFSET, // dateOffset
                     Converters.fake(),
                     DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/MissingConverterVerifierTest.java
@@ -267,6 +267,11 @@ public final class MissingConverterVerifierTest implements TreePrintableTesting,
         );
 
         @Override
+        public boolean canNumbersHaveGroupSeparator() {
+            return false;
+        }
+
+        @Override
         public long dateOffset() {
             return 0;
         }

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterFormatPatternToStringTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterFormatPatternToStringTest.java
@@ -304,6 +304,7 @@ public final class SpreadsheetConverterFormatPatternToStringTest extends Spreads
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         converter.cast(ConverterContext.class),
                         DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContextTest.java
@@ -171,6 +171,7 @@ public final class SpreadsheetConverterNumberToTextSpreadsheetConverterContextTe
                     ExpressionNumberConverterContexts.basic(
                         Converters.fake(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersConverterProviderTest.java
@@ -156,6 +156,7 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
                     ExpressionNumberConverterContexts.basic(
                         Converters.fake(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
@@ -2820,6 +2820,7 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(), // not used
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         DateTimeContexts.basic(
@@ -3046,6 +3047,8 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(), // not used
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
+
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         DateTimeContexts.fake(), // unused only doing numbers

--- a/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
@@ -234,6 +234,7 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
             ExpressionNumberConverterContexts.basic(
                 Converters.fake(),
                 ConverterContexts.basic(
+                    false, // canNumbersHaveGroupSeparator
                     Converters.JAVA_EPOCH_OFFSET, // dateOffset
                     Converters.fake(),
                     DATE_TIME_CONTEXT,

--- a/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetFormatterTest.java
@@ -143,6 +143,7 @@ public final class ExpressionSpreadsheetFormatterTest implements SpreadsheetForm
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(), // not used
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         DateTimeContexts.fake(),

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterSpreadsheetFormatterContextTest.java
@@ -171,6 +171,7 @@ public final class SpreadsheetFormatterConverterSpreadsheetFormatterContextTest 
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         dateTimeContext(),

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
@@ -136,6 +136,7 @@ public final class SpreadsheetFormatterConverterTest implements ConverterTesting
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         DateTimeContexts.fake(),

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterConditionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternSpreadsheetFormatterConditionTest.java
@@ -327,6 +327,7 @@ public final class SpreadsheetPatternSpreadsheetFormatterConditionTest extends S
                     ExpressionNumberConverterContexts.basic(
                         Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.fake(),

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
@@ -1254,6 +1254,7 @@ public final class SpreadsheetNumberParsePatternTest extends SpreadsheetParsePat
                 ExpressionNumberConverterContexts.basic(
                     Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         DateTimeContexts.fake(), // DateTimeContext unused

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
@@ -867,6 +867,7 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
                 ExpressionNumberConverterContexts.basic(
                     Converters.fake(),
                     ConverterContexts.basic(
+                        false, // canNumbersHaveGroupSeparator
                         Converters.JAVA_EPOCH_OFFSET, // dateOffset
                         Converters.fake(),
                         this.dateTimeContext(),

--- a/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaParsersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/formula/SpreadsheetFormulaParsersTest.java
@@ -4199,6 +4199,7 @@ public final class SpreadsheetFormulaParsersTest implements PublicStaticHelperTe
                     ExpressionNumberConverterContexts.basic(
                         Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             dateTimeContext(),

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1411,6 +1411,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                     ExpressionNumberConverterContexts.basic(
                         Converters.fake(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
@@ -137,6 +137,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNu
                     ExpressionNumberConverterContexts.basic(
                         Converters.fake(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest.java
@@ -91,6 +91,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserNumberTest ex
                     ExpressionNumberConverterContexts.basic(
                         Converters.fake(),
                         ConverterContexts.basic(
+                            false, // canNumbersHaveGroupSeparator
                             Converters.JAVA_EPOCH_OFFSET, // dateOffset
                             Converters.fake(),
                             DateTimeContexts.basic(


### PR DESCRIPTION
….canNumbersHaveGroupSeparator

- https://github.com/mP1/walkingkooka-convert/pull/307
- ConverterContext.canNumbersHaveGroupSeparator

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7552
- SpreadsheetConverterContext.isGroupSeparatorWithinNumbersSupported