### PR TITLE
SpreadsheetConverters.number String to Number gives ExpressionNumber FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet.convert;
 
+import walkingkooka.Cast;
 import walkingkooka.Either;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
@@ -27,6 +28,7 @@ import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserContexts;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.Parsers;
+import walkingkooka.tree.expression.ExpressionNumber;
 
 import java.math.BigDecimal;
 import java.util.function.BiFunction;
@@ -79,9 +81,12 @@ final class SpreadsheetConverterToNumberSpreadsheetValueVisitorStringConverter e
         final Either<T, String> result;
 
         if(parsed.isLeft()) {
+            // if type is Number actually want ExpressionNumber
             result = context.convert(
                 parsed.leftValue(),
-                type
+                Number.class == type ?
+                    Cast.to(ExpressionNumber.class) :
+                    type
             );
 
         } else {

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterToNumberTest.java
@@ -561,14 +561,12 @@ public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverter
         );
     }
 
-    // TODO https://github.com/mP1/walkingkooka-spreadsheet/issues/9042
-    // SpreadsheetConverters.number String to Number should give ExpressionNumber not BigDecimal
     @Test
     public void testConvertStringToNumber() {
         this.convertAndCheck(
             STRING_HALF,
             Number.class,
-            new BigDecimal(BYTE_STRING_HALF)
+            EXPRESSION_NUMBER_KIND.create(BYTE_STRING_HALF)
         );
     }
 
@@ -623,8 +621,8 @@ public final class SpreadsheetConverterToNumberTest extends SpreadsheetConverter
 
             private final Converter<SpreadsheetConverterContext> converter = SpreadsheetConverters.collection(
                 Lists.of(
-                SpreadsheetConverters.text(),
-                SpreadsheetConverters.numberToNumber()
+                    SpreadsheetConverters.text(),
+                    SpreadsheetConverters.numberToNumber()
                 )
             );
 

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
@@ -1734,14 +1734,12 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
         );
     }
 
-    // TODO https://github.com/mP1/walkingkooka-spreadsheet/issues/9042
-    // SpreadsheetConverters.number String to Number should give ExpressionNumber not BigDecimal
     @Test
     public void testNumberConvertStringToNumber() {
         this.numberConvertAndCheck(
             "123.5",
             Number.class,
-            BigDecimal.valueOf(123.5)
+            EXPRESSION_NUMBER_KIND.create(123.5)
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9042
- SpreadsheetConverters.number String to Number should give ExpressionNumber not BigDecimal