### PR TITLE
XXXSpreadsheetContext.createMetadata removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
@@ -101,15 +101,6 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
     // SpreadsheetContext...............................................................................................
 
     @Override
-    public SpreadsheetMetadata createMetadata(final EmailAddress user,
-                                              final Optional<Locale> locale) {
-        Objects.requireNonNull(user, "user");
-        Objects.requireNonNull(locale, "locale");
-
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<SpreadsheetMetadata> loadMetadata(final SpreadsheetId id) {
         Objects.requireNonNull(id, "id");
 

--- a/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetContext.java
@@ -135,12 +135,6 @@ public class FakeSpreadsheetContext extends FakeSpreadsheetProvider implements S
     // SpreadsheetMetadataContext.......................................................................................
 
     @Override
-    public SpreadsheetMetadata createMetadata(final EmailAddress user,
-                                              final Optional<Locale> locale) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<SpreadsheetMetadata> loadMetadata(final SpreadsheetId id) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
- Unnecessary because of default method: SpreadsheetContext.createMetadata