### PR TITLE
OptionalSpreadsheetValue.toString() FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/value/OptionalSpreadsheetValue.java
+++ b/src/main/java/walkingkooka/spreadsheet/value/OptionalSpreadsheetValue.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.value;
 
 import walkingkooka.Cast;
 import walkingkooka.Value;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
@@ -74,7 +75,9 @@ public final class OptionalSpreadsheetValue<T> implements Value<Optional<T>> {
 
     @Override
     public String toString() {
-        return this.value.toString();
+        return this.value.map(CharSequences::quoteIfChars)
+            .orElse("")
+            .toString();
     }
 
     // json.............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/value/OptionalSpreadsheetValueTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/value/OptionalSpreadsheetValueTest.java
@@ -24,6 +24,7 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.format.provider.SpreadsheetFormatterSelector;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
@@ -94,11 +95,22 @@ public final class OptionalSpreadsheetValueTest implements ClassTesting<Optional
 
     @Test
     public void testToString() {
-        final Optional<String> value = Optional.of("Hello123");
+        final String value = "Hello123";
 
         this.toStringAndCheck(
-            OptionalSpreadsheetValue.with(value),
-            value.toString()
+            OptionalSpreadsheetValue.with(
+                Optional.of(value)
+            ),
+            CharSequences.quoteAndEscape(value)
+                .toString()
+        );
+    }
+
+    @Test
+    public void testToStringWithEmpty() {
+        this.toStringAndCheck(
+            OptionalSpreadsheetValue.EMPTY,
+            ""
         );
     }
 


### PR DESCRIPTION
- Previously the internal Optional#toString was returned