### PR TITLE
SpreadsheetErrorKind.toError lazy cache

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetErrorKind.java
@@ -144,8 +144,14 @@ public enum SpreadsheetErrorKind implements HasText {
      * Returns a {@link SpreadsheetError} with this {@link SpreadsheetErrorKind} but no message or value.
      */
     public SpreadsheetError toError() {
-        return this.setMessage(SpreadsheetError.NO_MESSAGE);
+        if (null == this.spreadsheetError) {
+            this.spreadsheetError = this.setMessage(SpreadsheetError.NO_MESSAGE);
+        }
+        return this.spreadsheetError;
     }
+
+    // lazy cache
+    private SpreadsheetError spreadsheetError;
 
     public SpreadsheetError setMessage(final String message) {
         return this.setMessageAndValue(

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetErrorKindTest.java
@@ -39,6 +39,7 @@ import walkingkooka.tree.expression.function.UnknownExpressionFunctionException;
 import java.math.MathContext;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SpreadsheetErrorKindTest implements ParseStringTesting<SpreadsheetErrorKind>,
@@ -378,6 +379,18 @@ public final class SpreadsheetErrorKindTest implements ParseStringTesting<Spread
                     Optional.empty()
                 ),
                 error
+            );
+        }
+    }
+
+    @Test
+    public void testToErrorCached() {
+        for (final SpreadsheetErrorKind kind : SpreadsheetErrorKind.values()) {
+            final SpreadsheetError error = kind.toError();
+            assertSame(
+                error,
+                kind.toError(),
+                () -> kind + ".toError not cached"
             );
         }
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/7663
- SpreadsheetErrorKind.toError should cache instance