### PR TITLE
SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter Sp…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
@@ -49,7 +49,7 @@ final class SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter e
             BigDecimal.class,
             Parsers.bigDecimal(), // parser
             (final SpreadsheetConverterContext c) -> ParserContexts.basic(
-                false, // canNumbersHaveGroupSeparator
+                c.canNumbersHaveGroupSeparator(), // canNumbersHaveGroupSeparator
                 InvalidCharacterExceptionFactory.POSITION,
                 DateTimeContexts.fake(),
                 c

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToBooleanTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToBooleanTest.java
@@ -536,6 +536,12 @@ public final class SpreadsheetConverterToBooleanTest extends SpreadsheetConverte
     @Override
     public SpreadsheetConverterContext createContext() {
         return new FakeSpreadsheetConverterContext() {
+
+            @Override
+            public boolean canNumbersHaveGroupSeparator() {
+                return false;
+            }
+
             @Override
             public long dateOffset() {
                 return Converters.EXCEL_1900_DATE_SYSTEM_OFFSET;

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
@@ -569,6 +569,12 @@ public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverter
     @Override
     public SpreadsheetConverterContext createContext() {
         return new FakeSpreadsheetConverterContext() {
+
+            @Override
+            public boolean canNumbersHaveGroupSeparator() {
+                return false;
+            }
+
             @Override
             public long dateOffset() {
                 return Converters.EXCEL_1900_DATE_SYSTEM_OFFSET;

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
@@ -1517,6 +1517,11 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
         }
 
         @Override
+        public boolean canNumbersHaveGroupSeparator() {
+            return false;
+        }
+
+        @Override
         public String currencySymbol() {
             return this.decimalNumberContext.currencySymbol();
         }
@@ -2420,6 +2425,11 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
                 @Override
                 public ExpressionNumberKind expressionNumberKind() {
                     return EXPRESSION_NUMBER_KIND;
+                }
+
+                @Override
+                public boolean canNumbersHaveGroupSeparator() {
+                    return false;
                 }
 
                 @Override


### PR DESCRIPTION
…readsheetParserContext copies SpreadsheetConverterContext.canNumbersHaveGroupSeparator FIX

- Previously canNumbersHaveGroupSeparator was *ALWAYS* false, true enables the groupSeparator to be handled by BigDecimalParser