### PR TITLE
SpreadsheetId implements HasText

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetId.java
@@ -24,6 +24,7 @@ import walkingkooka.Value;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.text.CharSequences;
+import walkingkooka.text.HasText;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.TreePrintable;
 import walkingkooka.tree.json.JsonNode;
@@ -37,6 +38,7 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 public final class SpreadsheetId implements Comparable<SpreadsheetId>,
     HasId<Long>,
     Value<Long>,
+    HasText,
     HasUrlFragment,
     HasNotFoundText,
     TreePrintable {
@@ -159,5 +161,12 @@ public final class SpreadsheetId implements Comparable<SpreadsheetId>,
     @Override
     public void printTree(final IndentingPrinter printer) {
         printer.println(this.toString());
+    }
+
+    // HasText..........................................................................................................
+
+    @Override
+    public String text() {
+        return this.toString();
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetIdTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetIdTest.java
@@ -25,6 +25,7 @@ import walkingkooka.net.HasUrlFragmentTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.test.ParseStringTesting;
+import walkingkooka.text.HasTextTesting;
 import walkingkooka.text.printer.TreePrintableTesting;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
@@ -33,6 +34,7 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
     ComparableTesting2<SpreadsheetId>,
     HasNotFoundTextTesting,
+    HasTextTesting,
     HasUrlFragmentTesting,
     JsonNodeMarshallingTesting<SpreadsheetId>,
     ParseStringTesting<SpreadsheetId>,
@@ -71,6 +73,16 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
     @Test
     public void testUrlFragment() {
         this.urlFragmentAndCheck(
+            SpreadsheetId.with(0x123456),
+            "123456"
+        );
+    }
+
+    // HasText..........................................................................................................
+
+    @Test
+    public void testText() {
+        this.textAndCheck(
             SpreadsheetId.with(0x123456),
             "123456"
         );


### PR DESCRIPTION
- Necessary to support easy printing of SpreadsheetId returned by a function in a terminal, eg setEnv("spreadsheetId", 1) - currently fails because cannot be converted into String for printing.