### PR TITLE
POM: surefire argLine removed coveralls FIX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,6 @@
               <includes>
                   <include>**/*Test.java</include>
               </includes>
-              <argLine>-Xmx2G -Duser.language=EN -Duser.region=AU</argLine>
             <trimStackTrace>false</trimStackTrace>
           </configuration>
         <dependencies>


### PR DESCRIPTION
- Removing the surefire argline should fix coveralls.