### PR TITLE
SpreadsheetContext.setSpreadsheetId

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
@@ -106,10 +106,12 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
         this.spreadsheetEngineContext = null != spreadsheetEngineContextFactory ?
             spreadsheetEngineContextFactory.apply(this) :
             spreadsheetEngineContext;
+        this.spreadsheetEngineContextFactory = spreadsheetEngineContextFactory;
 
         this.httpRouter = null == httpRouter ?
             httpRouterFactory.apply(this.spreadsheetEngineContext) :
             httpRouter;
+        this.httpRouterFactory = httpRouterFactory;
     }
 
     @Override
@@ -119,12 +121,39 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
 
     private final AbsoluteUrl serverUrl;
 
+    // SpreadsheetId....................................................................................................
+
     @Override
     public SpreadsheetId spreadsheetId() {
         return this.spreadsheetId;
     }
 
     private final SpreadsheetId spreadsheetId;
+
+
+    @Override
+    public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
+        Objects.requireNonNull(id, "id");
+
+        return this.spreadsheetId.equals(id) ?
+            this :
+            new BasicSpreadsheetContext(
+                this.serverUrl,
+                id,
+                this.spreadsheetIdToStoreRepository,
+                null, // SpreadsheetStoreRepository
+                this.spreadsheetProvider,
+                this.spreadsheetEngineContextFactory,
+                null, // SpreadsheetEngineContext
+                this.httpRouterFactory,
+                null, // httpRouter
+                this.environmentContext,
+                this.localeContext,
+                this.providerContext
+            );
+    }
+
+    // StoreRepository..................................................................................................
 
     @Override
     public SpreadsheetStoreRepository storeRepository() {
@@ -223,6 +252,8 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
 
     private final SpreadsheetEngineContext spreadsheetEngineContext;
 
+    private final Function<SpreadsheetContext, SpreadsheetEngineContext> spreadsheetEngineContextFactory;
+
     @Override
     public Router<HttpRequestAttribute<?>, HttpHandler> httpRouter() {
         return this.httpRouter;
@@ -232,6 +263,8 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
      * The cached router for this spreadsheet.
      */
     private final Router<HttpRequestAttribute<?>, HttpHandler> httpRouter;
+
+    private final Function<SpreadsheetEngineContext, Router<HttpRequestAttribute<?>, HttpHandler>> httpRouterFactory;
 
     // EnvironmentContextDelegator......................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetContext.java
@@ -55,6 +55,11 @@ public class FakeSpreadsheetContext extends FakeSpreadsheetProvider implements S
     }
 
     @Override
+    public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public SpreadsheetStoreRepository storeRepository() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContext.java
@@ -63,6 +63,11 @@ public interface SpreadsheetContext extends SpreadsheetProvider,
     SpreadsheetId spreadsheetId();
 
     /**
+     * Returns a {@link SpreadsheetContext} with the given {@link SpreadsheetId}, creating a new instance if different.
+     */
+    SpreadsheetContext setSpreadsheetId(final SpreadsheetId spreadsheetId);
+
+    /**
      * The {@link SpreadsheetStoreRepository} for the selected spreadsheet.
      */
     SpreadsheetStoreRepository storeRepository();

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextTesting.java
@@ -24,6 +24,9 @@ import walkingkooka.plugin.HasProviderContextTesting;
 import walkingkooka.spreadsheet.meta.HasSpreadsheetMetadataTesting;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextTesting;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends EnvironmentContextTesting2<C>,
     HasProviderContextTesting,
     HasSpreadsheetMetadataTesting,
@@ -38,6 +41,31 @@ public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends
             context.spreadsheetId()
         );
     }
+
+    // setSpreadsheetId.................................................................................................
+
+    @Test
+    default void testSetSpreadsheetIdWithNullFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createContext()
+                .setSpreadsheetId(null)
+        );
+    }
+
+    @Test
+    default void testSetSpreadsheetIdWithSame() {
+        final C context = this.createContext();
+
+        assertSame(
+            context,
+            context.setSpreadsheetId(
+                context.spreadsheetId()
+            )
+        );
+    }
+
+    // setLocale........................................................................................................
 
     @Test
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContext.java
@@ -453,6 +453,22 @@ final class BasicSpreadsheetEngineContext implements SpreadsheetEngineContext,
     }
 
     @Override
+    public SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId id) {
+        final SpreadsheetContext before = this.spreadsheetContext;
+        final SpreadsheetContext after = before.setSpreadsheetId(id);
+
+        return before.equals(after) ?
+            this :
+            new BasicSpreadsheetEngineContext(
+                this.mode,
+                this.canConvert,
+                this.spreadsheetLabelNameResolver,
+                after,
+                this.terminalContext
+            );
+    }
+
+    @Override
     public SpreadsheetStoreRepository storeRepository() {
         return this.spreadsheetContext.storeRepository();
     }

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngineContext.java
@@ -218,6 +218,13 @@ public class FakeSpreadsheetEngineContext extends FakeSpreadsheetProvider implem
         throw new UnsupportedOperationException();
     }
 
+    // SpreadsheetEngineContext.........................................................................................
+
+    @Override
+    public SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId id) {
+        throw new UnsupportedOperationException();
+    }
+
     // EnvironmentContext...............................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContext.java
@@ -24,6 +24,7 @@ import walkingkooka.net.email.EmailAddress;
 import walkingkooka.spreadsheet.HasMissingCellNumberValue;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetContext;
+import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionEvaluationContext;
 import walkingkooka.spreadsheet.format.provider.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
@@ -110,6 +111,14 @@ public interface SpreadsheetEngineContext extends Context,
         return this.spreadsheetMetadata()
             .missingCellNumberValue();
     }
+
+    // SpreadsheetContext...............................................................................................
+
+    /**
+     * {@see SpreadsheetContext#setSpreadsheetId}
+     */
+    @Override
+    SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId spreadsheetId);
 
     // EnvironmentContext...............................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextDelegatorTest.java
@@ -51,6 +51,23 @@ public final class SpreadsheetContextDelegatorTest implements SpreadsheetContext
 
     final static class TestSpreadsheetContextDelegator implements SpreadsheetContextDelegator {
 
+        private final static SpreadsheetId SPREADSHEET_ID = SpreadsheetId.with(1);
+
+        @Override
+        public SpreadsheetId spreadsheetId() {
+            return SPREADSHEET_ID;
+        }
+
+        @Override
+        public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
+            Objects.requireNonNull(id, "id");
+
+            if (SPREADSHEET_ID.equals(id)) {
+                return this;
+            }
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public SpreadsheetEngineContext spreadsheetEngineContext() {
             throw new UnsupportedOperationException();
@@ -79,6 +96,11 @@ public final class SpreadsheetContextDelegatorTest implements SpreadsheetContext
         }
 
         private final SpreadsheetContext context = new FakeSpreadsheetContext() {
+
+            @Override
+            public SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId id) {
+                throw new UnsupportedOperationException();
+            }
 
             @Override
             public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextTestingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextTestingTest.java
@@ -40,6 +40,23 @@ public final class SpreadsheetContextTestingTest implements SpreadsheetContextTe
 
     static class TestSpreadsheetContext extends FakeSpreadsheetContext {
 
+        private final static SpreadsheetId SPREADSHEET_ID = SpreadsheetId.with(1);
+
+        @Override
+        public SpreadsheetId spreadsheetId() {
+            return SPREADSHEET_ID;
+        }
+
+        @Override
+        public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
+            Objects.requireNonNull(id, "id");
+
+            if (SPREADSHEET_ID.equals(id)) {
+                return this;
+            }
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {
             Objects.requireNonNull(name, "name");

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -1525,6 +1525,16 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
         }
 
         @Override
+        public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
+            Objects.requireNonNull(id, "id");
+
+            if (SPREADSHEET_ID.equals(id)) {
+                return this;
+            }
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public SpreadsheetStoreRepository storeRepository() {
             return this.storeRepository;
         }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -581,6 +581,11 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
         }
 
         @Override
+        public SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public SpreadsheetStoreRepository storeRepository() {
             return this.spreadsheetStoreRepository;
         }

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextDelegatorTest.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.engine;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
@@ -30,6 +31,12 @@ import java.util.Optional;
 public final class SpreadsheetEngineContextDelegatorTest implements ClassTesting<SpreadsheetEngineContextDelegator> {
 
     final static class TestSpreadsheetEngineContextDelegator implements SpreadsheetEngineContextDelegator {
+
+        @Override
+        public SpreadsheetEngineContext setSpreadsheetId(final SpreadsheetId id) {
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public SpreadsheetEngineContext spreadsheetEngineContext() {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
- This setter is required to support executing SpreadsheetEngineContext metadata/cell/etc methods.