### PR TITLE
SpreadsheetContext.SPREADSHEET_ID spreadsheetId sync EnvironmentConte…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/BasicSpreadsheetContext.java
@@ -112,6 +112,11 @@ final class BasicSpreadsheetContext implements SpreadsheetContext,
             httpRouterFactory.apply(this.spreadsheetEngineContext) :
             httpRouter;
         this.httpRouterFactory = httpRouterFactory;
+
+        this.setEnvironmentValue(
+            SPREADSHEET_ID,
+            spreadsheetId
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContext.java
@@ -49,6 +49,13 @@ public interface SpreadsheetContext extends SpreadsheetProvider,
     LocaleContext,
     SpreadsheetMetadataContext {
 
+    /**
+     * The {@link EnvironmentContext#environmentValue(EnvironmentValueName)} should always match {@link #spreadsheetId()}.
+     */
+    EnvironmentValueName<SpreadsheetId> SPREADSHEET_ID = EnvironmentValueName.with(
+        "spreadsheet-id"
+    );
+
     @Override
     default SpreadsheetMetadata createMetadata(final EmailAddress user,
                                                final Optional<Locale> locale) {

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextTesting.java
@@ -34,6 +34,19 @@ public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends
     LocaleContextTesting2<C>,
     SpreadsheetMetadataContextTesting<C> {
 
+    // spreadsheetId....................................................................................................
+
+    @Test
+    default void testEnvironmentValueNameWithSpreadsheetId() {
+        final C context = this.createContext();
+
+        this.environmentValueAndCheck(
+            context,
+            SpreadsheetContext.SPREADSHEET_ID,
+            context.spreadsheetId()
+        );
+    }
+
     default void spreadsheetIdAndCheck(final C context,
                                        final SpreadsheetId expected) {
         this.checkEquals(

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextDelegatorTest.java
@@ -105,7 +105,12 @@ public final class SpreadsheetContextDelegatorTest implements SpreadsheetContext
             @Override
             public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {
                 Objects.requireNonNull(name, "name");
-                throw new UnsupportedOperationException();
+
+                return Optional.ofNullable(
+                    SPREADSHEET_ID.equals(name) ?
+                        (T) TestSpreadsheetContextDelegator.SPREADSHEET_ID :
+                        null
+                );
             }
 
             @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextTestingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextTestingTest.java
@@ -60,7 +60,12 @@ public final class SpreadsheetContextTestingTest implements SpreadsheetContextTe
         @Override
         public <T> Optional<T> environmentValue(final EnvironmentValueName<T> name) {
             Objects.requireNonNull(name, "name");
-            throw new UnsupportedOperationException();
+
+            return Optional.ofNullable(
+                SpreadsheetContext.SPREADSHEET_ID.equals(name) ?
+                    (T) TestSpreadsheetContext.SPREADSHEET_ID :
+                    null
+            );
         }
 
         @Override

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineContextTest.java
@@ -1505,13 +1505,21 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
                                final EnvironmentContext environmentContext,
                                final LocaleContext localeContext,
                                final ProviderContext providerContext) {
-            checkEquals(SPREADSHEET_ID, metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_ID));
+            checkEquals(
+                BasicSpreadsheetEngineContextTest.SPREADSHEET_ID,
+                metadata.getOrFail(SpreadsheetMetadataPropertyName.SPREADSHEET_ID)
+            );
             this.metadata = metadata;
             this.storeRepository = storeRepository;
 
             this.environmentContext = environmentContext;
             this.localeContext = localeContext;
             this.providerContext = providerContext;
+
+            environmentContext.setEnvironmentValue(
+                SPREADSHEET_ID,
+                BasicSpreadsheetEngineContextTest.SPREADSHEET_ID
+            );
         }
 
         @Override
@@ -1521,14 +1529,14 @@ public final class BasicSpreadsheetEngineContextTest implements SpreadsheetEngin
 
         @Override
         public SpreadsheetId spreadsheetId() {
-            return SPREADSHEET_ID;
+            return BasicSpreadsheetEngineContextTest.SPREADSHEET_ID;
         }
 
         @Override
         public SpreadsheetContext setSpreadsheetId(final SpreadsheetId id) {
             Objects.requireNonNull(id, "id");
 
-            if (SPREADSHEET_ID.equals(id)) {
+            if (this.spreadsheetId().equals(id)) {
                 return this;
             }
             throw new UnsupportedOperationException();


### PR DESCRIPTION
…xt.environmentValueName

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/8117
- SpreadsheetContext.EnvironmentContext.SPREADSHEET_ID should match SpreadsheetContext#spreadsheetId

- Especially necessary within a (Spreadsheet)TerminalContext