### PR TITLE
SpreadsheetEngine.navigate lazy resolveLabel

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -2420,25 +2420,15 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
 
         Optional<SpreadsheetViewport> result;
 
-        SpreadsheetViewport notLabelViewport = viewport;
-
         final Optional<AnchoredSpreadsheetSelection> maybeAnchored = viewport.anchoredSelection();
         if (maybeAnchored.isPresent()) {
             final AnchoredSpreadsheetSelection anchoredBefore = maybeAnchored.get();
             final SpreadsheetSelection selection = anchoredBefore.selection();
 
+            // special case for label selections. Try restore label if after navigation the selection is equivalent to label
             if (selection.isLabelName()) {
-                final SpreadsheetSelection selectionNotLabel = context.resolveLabelOrFail(selection.toLabelName());
-                notLabelViewport = notLabelViewport.setAnchoredSelection(
-                    Optional.of(
-                        selectionNotLabel.setAnchor(
-                            anchoredBefore.anchor()
-                        )
-                    )
-                );
-
-                result = this.navigateNonLabelSelection(
-                    notLabelViewport,
+                result = this.navigate0(
+                    viewport,
                     context
                 );
 
@@ -2448,7 +2438,11 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                     if (resultMaybeAnchored.isPresent()) {
                         final AnchoredSpreadsheetSelection resultAnchored = resultMaybeAnchored.get();
                         final SpreadsheetSelection resultSelection = resultAnchored.selection();
-                        if (resultSelection.equalsIgnoreReferenceKind(selectionNotLabel)) {
+
+                        if (resultSelection.equalsIgnoreReferenceKind(
+                            context.resolveIfLabel(selection)
+                                .orElse(null)
+                        )) {
                             result = Optional.of(
                                 // restore the original label
                                 viewportResult.setAnchoredSelection(maybeAnchored)
@@ -2457,14 +2451,14 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                     }
                 }
             } else {
-                result = this.navigateNonLabelSelection(
-                    notLabelViewport,
+                result = this.navigate0(
+                    viewport,
                     context
                 );
             }
         } else {
-            result = this.navigateNonLabelSelection(
-                notLabelViewport,
+            result = this.navigate0(
+                viewport,
                 context
             );
         }
@@ -2472,11 +2466,11 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         return result;
     }
 
-    private Optional<SpreadsheetViewport> navigateNonLabelSelection(final SpreadsheetViewport viewport,
-                                                                    final SpreadsheetEngineContext context) {
+    private Optional<SpreadsheetViewport> navigate0(final SpreadsheetViewport viewport,
+                                                    final SpreadsheetEngineContext context) {
         final SpreadsheetStoreRepository repository = context.storeRepository();
 
-        return this.navigateNonLabelSelection0(
+        return this.navigate1(
             viewport,
             SpreadsheetViewportNavigationContexts.basic(
                 context, // SpreadsheetLabelNameResolver
@@ -2495,8 +2489,8 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
         );
     }
 
-    private Optional<SpreadsheetViewport> navigateNonLabelSelection0(final SpreadsheetViewport viewport,
-                                                                     final SpreadsheetViewportNavigationContext context) {
+    private Optional<SpreadsheetViewport> navigate1(final SpreadsheetViewport viewport,
+                                                    final SpreadsheetViewportNavigationContext context) {
         final List<SpreadsheetViewportNavigation> navigations = viewport.navigations()
             .compact();
 
@@ -2516,8 +2510,11 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
             final AnchoredSpreadsheetSelection anchored = navigating.anchoredSelection()
                 .orElse(null);
             if (null != anchored) {
-                final SpreadsheetSelection selection = anchored.selection();
-                if (selection.isHidden(context::isColumnHidden, context::isRowHidden)) {
+                final SpreadsheetSelection selectionNotLabel = context.resolveIfLabel(
+                    anchored.selection()
+                ).orElse(null);
+
+                if (null == selectionNotLabel || selectionNotLabel.isHidden(context::isColumnHidden, context::isRowHidden)) {
                     // selection is hidden clear it.
                     navigating = navigating.clearAnchoredSelection();
                 }

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigation.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigation.java
@@ -191,6 +191,8 @@ public abstract class SpreadsheetViewportNavigation implements HasText {
 
     /**
      * Executes this navigation on the given selection and anchor returning the updated result.
+     * If the current selection is an unknown {@link walkingkooka.spreadsheet.reference.SpreadsheetLabelName},
+     * new selects will ignore, while extends will fail because how can it extend an unknown cell ?
      */
     public final SpreadsheetViewport update(final SpreadsheetViewport viewport,
                                             final SpreadsheetViewportNavigationContext context) {

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationColumnOrRow.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
 
@@ -39,21 +40,29 @@ abstract class SpreadsheetViewportNavigationColumnOrRow extends SpreadsheetViewp
         if (maybeAnchored.isPresent()) {
             // selection present try and move it.
             final AnchoredSpreadsheetSelection anchoredSelection = maybeAnchored.get();
-            final Optional<AnchoredSpreadsheetSelection> maybeMovedSelection = this.updateSelection(
-                anchoredSelection.selection(),
-                anchoredSelection.anchor(),
-                context
-            );
+            final SpreadsheetSelection selectionOrNull = context.resolveIfLabel(
+                anchoredSelection.selection()
+            ).orElse(null);
 
-            if (maybeMovedSelection.isPresent()) {
-                final AnchoredSpreadsheetSelection movedSelection = maybeMovedSelection.get();
-                result = updateViewport(
-                    movedSelection,
-                    viewport,
+            if(null == selectionOrNull) {
+                result = viewport.clearAnchoredSelection();
+            } else {
+                final Optional<AnchoredSpreadsheetSelection> maybeMovedSelection = this.updateSelection(
+                    selectionOrNull,
+                    anchoredSelection.anchor(),
                     context
                 );
-            } else {
-                result = viewport.clearAnchoredSelection();
+
+                if (maybeMovedSelection.isPresent()) {
+                    final AnchoredSpreadsheetSelection movedSelection = maybeMovedSelection.get();
+                    result = updateViewport(
+                        movedSelection,
+                        viewport,
+                        context
+                    );
+                } else {
+                    result = viewport.clearAnchoredSelection();
+                }
             }
         }
 

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScroll.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScroll.java
@@ -18,6 +18,7 @@
 package walkingkooka.spreadsheet.viewport;
 
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 
 import java.util.Optional;
 
@@ -48,7 +49,7 @@ abstract class SpreadsheetViewportNavigationScroll extends SpreadsheetViewportNa
 
     // update...........................................................................................................
 
-    @Override
+    @Override //
     final SpreadsheetViewport update0(final SpreadsheetViewport viewport,
                                       final SpreadsheetViewportNavigationContext context) {
         SpreadsheetViewport result = viewport;
@@ -69,15 +70,32 @@ abstract class SpreadsheetViewportNavigationScroll extends SpreadsheetViewportNa
 
             result = result.setRectangle(movedRectangle);
 
-            final Optional<AnchoredSpreadsheetSelection> maybeAnchoredSelection = viewport.anchoredSelection();
-            if (maybeAnchoredSelection.isPresent()) {
-                result = result.setAnchoredSelection(
-                    updateViewportSelection(
-                        maybeAnchoredSelection.get(),
+            final AnchoredSpreadsheetSelection anchoredSelectionOrNull = viewport.anchoredSelection()
+                .orElse(null);
+            if (null != anchoredSelectionOrNull) {
+                final SpreadsheetSelection selection = anchoredSelectionOrNull.selection();
+                final SpreadsheetSelection notLabelSelectionOrNull = context.resolveIfLabel(selection)
+                    .orElse(null);
+
+                if (null != notLabelSelectionOrNull) {
+                    Optional<AnchoredSpreadsheetSelection> updatedSelection = this.updateViewportSelection(
+                        notLabelSelectionOrNull.setAnchorOrDefault(
+                            anchoredSelectionOrNull.anchor()
+                        ),
                         rectangle,
                         context
-                    )
-                );
+                    );
+                    // selection might not have moved, restore label if it was originally a label
+                    if (false == notLabelSelectionOrNull.equalsIgnoreReferenceKind(
+                        updatedSelection.map(AnchoredSpreadsheetSelection::selection)
+                            .orElse(null))
+                    ) {
+                        result = result.setAnchoredSelection(updatedSelection);
+                    }
+
+                } else {
+                    result = result.clearAnchoredSelection();
+                }
             }
 
         } else {

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtend.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtend.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.spreadsheet.viewport;
 
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+
 import java.util.Optional;
 
 abstract class SpreadsheetViewportNavigationScrollExtend extends SpreadsheetViewportNavigationScroll {
@@ -29,11 +31,18 @@ abstract class SpreadsheetViewportNavigationScrollExtend extends SpreadsheetView
     final Optional<AnchoredSpreadsheetSelection> updateViewportSelection(final AnchoredSpreadsheetSelection anchoredSelection,
                                                                          final SpreadsheetViewportRectangle rectangle,
                                                                          final SpreadsheetViewportNavigationContext context) {
-        return this.updateSelection(
-            anchoredSelection.selection(),
-            anchoredSelection.anchor(),
-            context
-        );
+        final SpreadsheetSelection selectionOrNull = context.resolveIfLabel(
+            anchoredSelection.selection()
+        ).orElse(null);
+
+        // if selection is an unknown label, clear the selection and ignore the extend.
+        return null == selectionOrNull ?
+            Optional.empty() :
+            this.updateSelection(
+                selectionOrNull,
+                anchoredSelection.anchor(),
+                context
+            );
     }
 
     // text.............................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtend.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtend.java
@@ -64,6 +64,8 @@ abstract class SpreadsheetViewportNavigationSelectionExtend<T extends Spreadshee
                         viewport,
                         context
                     );
+                } else {
+                    result = viewport.clearAnchoredSelection();
                 }
             } else {
                 result = this.updateViewport(

--- a/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtendCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtendCell.java
@@ -46,15 +46,20 @@ final class SpreadsheetViewportNavigationSelectionExtendCell extends Spreadsheet
     Optional<AnchoredSpreadsheetSelection> updateSelection(final SpreadsheetSelection selection,
                                                            final SpreadsheetViewportAnchor anchor,
                                                            final SpreadsheetViewportNavigationContext context) {
-        return selection.isCell() ||
-            selection.isCellRange() ?
-            this.updateCellOrCellRange(
-                selection,
-                anchor
-            ) :
-            Optional.of(
-                this.selection.setDefaultAnchor()
-            );
+        // selection could a label, if the label is unknown extending will fail.
+        final SpreadsheetSelection notLabelSelection = context.resolveIfLabel(selection)
+            .orElse(null);
+
+        return null == notLabelSelection ?
+            Optional.empty() :
+            notLabelSelection.isCellOrCellRange() ?
+                this.updateCellOrCellRange(
+                    notLabelSelection,
+                    anchor
+                ) :
+                Optional.of(
+                    this.selection.setDefaultAnchor()
+                );
     }
 
     private Optional<AnchoredSpreadsheetSelection> updateCellOrCellRange(final SpreadsheetSelection selection,

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendDownTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendDownTest.java
@@ -68,6 +68,46 @@ public final class SpreadsheetViewportNavigationScrollExtendDownTest extends Spr
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        LABEL_C3.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.parseCellRange("C3:C5")
+                            .setAnchor(SpreadsheetViewportAnchor.TOP_LEFT)
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         this.updateAndCheck(
             SpreadsheetSelection.parseCell("C3")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendLeftTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendLeftTest.java
@@ -68,6 +68,47 @@ public final class SpreadsheetViewportNavigationScrollExtendLeftTest extends Spr
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.labelName("LabelE5")
+                            .setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.parseCellRange("C5:E5")
+                            .setAnchor(SpreadsheetViewportAnchor.BOTTOM_RIGHT)
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         this.updateAndCheck(
             SpreadsheetSelection.parseCell("E5")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendRightTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendRightTest.java
@@ -68,6 +68,46 @@ public final class SpreadsheetViewportNavigationScrollExtendRightTest extends Sp
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        LABEL_C3.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.parseCellRange("C3:E3")
+                            .setAnchor(SpreadsheetViewportAnchor.TOP_LEFT)
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         this.updateAndCheck(
             SpreadsheetSelection.parseCell("C3")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendUpTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollExtendUpTest.java
@@ -68,6 +68,47 @@ public final class SpreadsheetViewportNavigationScrollExtendUpTest extends Sprea
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.labelName("LabelE5")
+                            .setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        SpreadsheetSelection.parseCellRange("E3:E5")
+                            .setAnchor(SpreadsheetViewportAnchor.BOTTOM_RIGHT)
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         this.updateAndCheck(
             SpreadsheetSelection.parseCell("E5")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveDownTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveDownTest.java
@@ -60,6 +60,41 @@ public final class SpreadsheetViewportNavigationScrollMoveDownTest extends Sprea
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
+            LABEL_C3.setDefaultAnchor()
+        );
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection)
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .clearAnchoredSelection()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
             SpreadsheetSelection.parseColumn("C")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveLeftTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveLeftTest.java
@@ -62,6 +62,42 @@ public final class SpreadsheetViewportNavigationScrollMoveLeftTest extends Sprea
     }
 
     @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithLabel() {
+        final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
+            SpreadsheetSelection.labelName("LabelE5")
+                .setDefaultAnchor()
+        );
+
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection),
+            SpreadsheetSelection.parseCell("C5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection)
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
             SpreadsheetSelection.parseColumn("E")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveRightTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveRightTest.java
@@ -61,6 +61,40 @@ public final class SpreadsheetViewportNavigationScrollMoveRightTest extends Spre
     }
 
     @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithLabel() {
+        final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
+            LABEL_C3.setDefaultAnchor()
+        );
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("C3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection)
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
             SpreadsheetSelection.parseColumn("C")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveUpTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationScrollMoveUpTest.java
@@ -60,6 +60,42 @@ public final class SpreadsheetViewportNavigationScrollMoveUpTest extends Spreads
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
+            SpreadsheetSelection.labelName("LabelE5")
+                .setDefaultAnchor()
+        );
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(selection)
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        this.updateAndCheck(
+            SpreadsheetSelection.parseCell("E5")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .setAnchoredSelection(
+                    Optional.of(
+                        UNKNOWN_LABEL.setDefaultAnchor()
+                    )
+                ),
+            SpreadsheetSelection.parseCell("E3")
+                .viewportRectangle(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+                .viewport()
+                .clearAnchoredSelection()
+        );
+    }
+
+    @Test
     public void testUpdateColumn() {
         final Optional<AnchoredSpreadsheetSelection> selection = Optional.of(
             SpreadsheetSelection.parseColumn("E")

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtendCellTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionExtendCellTest.java
@@ -62,6 +62,19 @@ public final class SpreadsheetViewportNavigationSelectionExtendCellTest extends 
         );
     }
 
+    @Test
+    public void testUpdateCellUnknownLabel() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("C3");
+
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation(cell),
+            Optional.of(
+                UNKNOWN_LABEL.setDefaultAnchor()
+            ),
+            Optional.empty() // expected
+        );
+    }
+
     // cell.............................................................................................................
 
     @Test
@@ -133,6 +146,62 @@ public final class SpreadsheetViewportNavigationSelectionExtendCellTest extends 
                 .setDefaultAnchor(),
             SpreadsheetSelection.parseCellRange(expectedCellRange)
                 .setAnchor(expectedAnchor)
+        );
+    }
+
+    @Test
+    public void testUpdateCellWhenLabelWhenTopLeft() {
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation("D4"),
+            Optional.of(
+                LABEL_C3.setDefaultAnchor()
+            ), // selection
+            Optional.of(
+                SpreadsheetSelection.parseCellRange("C3:D4")
+                    .setAnchor(SpreadsheetViewportAnchor.TOP_LEFT)
+            ) // expected selection
+        );
+    }
+
+    @Test
+    public void testUpdateCellWhenLabelWhenTopRight() {
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation("B4"),
+            Optional.of(
+                LABEL_C3.setDefaultAnchor()
+            ), // selection
+            Optional.of(
+                SpreadsheetSelection.parseCellRange("B3:C4")
+                    .setAnchor(SpreadsheetViewportAnchor.TOP_RIGHT)
+            ) // expected selection
+        );
+    }
+
+    @Test
+    public void testUpdateCellWhenLabelWhenBottomLeft() {
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation("D2"),
+            Optional.of(
+                LABEL_C3.setDefaultAnchor()
+            ), // selection
+            Optional.of(
+                SpreadsheetSelection.parseCellRange("C2:D3")
+                    .setAnchor(SpreadsheetViewportAnchor.BOTTOM_LEFT)
+            ) // expected selection
+        );
+    }
+
+    @Test
+    public void testUpdateCellWhenLabelWhenBottomRight() {
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation("B2"),
+            Optional.of(
+                LABEL_C3.setDefaultAnchor()
+            ), // selection
+            Optional.of(
+                SpreadsheetSelection.parseCellRange("B2:C3")
+                    .setAnchor(SpreadsheetViewportAnchor.BOTTOM_RIGHT)
+            ) // expected selection
         );
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionSelectCellTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationSelectionSelectCellTest.java
@@ -58,6 +58,28 @@ public final class SpreadsheetViewportNavigationSelectionSelectCellTest extends 
     }
 
     @Test
+    public void testUpdateCellWithLabel() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("C3");
+
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation(cell),
+            LABEL_C3.setDefaultAnchor(),
+            cell.setDefaultAnchor()
+        );
+    }
+
+    @Test
+    public void testUpdateCellWithUnknownLabel() {
+        final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("C3");
+
+        this.updateAndCheck(
+            this.createSpreadsheetViewportNavigation(cell),
+            UNKNOWN_LABEL.setDefaultAnchor(),
+            cell.setDefaultAnchor()
+        );
+    }
+
+    @Test
     public void testUpdateCellMovesHome() {
         final SpreadsheetCellReference cell = SpreadsheetSelection.parseCell("Z99");
 

--- a/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/viewport/SpreadsheetViewportNavigationTestCase2.java
@@ -22,9 +22,11 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.predicate.Predicates;
+import walkingkooka.spreadsheet.reference.FakeSpreadsheetLabelNameResolver;
+import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
-import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
+import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.reference.SpreadsheetRowReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.test.ParseStringTesting;
@@ -41,6 +43,16 @@ public abstract class SpreadsheetViewportNavigationTestCase2<T extends Spreadshe
     SpreadsheetViewportNavigationTestCase<T> implements ParseStringTesting<List<T>>,
     HasTextTesting,
     TreePrintableTesting {
+
+    final static SpreadsheetLabelName UNKNOWN_LABEL = SpreadsheetSelection.labelName("UnknownLabel404");
+
+    final static SpreadsheetLabelName LABEL_C3 = SpreadsheetSelection.labelName("LabelC3");
+    
+    final static SpreadsheetCellReference LABEL_C3_SELECTION = SpreadsheetSelection.parseCell("C3");
+
+    final static SpreadsheetLabelName LABEL_C3D4 = SpreadsheetSelection.labelName("LabelC3D4");
+
+    final static SpreadsheetCellRangeReference LABEL_C3D4_SELECTION = SpreadsheetSelection.parseCellRange("C3:D4");
 
     SpreadsheetViewportNavigationTestCase2() {
         super();
@@ -145,6 +157,15 @@ public abstract class SpreadsheetViewportNavigationTestCase2<T extends Spreadshe
         );
     }
 
+    final void updateAndCheck(final SpreadsheetViewportNavigation navigation,
+                              final AnchoredSpreadsheetSelection selection) {
+        this.updateAndCheck(
+            navigation,
+            Optional.of(selection),
+            Optional.empty()
+        );
+    }
+
     final void updateAndCheck(final Optional<AnchoredSpreadsheetSelection> anchoredSelection,
                               final Optional<AnchoredSpreadsheetSelection> expected) {
         this.updateAndCheck(
@@ -223,7 +244,33 @@ public abstract class SpreadsheetViewportNavigationTestCase2<T extends Spreadshe
             navigation.update(
                 viewport,
                 SpreadsheetViewportNavigationContexts.basic(
-                    SpreadsheetLabelNameResolvers.fake(),
+                    new FakeSpreadsheetLabelNameResolver() {
+
+                        @Override
+                        public Optional<SpreadsheetSelection> resolveLabel(final SpreadsheetLabelName labelName) {
+                            SpreadsheetSelection notLabel;
+
+                            if (UNKNOWN_LABEL.equals(labelName)) {
+                                notLabel = null;
+                            } else {
+                                final String labelNameString = labelName.value();
+
+                                // the cell or cell range appears after the "Label" prefix
+                                final String labelPrefix = "Label";
+                                if (labelNameString.startsWith(labelPrefix)) {
+                                    notLabel = SpreadsheetSelection.parseCellOrCellRange(
+                                        labelNameString.substring(
+                                            labelPrefix.length()
+                                        )
+                                    );
+                                } else {
+                                    throw new UnsupportedOperationException("Unknown label " + labelName);
+                                }
+                            }
+
+                            return Optional.ofNullable(notLabel);
+                        }
+                    },
                     hiddenColumns,
                     COLUMN_TO_WIDTH,
                     hiddenRows,


### PR DESCRIPTION
- Sometimes if the current selection when an unknown label, it is not important such as a new selection. However for extends the navigation will fail and the selection will be cleared.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9013
- SpreadsheetEngine.navigate shouldnt fail if selection is unknown label.