### PR TITLE
BasicSpreadsheetEngineContext.formatValueAndStyle formatting failure FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -377,31 +377,28 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
         final Optional<Object> value = formula.errorOrValue();
 
         SpreadsheetCell formattedCell = cell;
-        Optional<TextNode> formatted = this.formatValue(
-            cell,
-            value,
-            formatter
-        ).map(
-            f -> cell.style()
-                .replace(f)
-        );
+        Optional<TextNode> formatted;
 
-
-        SpreadsheetError error = null;
-
-        // if format was unsuccessful probably "formatter not found" and there is no error replace error
-        if (false == formatted.isPresent()) {
-            error = SpreadsheetError.formatterNotFound(
+        try {
+            formatted = this.formatValue(
+                cell,
+                value,
+                formatter
+            ).map(
+                f -> cell.style()
+                    .replace(f)
+            );
+        } catch (final UnsupportedOperationException rethrow) {
+            throw rethrow;
+        } catch (final RuntimeException cause) {
+            final SpreadsheetError error = SpreadsheetError.formatterNotFound(
                 formatter.map(SpreadsheetFormatterSelector::name)
                     .orElse(null)
             );
             formatted = Optional.of(
                 TextNode.text(error.text())
             );
-        }
 
-        // if no ERROR save new "formatted not found" ERROR if no error was present.
-        if (null != error && false == formula.error().isPresent()) {
             formattedCell = formattedCell.setFormula(
                 formula.setError(
                     Optional.of(error)

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -45,6 +45,7 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetColors;
 import walkingkooka.spreadsheet.SpreadsheetDescription;
+import walkingkooka.spreadsheet.SpreadsheetError;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparator;
 import walkingkooka.spreadsheet.compare.SpreadsheetComparators;
 import walkingkooka.spreadsheet.conditionalformat.SpreadsheetConditionalFormattingRule;
@@ -835,7 +836,43 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
         );
     }
 
-    // formatValueAndStyle...................................................................................................
+    // formatValueAndStyle..............................................................................................
+
+    @Test
+    public void testFormatValueAndStyleWithUnknownFormatterFails() {
+        final SpreadsheetCell cell = SpreadsheetSelection.A1.setFormula(
+            SpreadsheetFormula.EMPTY.setText("1")
+                .setValue(
+                    Optional.of(1)
+                )
+        );
+
+        final SpreadsheetFormatterSelector formatter = SpreadsheetFormatterSelector.parse("unknown-formatter-404 param1");
+
+        this.formatAndStyleAndCheck(
+            this.createContext(
+                METADATA,
+                SpreadsheetLabelStores.fake(),
+                SpreadsheetCellRangeStores.treeMap()
+            ),
+            cell,
+            formatter,
+            cell.setFormula(
+                cell.formula()
+                    .setError(
+                        Optional.of(
+                            SpreadsheetError.formatterNotFound(
+                                formatter.name()
+                            )
+                        )
+                    )
+            ).setFormattedValue(
+                Optional.of(
+                    TextNode.text("#ERROR")
+                )
+            )
+        );
+    }
 
     @Test
     public void testFormatValueAndStyle() {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -4752,6 +4752,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         );
 
         final ConverterSelector formulaConverterSelector = ConverterSelector.parse("null-to-number");
+        final ConverterSelector formattingConverterSelector = ConverterSelector.parse("text");
         final ConverterSelector validationConverterSelector = ConverterSelector.parse("fake");
         final ValidatorSelector validatorSelector = ValidatorSelector.parse("TestValidator");
 
@@ -4762,14 +4763,16 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 SpreadsheetMetadataPropertyName.CONVERTERS,
                 ConverterAliasSet.EMPTY
                     .concat(
-                        ConverterAlias.parse(formulaConverterSelector.text())
+                        ConverterAlias.parse("null-to-number")
+                    ).concat(
+                        ConverterAlias.parse("text")
                     )
             ).set(
                 SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                 formulaConverterSelector
             ).set(
                 SpreadsheetMetadataPropertyName.FORMATTING_CONVERTER,
-                formulaConverterSelector
+                formattingConverterSelector
             ).set(
                 SpreadsheetMetadataPropertyName.VALIDATION_CONVERTER,
                 validationConverterSelector
@@ -4792,9 +4795,10 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                                                                final List<?> values,
                                                                                final ProviderContext context) {
                         if (formulaConverterSelector.name().equals(name)) {
-                            return Cast.to(
-                                SpreadsheetConverters.nullToNumber()
-                            );
+                            return CONVERTER_PROVIDER.converter(name, values, context);
+                        }
+                        if (formattingConverterSelector.name().equals(name)) {
+                            return CONVERTER_PROVIDER.converter(name, values, context);
                         }
                         if (validationConverterSelector.name().equals(name)) {
                             return Converters.fake();
@@ -4847,10 +4851,8 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 )
         ).setFormattedValue(
             Optional.of(
-                TextNode.text(
-                    SpreadsheetError.formatterNotFound(null)
-                        .text()
-                )
+                TextNode.text("#ERROR " + FORMATTED_PATTERN_SUFFIX)
+                    .setTextStyle(STYLE)
             )
         );
 
@@ -4886,6 +4888,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         );
 
         final ConverterSelector formulaConverterSelector = ConverterSelector.parse("null-to-number");
+        final ConverterSelector formattingConverterSelector = ConverterSelector.parse("text");
         final ConverterSelector validationConverterSelector = ConverterSelector.parse("TestValidationConverter");
         final ValidatorSelector validatorSelector = ValidatorSelector.parse("TestValidator");
 
@@ -4894,9 +4897,10 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
             SERVER_URL,
             METADATA.set(
                 SpreadsheetMetadataPropertyName.CONVERTERS,
-                ConverterAliasSet.EMPTY
-                    .concat(
+                ConverterAliasSet.EMPTY.concat(
                         ConverterAlias.parse(formulaConverterSelector.text())
+                    ).concat(
+                        ConverterAlias.parse(formattingConverterSelector.text())
                     ).concat(
                         ConverterAlias.parse(validationConverterSelector.text())
                     )
@@ -4905,7 +4909,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                 formulaConverterSelector
             ).set(
                 SpreadsheetMetadataPropertyName.FORMATTING_CONVERTER,
-                formulaConverterSelector
+                formattingConverterSelector
             ).set(
                 SpreadsheetMetadataPropertyName.VALIDATION_CONVERTER,
                 validationConverterSelector
@@ -4928,9 +4932,10 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                                                                                final List<?> values,
                                                                                final ProviderContext context) {
                         if (formulaConverterSelector.name().equals(name)) {
-                            return Cast.to(
-                                SpreadsheetConverters.nullToNumber()
-                            );
+                            return CONVERTER_PROVIDER.converter(name, values, context);
+                        }
+                        if (formattingConverterSelector.name().equals(name)) {
+                            return CONVERTER_PROVIDER.converter(name, values, context);
                         }
                         if (validationConverterSelector.name().equals(name)) {
                             return new FakeConverter<>() {
@@ -5001,9 +5006,8 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         ).setFormattedValue(
             Optional.of(
                 TextNode.text(
-                    SpreadsheetError.formatterNotFound(null)
-                        .text()
-                )
+                    "#ERROR " + FORMATTED_PATTERN_SUFFIX
+                ).setTextStyle(STYLE)
             )
         );
 


### PR DESCRIPTION
- Previously formatters that returned an empty TextNode would then be reformatted with error=formatterNotFound.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7609
- BasicSpreadsheetEngineContext.formatValueAndStyle handles formatting failure poorly