### PR TITLE
SpreadsheetMetadataPropertyName.parseUrlFragmentSaveValue CurrencyCod…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyName.java
@@ -25,6 +25,7 @@ import walkingkooka.collect.set.Sets;
 import walkingkooka.color.Color;
 import walkingkooka.convert.provider.ConverterAliasSet;
 import walkingkooka.convert.provider.ConverterSelector;
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.environment.AuditInfo;
@@ -682,7 +683,7 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
      * property. Not all properties support this operation, and will throw a {@link UnsupportedOperationException}.
      */
     public final T parseUrlFragmentSaveValue(final String value,
-                                             final CurrencyLocaleContext context) {
+                                             final CurrencyCodeLanguageTagContext context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
@@ -695,10 +696,10 @@ public abstract class SpreadsheetMetadataPropertyName<T> implements Name,
     }
 
     abstract T parseUrlFragmentSaveValueNonNull(final String value,
-                                                final CurrencyLocaleContext context);
+                                                final CurrencyCodeLanguageTagContext context);
 
     /**
-     * This common method should be called by subclasses to indicate {@link #parseUrlFragmentSaveValue(String, CurrencyLocaleContext)} is not supported.
+     * This common method should be called by subclasses to indicate {@link #parseUrlFragmentSaveValue(String, CurrencyCodeLanguageTagContext)} is not supported.
      */
     final T failParseUrlFragmentSaveValueUnsupported() {
         throw new UnsupportedOperationException("UrlFragment save value not supported for " + CharSequences.quoteAndEscape(this.value()));

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfo.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameAuditInfo.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.environment.AuditInfo;
 
@@ -74,7 +75,7 @@ final class SpreadsheetMetadataPropertyNameAuditInfo extends SpreadsheetMetadata
 
     @Override
     AuditInfo parseUrlFragmentSaveValueNonNull(final String value,
-                                               final CurrencyLocaleContext context) {
+                                               final CurrencyCodeLanguageTagContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameBoolean.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -55,7 +56,7 @@ abstract class SpreadsheetMetadataPropertyNameBoolean extends SpreadsheetMetadat
 
     @Override //
     final Boolean parseUrlFragmentSaveValueNonNull(final String value,
-                                                   final CurrencyLocaleContext context) {
+                                                   final CurrencyCodeLanguageTagContext context) {
         return Boolean.valueOf(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCharacter.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.text.CharSequences;
 
@@ -72,7 +73,7 @@ abstract class SpreadsheetMetadataPropertyNameCharacter extends SpreadsheetMetad
 
     @Override //
     final Character parseUrlFragmentSaveValueNonNull(final String value,
-                                                     final CurrencyLocaleContext context) {
+                                                     final CurrencyCodeLanguageTagContext context) {
         if (value.length() != 1) {
             throw new IllegalArgumentException("Invalid value " + CharSequences.quoteAndEscape(value) + " expected a single character");
         }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterAliasSet.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.convert.provider.ConverterAliasSet;
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameConverterAliasSet extends Spreadsh
 
     @Override //
     final ConverterAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                             final CurrencyLocaleContext context) {
+                                                             final CurrencyCodeLanguageTagContext context) {
         return ConverterAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameConverterSelector.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.convert.provider.ConverterSelector;
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameConverterSelector extends Spreadsh
 
     @Override //
     final ConverterSelector parseUrlFragmentSaveValueNonNull(final String value,
-                                                             final CurrencyLocaleContext context) {
+                                                             final CurrencyCodeLanguageTagContext context) {
         return ConverterSelector.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCurrency.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameCurrency.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Currency;
@@ -76,7 +77,7 @@ final class SpreadsheetMetadataPropertyNameCurrency extends SpreadsheetMetadataP
 
     @Override
     Currency parseUrlFragmentSaveValueNonNull(final String value,
-                                              final CurrencyLocaleContext context) {
+                                              final CurrencyCodeLanguageTagContext context) {
         return context.currencyForCurrencyCodeOrFail(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeOffset.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -68,7 +69,7 @@ final class SpreadsheetMetadataPropertyNameDateTimeOffset extends SpreadsheetMet
 
     @Override
     Long parseUrlFragmentSaveValueNonNull(final String value,
-                                          final CurrencyLocaleContext context) {
+                                          final CurrencyCodeLanguageTagContext context) {
         return Long.parseLong(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbols.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDateTimeSymbols.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.datetime.DateTimeSymbols;
 
@@ -77,7 +78,7 @@ final class SpreadsheetMetadataPropertyNameDateTimeSymbols extends SpreadsheetMe
 
     @Override //
     DateTimeSymbols parseUrlFragmentSaveValueNonNull(final String value,
-                                                     final CurrencyLocaleContext context) {
+                                                     final CurrencyCodeLanguageTagContext context) {
         return DateTimeSymbols.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbols.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameDecimalNumberSymbols.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.math.DecimalNumberSymbols;
 
@@ -71,7 +72,7 @@ final class SpreadsheetMetadataPropertyNameDecimalNumberSymbols extends Spreadsh
 
     @Override
     DecimalNumberSymbols parseUrlFragmentSaveValueNonNull(final String value,
-                                                          final CurrencyLocaleContext context) {
+                                                          final CurrencyCodeLanguageTagContext context) {
         return DecimalNumberSymbols.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionFunctions;
 import walkingkooka.tree.expression.function.provider.ExpressionFunctionAliasSet;
@@ -60,7 +61,7 @@ abstract class SpreadsheetMetadataPropertyNameExpressionFunctionAliasSet extends
 
     @Override //
     final ExpressionFunctionAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                      final CurrencyLocaleContext context) {
+                                                                      final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetExpressionFunctions.parseAliasSet(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameExpressionNumberKind.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
@@ -69,7 +70,7 @@ final class SpreadsheetMetadataPropertyNameExpressionNumberKind extends Spreadsh
 
     @Override
     ExpressionNumberKind parseUrlFragmentSaveValueNonNull(final String value,
-                                                          final CurrencyLocaleContext context) {
+                                                          final CurrencyCodeLanguageTagContext context) {
         return ExpressionNumberKind.valueOf(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQuery.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFindQuery.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetCellQuery;
 
@@ -76,7 +77,7 @@ final class SpreadsheetMetadataPropertyNameFindQuery extends SpreadsheetMetadata
 
     @Override
     SpreadsheetCellQuery parseUrlFragmentSaveValueNonNull(final String value,
-                                                          final CurrencyLocaleContext context) {
+                                                          final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetCellQuery.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.validation.form.provider.FormHandlerAliasSet;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameFormHandlerAliasSet extends Spread
 
     @Override
     public final FormHandlerAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                      final CurrencyLocaleContext context) {
+                                                                      final CurrencyCodeLanguageTagContext context) {
         return FormHandlerAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFormHandlerSelector.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.validation.form.provider.FormHandlerSelector;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameFormHandlerSelector extends Spread
 
     @Override //
     final FormHandlerSelector parseUrlFragmentSaveValueNonNull(final String value,
-                                                               final CurrencyLocaleContext context) {
+                                                               final CurrencyCodeLanguageTagContext context) {
         return FormHandlerSelector.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenColumns.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -80,7 +81,7 @@ final class SpreadsheetMetadataPropertyNameFrozenColumns extends SpreadsheetMeta
 
     @Override
     SpreadsheetColumnRangeReference parseUrlFragmentSaveValueNonNull(final String value,
-                                                                     final CurrencyLocaleContext context) {
+                                                                     final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetSelection.parseColumnRange(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameFrozenRows.java
@@ -19,6 +19,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -81,7 +82,7 @@ final class SpreadsheetMetadataPropertyNameFrozenRows extends SpreadsheetMetadat
 
     @Override
     SpreadsheetRowRangeReference parseUrlFragmentSaveValueNonNull(final String value,
-                                                                  final CurrencyLocaleContext context) {
+                                                                  final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetSelection.parseRowRange(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameInteger.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -52,7 +53,7 @@ abstract class SpreadsheetMetadataPropertyNameInteger extends SpreadsheetMetadat
 
     @Override //
     final Integer parseUrlFragmentSaveValueNonNull(final String value,
-                                                   final CurrencyLocaleContext context) {
+                                                   final CurrencyCodeLanguageTagContext context) {
         return Integer.parseInt(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameLocale.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Locale;
@@ -69,7 +70,7 @@ final class SpreadsheetMetadataPropertyNameLocale extends SpreadsheetMetadataPro
 
     @Override
     Locale parseUrlFragmentSaveValueNonNull(final String value,
-                                            final CurrencyLocaleContext context) {
+                                            final CurrencyCodeLanguageTagContext context) {
         return context.localeForLanguageTagOrFail(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameNumberedColor.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 import walkingkooka.color.Color;
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.naming.Name;
 import walkingkooka.spreadsheet.color.SpreadsheetColors;
@@ -103,7 +104,7 @@ final class SpreadsheetMetadataPropertyNameNumberedColor extends SpreadsheetMeta
 
     @Override
     Color parseUrlFragmentSaveValueNonNull(final String value,
-                                           final CurrencyLocaleContext context) {
+                                           final CurrencyCodeLanguageTagContext context) {
         return Color.parse(value);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePluginNameSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNamePluginNameSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.plugin.PluginNameSet;
 
@@ -68,7 +69,7 @@ final class SpreadsheetMetadataPropertyNamePluginNameSet extends SpreadsheetMeta
 
     @Override
     PluginNameSet parseUrlFragmentSaveValueNonNull(final String text,
-                                                   final CurrencyLocaleContext context) {
+                                                   final CurrencyCodeLanguageTagContext context) {
         return PluginNameSet.parse(text);
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameRoundingMode.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.math.RoundingMode;
@@ -69,7 +70,7 @@ final class SpreadsheetMetadataPropertyNameRoundingMode extends SpreadsheetMetad
 
     @Override
     RoundingMode parseUrlFragmentSaveValueNonNull(final String value,
-                                                  final CurrencyLocaleContext context) {
+                                                  final CurrencyCodeLanguageTagContext context) {
         return RoundingMode.valueOf(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSortComparators.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorNameList;
 
@@ -75,7 +76,7 @@ final class SpreadsheetMetadataPropertyNameSortComparators extends SpreadsheetMe
 
     @Override
     SpreadsheetComparatorNameList parseUrlFragmentSaveValueNonNull(final String value,
-                                                                   final CurrencyLocaleContext context) {
+                                                                   final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetComparatorNameList.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorAliasSet;
 
@@ -60,7 +61,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetComparatorAliasSet exte
 
     @Override //
     final SpreadsheetComparatorAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                         final CurrencyLocaleContext context) {
+                                                                         final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetComparatorAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.export.provider.SpreadsheetExporterAliasSet;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetExporterAliasSet extend
 
     @Override //
     final SpreadsheetExporterAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                       final CurrencyLocaleContext context) {
+                                                                       final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetExporterAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.format.provider.SpreadsheetFormatterAliasSet;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetFormatterAliasSet exten
 
     @Override //
     final SpreadsheetFormatterAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                        final CurrencyLocaleContext context) {
+                                                                        final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetFormatterAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.locale.LocaleContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetFormatPattern;
@@ -75,7 +76,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelector exten
 
     @Override //
     final SpreadsheetFormatterSelector parseUrlFragmentSaveValueNonNull(final String value,
-                                                                        final CurrencyLocaleContext context) {
+                                                                        final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetFormatterSelector.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetId.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -69,7 +70,7 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetId extends SpreadsheetMeta
 
     @Override
     SpreadsheetId parseUrlFragmentSaveValueNonNull(final String value,
-                                                   final CurrencyLocaleContext context) {
+                                                   final CurrencyCodeLanguageTagContext context) {
         return this.failParseUrlFragmentSaveValueUnsupported();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.importer.provider.SpreadsheetImporterAliasSet;
 
@@ -60,7 +61,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetImporterAliasSet extend
 
     @Override //
     final SpreadsheetImporterAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                       final CurrencyLocaleContext context) {
+                                                                       final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetImporterAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetName.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.util.Optional;
@@ -69,7 +70,7 @@ final class SpreadsheetMetadataPropertyNameSpreadsheetName extends SpreadsheetMe
 
     @Override
     SpreadsheetName parseUrlFragmentSaveValueNonNull(final String value,
-                                                     final CurrencyLocaleContext context) {
+                                                     final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetName.with(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.parser.provider.SpreadsheetParserAliasSet;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetParserAliasSet extends 
 
     @Override //
     final SpreadsheetParserAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                     final CurrencyLocaleContext context) {
+                                                                     final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetParserAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserSelector.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserSelector.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetParsePattern;
 import walkingkooka.spreadsheet.format.pattern.SpreadsheetPatternKind;
@@ -77,7 +78,7 @@ abstract class SpreadsheetMetadataPropertyNameSpreadsheetParserSelector extends 
 
     @Override //
     final SpreadsheetParserSelector parseUrlFragmentSaveValueNonNull(final String value,
-                                                                     final CurrencyLocaleContext context) {
+                                                                     final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetParserSelector.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameString.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 
 import java.text.DecimalFormatSymbols;
@@ -66,7 +67,7 @@ abstract class SpreadsheetMetadataPropertyNameString extends SpreadsheetMetadata
 
     @Override //
     final String parseUrlFragmentSaveValueNonNull(final String value,
-                                                  final CurrencyLocaleContext context) {
+                                                  final CurrencyCodeLanguageTagContext context) {
         return value;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameStyle.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.tree.text.TextStyle;
 
@@ -71,7 +72,7 @@ final class SpreadsheetMetadataPropertyNameStyle extends SpreadsheetMetadataProp
 
     @Override
     TextStyle parseUrlFragmentSaveValueNonNull(final String value,
-                                               final CurrencyLocaleContext context) {
+                                               final CurrencyCodeLanguageTagContext context) {
         return this.failParseUrlFragmentSaveValueUnsupported();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameValidatorAliasSet.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameValidatorAliasSet.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.meta;
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.validation.provider.ValidatorAliasSet;
 
@@ -59,7 +60,7 @@ abstract class SpreadsheetMetadataPropertyNameValidatorAliasSet extends Spreadsh
 
     @Override
     public final ValidatorAliasSet parseUrlFragmentSaveValueNonNull(final String value,
-                                                                    final CurrencyLocaleContext context) {
+                                                                    final CurrencyCodeLanguageTagContext context) {
         return ValidatorAliasSet.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportHome.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportHome.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -77,7 +78,7 @@ final class SpreadsheetMetadataPropertyNameViewportHome extends SpreadsheetMetad
 
     @Override
     SpreadsheetCellReference parseUrlFragmentSaveValueNonNull(final String value,
-                                                              final CurrencyLocaleContext context) {
+                                                              final CurrencyCodeLanguageTagContext context) {
         return SpreadsheetSelection.parseCell(value);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportSelection.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameViewportSelection.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.meta;
 
 
+import walkingkooka.currency.CurrencyCodeLanguageTagContext;
 import walkingkooka.currency.CurrencyLocaleContext;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 
@@ -75,7 +76,7 @@ final class SpreadsheetMetadataPropertyNameViewportSelection extends Spreadsheet
 
     @Override
     AnchoredSpreadsheetSelection parseUrlFragmentSaveValueNonNull(final String value,
-                                                                  final CurrencyLocaleContext context) {
+                                                                  final CurrencyCodeLanguageTagContext context) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
…eLanguageTagContext was CurrencyLocaleContext

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/8889
- SpreadsheetMetadataPropertyName.parseUrlFragmentSaveValue CurrencyCodeLanguageTagContext replace CurrencyLocaleContext