### PR TITLE
SpreadsheetMetadata.fromProperties CurrencyCodeLanguageTagContext rep…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1842,9 +1842,9 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
     // fromProperties...................................................................................................
 
     public static SpreadsheetMetadata fromProperties(final Properties properties,
-                                                     final CurrencyLocaleContext currencyLocaleContext) {
+                                                     final CurrencyCodeLanguageTagContext context) {
         Objects.requireNonNull(properties, "properties");
-        Objects.requireNonNull(currencyLocaleContext, "currencyLocaleContext");
+        Objects.requireNonNull(context, "context");
 
         SpreadsheetMetadata metadata = EMPTY;
 
@@ -1866,7 +1866,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                 Cast.to(
                     name.parseUrlFragmentSaveValue(
                         nameAndValue.getValue(),
-                        currencyLocaleContext
+                        context
                     )
                 )
             );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -1713,7 +1713,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     }
 
     @Test
-    public void testFromPropertiesWithNullCurrencyLocaleContextFails() {
+    public void testFromPropertiesWithNullContextFails() {
         assertThrows(
             NullPointerException.class,
             () -> SpreadsheetMetadata.fromProperties(
@@ -1886,7 +1886,7 @@ public final class SpreadsheetMetadataTest implements ClassTesting2<SpreadsheetM
     }
 
     private void fromPropertiesAndCheck(final Properties properties,
-                                        final CurrencyLocaleContext context,
+                                        final CurrencyCodeLanguageTagContext context,
                                         final SpreadsheetMetadata expected) {
         this.checkEquals(
             expected,


### PR DESCRIPTION
…lace CurrencyLocaleContext

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/8888
- SpreadsheetMetadata.fromProperties CurrencyCodeLanguageTagContext replace CurrencyLocaleContext