### PR TITLE
SpreadsheetMetadataPropertyName.ERROR_FORMATTER

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/FakeSpreadsheetMetadataVisitor.java
@@ -157,6 +157,11 @@ public class FakeSpreadsheetMetadataVisitor extends SpreadsheetMetadataVisitor {
     }
 
     @Override
+    protected void visitErrorFormatter(final SpreadsheetFormatterSelector selector) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visitExporters(final SpreadsheetExporterAliasSet aliases) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -198,6 +198,11 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     public static final SpreadsheetMetadataPropertyName<Integer> DEFAULT_YEAR = registerConstant(SpreadsheetMetadataPropertyNameIntegerDefaultYear.instance());
 
     /**
+     * A {@link SpreadsheetMetadataPropertyName} holding the <code>errorFormatter</code>
+     */
+    public static final SpreadsheetMetadataPropertyName<SpreadsheetFormatterSelector> ERROR_FORMATTER = registerConstant(SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.instance());
+
+    /**
      * A {@link SpreadsheetMetadataPropertyName} holding the <code>exporters</code>
      */
     public static final SpreadsheetMetadataPropertyName<SpreadsheetExporterAliasSet> EXPORTERS = registerConstant(SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSetExporters.instance());

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import walkingkooka.locale.LocaleContext;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
+import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
+
+import java.util.Optional;
+
+/**
+ * This {@link SpreadsheetMetadataPropertyName} holds the default formatter for {@link walkingkooka.spreadsheet.SpreadsheetError} values.
+ */
+final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector {
+
+    /**
+     * Singleton
+     */
+    static SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError instance() {
+        return new SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError();
+    }
+
+    /**
+     * Private constructor use singleton.
+     */
+    private SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError() {
+        super(
+            "errorFormatter",
+            null // no SpreadsheetPatternKind
+        );
+    }
+
+    @Override
+    void accept(final SpreadsheetFormatterSelector value,
+                final SpreadsheetMetadataVisitor visitor) {
+        visitor.visitErrorFormatter(value);
+    }
+
+    @Override
+    Optional<SpreadsheetFormatPattern> extractLocaleAwareValueSpreadsheetFormatPattern(final LocaleContext context) {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitor.java
@@ -171,6 +171,10 @@ public abstract class SpreadsheetMetadataVisitor extends Visitor<SpreadsheetMeta
         // nop
     }
 
+    protected void visitErrorFormatter(final SpreadsheetFormatterSelector selector) {
+        // nop
+    }
+
     protected void visitExporters(final SpreadsheetExporterAliasSet aliases) {
         // nop
     }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -2663,6 +2663,10 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
             FormHandlerSelector.parse("hello-form-handler")
         );
         properties.put(SpreadsheetMetadataPropertyName.DEFAULT_YEAR, 1901);
+        properties.put(
+            SpreadsheetMetadataPropertyName.ERROR_FORMATTER,
+            SpreadsheetPattern.parseTextFormatPattern("\"ERROR\" @").spreadsheetFormatterSelector()
+        );
         properties.put(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.BIG_DECIMAL);
         properties.put(
             SpreadsheetMetadataPropertyName.EXPORTERS,

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorErrorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorErrorTest.java
@@ -1,0 +1,63 @@
+
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.meta;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.locale.LocaleContexts;
+import walkingkooka.spreadsheet.format.SpreadsheetFormatterSelector;
+
+import java.util.Optional;
+
+public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorErrorTest extends SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorTestCase<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError>
+    implements SpreadsheetMetadataTesting {
+
+    @Test
+    public void testExtractLocaleAwareValue() {
+        this.checkEquals(
+            Optional.empty(),
+            SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.instance()
+                .extractLocaleAwareValue(LocaleContexts.fake())
+        );
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(
+            SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.instance(),
+            "errorFormatter"
+        );
+    }
+
+    @Override
+    SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError createName() {
+        return SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.instance();
+    }
+
+    @Override
+    SpreadsheetFormatterSelector propertyValue() {
+        return SpreadsheetFormatterSelector.parse("hello-error-formatter");
+    }
+
+    // ClassTesting.....................................................................................................
+
+    @Override
+    public Class<SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError> type() {
+        return SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorError.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataVisitorTest.java
@@ -335,6 +335,19 @@ public final class SpreadsheetMetadataVisitorTest implements SpreadsheetMetadata
     }
 
     @Test
+    public void testVisitErrorFormatter() {
+        new TestSpreadsheetMetadataVisitor() {
+            @Override
+            protected void visitErrorFormatter(final SpreadsheetFormatterSelector s) {
+                this.visited = s;
+            }
+        }.accept(
+            SpreadsheetMetadataPropertyName.ERROR_FORMATTER,
+            SpreadsheetFormatterSelector.parse("hello-error-formatter")
+        );
+    }
+
+    @Test
     public void testVisitFindConverter() {
         new TestSpreadsheetMetadataVisitor() {
             @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7573
- SpreadsheetMetadataPropertyName: SpreadsheetFormatter for "errors".