### PR TITLE
SpreadsheetViewportNavigationContext extends SpreadsheetLabelNameReso…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -2479,6 +2479,7 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         return this.navigateNonLabelSelection0(
             viewport,
             SpreadsheetViewportNavigationContexts.basic(
+                context, // SpreadsheetLabelNameResolver
                 repository.columns()::isHidden,
                 (c) -> this.columnWidth(c, context),
                 repository.rows()::isHidden,

--- a/src/main/java/walkingkooka/spreadsheet/viewport/BasicSpreadsheetViewportNavigationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/BasicSpreadsheetViewportNavigationContext.java
@@ -18,6 +18,8 @@
 package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
@@ -28,12 +30,14 @@ import java.util.function.Predicate;
 
 final class BasicSpreadsheetViewportNavigationContext implements SpreadsheetViewportNavigationContext {
 
-    static BasicSpreadsheetViewportNavigationContext with(final Predicate<SpreadsheetColumnReference> columnHidden,
+    static BasicSpreadsheetViewportNavigationContext with(final SpreadsheetLabelNameResolver labelNameResolver,
+                                                          final Predicate<SpreadsheetColumnReference> columnHidden,
                                                           final Function<SpreadsheetColumnReference, Double> columnWidths,
                                                           final Predicate<SpreadsheetRowReference> rowHidden,
                                                           final Function<SpreadsheetRowReference, Double> rowHeights,
                                                           final Function<SpreadsheetViewport, SpreadsheetViewportWindows> windows) {
         return new BasicSpreadsheetViewportNavigationContext(
+            Objects.requireNonNull(labelNameResolver, "labelNameResolver"),
             Objects.requireNonNull(columnHidden, "columnHidden"),
             Objects.requireNonNull(columnWidths, "columnWidths"),
             Objects.requireNonNull(rowHidden, "rowHidden"),
@@ -42,17 +46,26 @@ final class BasicSpreadsheetViewportNavigationContext implements SpreadsheetView
         );
     }
 
-    private BasicSpreadsheetViewportNavigationContext(final Predicate<SpreadsheetColumnReference> columnHidden,
+    private BasicSpreadsheetViewportNavigationContext(final SpreadsheetLabelNameResolver labelNameResolver,
+                                                      final Predicate<SpreadsheetColumnReference> columnHidden,
                                                       final Function<SpreadsheetColumnReference, Double> columnWidths,
                                                       final Predicate<SpreadsheetRowReference> rowHidden,
                                                       final Function<SpreadsheetRowReference, Double> rowHeights,
                                                       final Function<SpreadsheetViewport, SpreadsheetViewportWindows> windows) {
+        this.labelNameResolver = labelNameResolver;
         this.columnHidden = columnHidden;
         this.columnWidths = columnWidths;
         this.rowHidden = rowHidden;
         this.rowHeights = rowHeights;
         this.windows = windows;
     }
+
+    @Override
+    public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName labelName) {
+        return this.labelNameResolver.resolveLabel(labelName);
+    }
+
+    private final SpreadsheetLabelNameResolver labelNameResolver;
 
     @Override
     public boolean isColumnHidden(final SpreadsheetColumnReference column) {
@@ -260,6 +273,6 @@ final class BasicSpreadsheetViewportNavigationContext implements SpreadsheetView
 
     @Override
     public String toString() {
-        return this.columnHidden + " " + this.columnWidths + " " + this.rowHidden + " " + this.rowHeights + " " + this.windows;
+        return this.labelNameResolver + " " + this.columnHidden + " " + this.columnWidths + " " + this.rowHidden + " " + this.rowHeights + " " + this.windows;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/viewport/FakeSpreadsheetViewportNavigationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/FakeSpreadsheetViewportNavigationContext.java
@@ -17,12 +17,19 @@
 
 package walkingkooka.spreadsheet.viewport;
 
+import walkingkooka.spreadsheet.reference.FakeSpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 
 import java.util.Optional;
 
-public class FakeSpreadsheetViewportNavigationContext implements SpreadsheetViewportNavigationContext {
+public class FakeSpreadsheetViewportNavigationContext extends FakeSpreadsheetLabelNameResolver
+    implements SpreadsheetViewportNavigationContext {
+
+    public FakeSpreadsheetViewportNavigationContext() {
+        super();
+    }
+
     @Override
     public boolean isColumnHidden(final SpreadsheetColumnReference column) {
         throw new UnsupportedOperationException();

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContext.java
@@ -19,14 +19,19 @@ package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.Context;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 
 import java.util.Optional;
 
 /**
- * The {@link Context} that accompanies a {@link SpreadsheetViewportNavigation#update(SpreadsheetViewport, SpreadsheetViewportNavigationContext)}
+ * The {@link Context} that accompanies a {@link SpreadsheetViewportNavigation#update(SpreadsheetViewport, SpreadsheetViewportNavigationContext)}.
+ * Note that {@link #resolveLabel(SpreadsheetLabelName)} and similar methods do not test if the matching selection
+ * is hidden.
  */
-public interface SpreadsheetViewportNavigationContext extends Context {
+public interface SpreadsheetViewportNavigationContext extends Context,
+    SpreadsheetLabelNameResolver {
 
     /**
      * Returns true if the {@link SpreadsheetColumnReference} is hidden.

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContextTesting.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.viewport;
 import org.junit.jupiter.api.Test;
 import walkingkooka.spreadsheet.provider.SpreadsheetProviderContextTesting;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolverTesting;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -28,7 +29,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public interface SpreadsheetViewportNavigationContextTesting<C extends SpreadsheetViewportNavigationContext> extends SpreadsheetProviderContextTesting<C> {
+public interface SpreadsheetViewportNavigationContextTesting<C extends SpreadsheetViewportNavigationContext> extends SpreadsheetProviderContextTesting<C>,
+    SpreadsheetLabelNameResolverTesting<C> {
 
     // isColumnHidden..................................................................................................
 
@@ -499,6 +501,11 @@ public interface SpreadsheetViewportNavigationContextTesting<C extends Spreadshe
             ),
             () -> "downPixels " + start + " " + pixels
         );
+    }
+
+    @Override
+    default C createSpreadsheetLabelNameResolver() {
+        return this.createContext();
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationContexts.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 
 import java.util.function.Function;
@@ -29,12 +30,14 @@ public final class SpreadsheetViewportNavigationContexts implements PublicStatic
     /**
      * {@see BasicSpreadsheetViewportNavigationContext}
      */
-    public static SpreadsheetViewportNavigationContext basic(final Predicate<SpreadsheetColumnReference> columnHidden,
+    public static SpreadsheetViewportNavigationContext basic(final SpreadsheetLabelNameResolver labelNameResolver,
+                                                             final Predicate<SpreadsheetColumnReference> columnHidden,
                                                              final Function<SpreadsheetColumnReference, Double> columnWidths,
                                                              final Predicate<SpreadsheetRowReference> rowHidden,
                                                              final Function<SpreadsheetRowReference, Double> rowHeights,
                                                              final Function<SpreadsheetViewport, SpreadsheetViewportWindows> windows) {
         return BasicSpreadsheetViewportNavigationContext.with(
+            labelNameResolver,
             columnHidden,
             columnWidths,
             rowHidden,

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetSelectionTestCase.java
@@ -73,6 +73,8 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
     ToStringTesting<S>,
     TreePrintableTesting {
 
+    private final static SpreadsheetLabelNameResolver SPREADSHEET_LABEL_NAME_RESOLVER = SpreadsheetLabelNameResolvers.fake();
+
     private final static Function<SpreadsheetViewport, SpreadsheetViewportWindows> WINDOWS_FUNCTION = (SpreadsheetViewport v) -> {
         throw new UnsupportedOperationException();
     };
@@ -966,6 +968,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.moveLeftColumn(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1013,6 +1016,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnWidths,
                     hiddenRows,
@@ -1050,6 +1054,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.moveUpRow(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1097,6 +1102,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnWidths,
                     hiddenRows,
@@ -1134,6 +1140,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.moveRightColumn(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1181,6 +1188,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnWidths,
                     hiddenRows,
@@ -1218,6 +1226,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.moveDownRow(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1265,6 +1274,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnWidths,
                     hiddenRows,
@@ -1398,6 +1408,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.extendLeftColumn(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1448,6 +1459,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnToWidths,
                     hiddenRows,
@@ -1489,6 +1501,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.extendUpRow(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1539,6 +1552,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnToWidths,
                     hiddenRows,
@@ -1579,6 +1593,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.extendRightColumn(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1629,6 +1644,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnToWidths,
                     hiddenRows,
@@ -1669,6 +1685,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
             selection.extendDownRow(
                 anchor,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,
@@ -1719,6 +1736,7 @@ public abstract class SpreadsheetSelectionTestCase<S extends SpreadsheetSelectio
                 anchor,
                 count,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     hiddenColumns,
                     columnToWidths,
                     hiddenRows,

--- a/src/test/java/walkingkooka/spreadsheet/viewport/BasicSpreadsheetViewportNavigationContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/BasicSpreadsheetViewportNavigationContextTest.java
@@ -24,6 +24,8 @@ import walkingkooka.predicate.Predicates;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
@@ -40,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public final class BasicSpreadsheetViewportNavigationContextTest implements ClassTesting<BasicSpreadsheetViewportNavigationContext>,
     SpreadsheetViewportNavigationContextTesting<BasicSpreadsheetViewportNavigationContext>,
     ToStringTesting<BasicSpreadsheetViewportNavigationContext> {
+
+    private final static SpreadsheetLabelNameResolver SPREADSHEET_LABEL_NAME_RESOLVER = SpreadsheetLabelNameResolvers.fake();
 
     private final static Function<SpreadsheetColumnReference, Double> COLUMN_TO_WIDTH = (c) -> {
         throw new UnsupportedOperationException();
@@ -59,6 +63,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             NullPointerException.class,
             () -> BasicSpreadsheetViewportNavigationContext
                 .with(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     null,
                     COLUMN_TO_WIDTH,
                     Predicates.fake(),
@@ -74,6 +79,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             NullPointerException.class,
             () -> BasicSpreadsheetViewportNavigationContext
                 .with(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     Predicates.fake(),
                     null,
                     Predicates.fake(),
@@ -88,6 +94,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
         assertThrows(
             NullPointerException.class,
             () -> BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(),
                 COLUMN_TO_WIDTH,
                 null,
@@ -103,6 +110,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             NullPointerException.class,
             () -> BasicSpreadsheetViewportNavigationContext
                 .with(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     Predicates.fake(),
                     COLUMN_TO_WIDTH,
                     Predicates.fake(),
@@ -118,6 +126,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             NullPointerException.class,
             () -> BasicSpreadsheetViewportNavigationContext
                 .with(
+                    SPREADSHEET_LABEL_NAME_RESOLVER,
                     Predicates.fake(),
                     COLUMN_TO_WIDTH,
                     Predicates.fake(),
@@ -132,6 +141,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
         final SpreadsheetColumnReference column = SpreadsheetSelection.parseColumn("B");
 
         final BasicSpreadsheetViewportNavigationContext context = BasicSpreadsheetViewportNavigationContext.with(
+            SPREADSHEET_LABEL_NAME_RESOLVER,
             Predicates.is(column),
             COLUMN_TO_WIDTH,
             Predicates.fake(),
@@ -156,6 +166,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
         final SpreadsheetRowReference row = SpreadsheetSelection.parseRow("123");
 
         final BasicSpreadsheetViewportNavigationContext context = BasicSpreadsheetViewportNavigationContext.with(
+            SPREADSHEET_LABEL_NAME_RESOLVER,
             Predicates.fake(),
             COLUMN_TO_WIDTH,
             Predicates.is(row),
@@ -261,6 +272,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                   final String column) {
         this.moveLeftColumnAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 hiddenColumns(columnHidden),
                 COLUMN_TO_WIDTH,
                 Predicates.fake(),
@@ -276,6 +288,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                   final String expected) {
         this.moveLeftColumnAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 hiddenColumns(columnHidden),
                 COLUMN_TO_WIDTH,
                 Predicates.fake(),
@@ -362,6 +375,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                    final String column) {
         this.moveRightColumnAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 hiddenColumns(columnHidden),
                 COLUMN_TO_WIDTH,
                 Predicates.fake(),
@@ -377,6 +391,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                    final String expected) {
         this.moveRightColumnAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 hiddenColumns(columnHidden),
                 COLUMN_TO_WIDTH,
                 Predicates.fake(),
@@ -473,6 +488,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                 final String row) {
         this.moveUpRowAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(),
                 COLUMN_TO_WIDTH,
                 this.hiddenRows(rowHidden),
@@ -488,6 +504,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                 final String expected) {
         this.moveUpRowAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(),
                 COLUMN_TO_WIDTH,
                 this.hiddenRows(rowHidden),
@@ -574,6 +591,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                  final String row) {
         this.moveDownRowAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(),
                 COLUMN_TO_WIDTH,
                 hiddenRows(rowHidden),
@@ -713,6 +731,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             start,
             pixels,
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 columnsHidden,
                 columnWidths::apply,
                 Predicates.fake(), // rows hidden
@@ -860,6 +879,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             start,
             pixels,
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 columnsHidden,
                 columnWidths::apply,
                 Predicates.fake(), // rows hidden
@@ -999,6 +1019,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             start,
             pixels,
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(), // columns hidden
                 COLUMN_TO_WIDTH,
                 rowsHidden,
@@ -1101,6 +1122,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
                                  final String expected) {
         this.moveDownRowAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(),
                 COLUMN_TO_WIDTH,
                 hiddenRows(rowHidden),
@@ -1162,6 +1184,7 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
             start,
             pixels,
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 Predicates.fake(), // hidden columns
                 COLUMN_TO_WIDTH,
                 rowsHidden,
@@ -1240,19 +1263,21 @@ public final class BasicSpreadsheetViewportNavigationContextTest implements Clas
 
         this.toStringAndCheck(
             BasicSpreadsheetViewportNavigationContext.with(
+                SPREADSHEET_LABEL_NAME_RESOLVER,
                 column,
                 COLUMN_TO_WIDTH,
                 row,
                 ROW_TO_HEIGHT,
                 WINDOWS_FUNCTION
             ),
-            column + " " + COLUMN_TO_WIDTH + " " + row + " " + ROW_TO_HEIGHT + " " + WINDOWS_FUNCTION
+            SPREADSHEET_LABEL_NAME_RESOLVER + " " + column + " " + COLUMN_TO_WIDTH + " " + row + " " + ROW_TO_HEIGHT + " " + WINDOWS_FUNCTION
         );
     }
 
     @Override
     public BasicSpreadsheetViewportNavigationContext createContext() {
         return BasicSpreadsheetViewportNavigationContext.with(
+            SPREADSHEET_LABEL_NAME_RESOLVER,
             Predicates.fake(),
             COLUMN_TO_WIDTH,
             Predicates.fake(),

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationTestCase2.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.set.Sets;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.test.ParseStringTesting;
@@ -222,6 +223,7 @@ public abstract class SpreadsheetViewportNavigationTestCase2<T extends Spreadshe
             navigation.update(
                 viewport,
                 SpreadsheetViewportNavigationContexts.basic(
+                    SpreadsheetLabelNameResolvers.fake(),
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,


### PR DESCRIPTION
…lver

- First step to changes to support lazy SpreadsheetLabelName resolving in BasicSpreadsheetEngine.navigate