### PR TITLE
BasicSpreadsheetConverterContext multiplier replaces hardcoded

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContext.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet.convert;
 import walkingkooka.Either;
 import walkingkooka.ToStringBuilder;
 import walkingkooka.UsesToStringBuilder;
+import walkingkooka.convert.BinaryNumberConverterFunction;
 import walkingkooka.convert.Converter;
 import walkingkooka.datetime.DateTimeSymbols;
 import walkingkooka.locale.LocaleContext;
@@ -32,7 +33,6 @@ import walkingkooka.spreadsheet.validation.SpreadsheetValidationReference;
 import walkingkooka.storage.HasUserDirectories;
 import walkingkooka.storage.HasUserDirectoriesDelegator;
 import walkingkooka.storage.StoragePath;
-import walkingkooka.tree.expression.convert.ExpressionNumberBinaryNumberConverterFunctions;
 import walkingkooka.tree.json.convert.JsonNodeConverterContext;
 import walkingkooka.tree.json.convert.JsonNodeConverterContextDelegator;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContextObjectPostProcessor;
@@ -51,6 +51,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
                                                  final Optional<SpreadsheetMetadata> spreadsheetMetadata,
                                                  final Optional<SpreadsheetValidationReference > validationReference,
                                                  final Converter<SpreadsheetConverterContext> converter,
+                                                 final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                  final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                                  final JsonNodeConverterContext jsonNodeConverterContext,
                                                  final LocaleContext localeContext) {
@@ -58,6 +59,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
         Objects.requireNonNull(spreadsheetMetadata, "spreadsheetMetadata");
         Objects.requireNonNull(validationReference, "validationReference");
         Objects.requireNonNull(converter, "converter");
+        Objects.requireNonNull(multiplier, "multiplier");
         Objects.requireNonNull(spreadsheetLabelNameResolver, "spreadsheetLabelNameResolver");
         Objects.requireNonNull(jsonNodeConverterContext, "jsonNodeConverterContext");
         Objects.requireNonNull(localeContext, "localeContext");
@@ -67,6 +69,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
             spreadsheetMetadata,
             validationReference,
             converter,
+            multiplier,
             spreadsheetLabelNameResolver,
             jsonNodeConverterContext,
             localeContext
@@ -77,6 +80,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
                                              final Optional<SpreadsheetMetadata> spreadsheetMetadata,
                                              final Optional<SpreadsheetValidationReference > validationReference,
                                              final Converter<SpreadsheetConverterContext> converter,
+                                             final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                              final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                              final JsonNodeConverterContext jsonNodeConverterContext,
                                              final LocaleContext localeContext) {
@@ -84,6 +88,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
         this.spreadsheetMetadata = spreadsheetMetadata;
         this.validationReference = validationReference;
         this.converter = converter;
+        this.multiplier = multiplier;
         this.spreadsheetLabelNameResolver = spreadsheetLabelNameResolver;
         this.jsonNodeConverterContext = jsonNodeConverterContext;
         this.localeContext = localeContext;
@@ -100,6 +105,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
                 this.spreadsheetMetadata,
                 this.validationReference,
                 this.converter,
+                this.multiplier,
                 this.spreadsheetLabelNameResolver,
                 after,
                 this.localeContext
@@ -117,6 +123,7 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
                 this.spreadsheetMetadata,
                 this.validationReference,
                 this.converter,
+                this.multiplier,
                 this.spreadsheetLabelNameResolver,
                 after,
                 this.localeContext
@@ -191,14 +198,15 @@ final class BasicSpreadsheetConverterContext implements SpreadsheetConverterCont
     public <N extends Number> N multiply(final Number left,
                                          final Number right,
                                          final Class<N> type) {
-        return ExpressionNumberBinaryNumberConverterFunctions.multiply()
-            .apply(
+        return this.multiplier.apply(
                 left,
                 right,
                 type,
                 this // ExpressionNumberConverterContext
             );
     }
+
+    private final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier;
 
     @Override
     public JsonNodeConverterContext jsonNodeConverterContext() {

--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterContexts.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.spreadsheet.convert;
 
+import walkingkooka.convert.BinaryNumberConverterFunction;
 import walkingkooka.convert.Converter;
 import walkingkooka.locale.LocaleContext;
 import walkingkooka.reflect.PublicStaticHelper;
@@ -42,6 +43,7 @@ public final class SpreadsheetConverterContexts implements PublicStaticHelper {
                                                     final Optional<SpreadsheetMetadata> spreadsheetMetadata,
                                                     final Optional<SpreadsheetValidationReference> validationReference,
                                                     final Converter<SpreadsheetConverterContext> converter,
+                                                    final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                     final SpreadsheetLabelNameResolver spreadsheetLabelNameResolver,
                                                     final JsonNodeConverterContext jsonNodeConverterContext,
                                                     final LocaleContext localeContext) {
@@ -50,6 +52,7 @@ public final class SpreadsheetConverterContexts implements PublicStaticHelper {
             spreadsheetMetadata,
             validationReference,
             converter,
+            multiplier,
             spreadsheetLabelNameResolver,
             jsonNodeConverterContext,
             localeContext

--- a/src/main/java/walkingkooka/spreadsheet/environment/SpreadsheetEnvironmentContextFactory.java
+++ b/src/main/java/walkingkooka/spreadsheet/environment/SpreadsheetEnvironmentContextFactory.java
@@ -323,6 +323,7 @@ public final class SpreadsheetEnvironmentContextFactory implements SpreadsheetEn
                 SpreadsheetConverterContexts.NO_METADATA,
                 SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
                 converter,
+                multiplier,
                 SpreadsheetLabelNameResolvers.empty(),
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -1143,6 +1143,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
             Optional.of(this),
             validationReference,
             converter,
+            multiplier,
             labelNameResolver,
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/main/java/walkingkooka/spreadsheet/provider/SpreadsheetProviderContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/provider/SpreadsheetProviderContext.java
@@ -132,6 +132,7 @@ final class SpreadsheetProviderContext implements ProviderContext,
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             converter,
+            multiplier,
             SpreadsheetLabelNameResolvers.empty(),
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/compare/BasicSpreadsheetComparatorContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/BasicSpreadsheetComparatorContextTest.java
@@ -105,6 +105,7 @@ public final class BasicSpreadsheetComparatorContextTest implements SpreadsheetC
         SpreadsheetConverterContexts.NO_METADATA,
         SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
         Converters.objectToString(),
+        BinaryNumberConverterFunctions.multiply(), // multiplier
         (label) -> {
             Objects.requireNonNull(label, "label");
             throw new UnsupportedOperationException();

--- a/src/test/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/BasicSpreadsheetConverterContextTest.java
@@ -19,6 +19,7 @@ package walkingkooka.spreadsheet.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.convert.BinaryNumberConverterFunction;
 import walkingkooka.convert.BinaryNumberConverterFunctions;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContexts;
@@ -82,6 +83,8 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
 
     private final static SpreadsheetLabelNameResolver LABEL_RESOLVER = SpreadsheetLabelNameResolvers.fake();
 
+    private final static BinaryNumberConverterFunction<SpreadsheetConverterContext> MULTIPLIER = ExpressionNumberBinaryNumberConverterFunctions.multiply();
+
     private final static JsonNodeConverterContext JSON_NODE_CONVERTER_CONTEXT = JsonNodeConverterContexts.fake();
 
     private final static Locale LOCALE = Locale.forLanguageTag("EN-AU");
@@ -99,6 +102,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 SpreadsheetConverterContexts.NO_METADATA,
                 VALIDATION_REFERENCE,
                 CONVERTER,
+                MULTIPLIER,
                 LABEL_RESOLVER,
                 JSON_NODE_CONVERTER_CONTEXT,
                 LOCALE_CONTEXT
@@ -115,6 +119,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 null,
                 VALIDATION_REFERENCE,
                 CONVERTER,
+                MULTIPLIER,
                 LABEL_RESOLVER,
                 JSON_NODE_CONVERTER_CONTEXT,
                 LOCALE_CONTEXT
@@ -130,6 +135,24 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 HAS_USER_DIRECTORIES,
                 SpreadsheetConverterContexts.NO_METADATA,
                 VALIDATION_REFERENCE,
+                null,
+                MULTIPLIER,
+                LABEL_RESOLVER,
+                JSON_NODE_CONVERTER_CONTEXT,
+                LOCALE_CONTEXT
+            )
+        );
+    }
+
+    @Test
+    public void testWithNullMultiplierFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> BasicSpreadsheetConverterContext.with(
+                HAS_USER_DIRECTORIES,
+                SpreadsheetConverterContexts.NO_METADATA,
+                VALIDATION_REFERENCE,
+                CONVERTER,
                 null,
                 LABEL_RESOLVER,
                 JSON_NODE_CONVERTER_CONTEXT,
@@ -147,6 +170,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 SpreadsheetConverterContexts.NO_METADATA,
                 VALIDATION_REFERENCE,
                 CONVERTER,
+                MULTIPLIER,
                 null,
                 JSON_NODE_CONVERTER_CONTEXT,
                 LOCALE_CONTEXT
@@ -163,6 +187,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 SpreadsheetConverterContexts.NO_METADATA,
                 VALIDATION_REFERENCE,
                 CONVERTER,
+                MULTIPLIER,
                 LABEL_RESOLVER,
                 null,
                 LOCALE_CONTEXT
@@ -179,6 +204,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
                 SpreadsheetConverterContexts.NO_METADATA,
                 VALIDATION_REFERENCE,
                 CONVERTER,
+                MULTIPLIER,
                 LABEL_RESOLVER,
                 JSON_NODE_CONVERTER_CONTEXT,
                 null
@@ -267,6 +293,7 @@ public final class BasicSpreadsheetConverterContextTest implements SpreadsheetCo
             SpreadsheetConverterContexts.NO_METADATA,
             VALIDATION_REFERENCE,
             CONVERTER,
+            MULTIPLIER,
             LABEL_RESOLVER,
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterFormatPatternToStringTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterFormatPatternToStringTest.java
@@ -304,6 +304,7 @@ public final class SpreadsheetConverterFormatPatternToStringTest extends Spreads
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             converter,
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(),
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConverterNumberToTextSpreadsheetConverterContextTest.java
@@ -209,6 +209,7 @@ public final class SpreadsheetConverterNumberToTextSpreadsheetConverterContextTe
                 SpreadsheetConverterContexts.NO_METADATA,
                 SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
                 Converters.fake(),
+                BinaryNumberConverterFunctions.multiply(), // multiplier
                 SpreadsheetLabelNameResolvers.empty(),
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
@@ -3726,6 +3726,7 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             SpreadsheetConverters.textToText(), // not used
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(), // not required
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(
@@ -4088,6 +4089,7 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             SpreadsheetConverters.textToText(), // not used
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(), // not required
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/convert/provider/SpreadsheetConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/provider/SpreadsheetConvertersConverterProviderTest.java
@@ -214,6 +214,7 @@ public class SpreadsheetConvertersConverterProviderTest implements ConverterProv
                 SpreadsheetConverterContexts.NO_METADATA,
                 SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
                 SpreadsheetConverters.system(),
+                BinaryNumberConverterFunctions.fake(), // multiplier
                 SpreadsheetLabelNameResolvers.fake(),
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BasicSpreadsheetFormatterContextTest.java
@@ -243,6 +243,7 @@ public final class BasicSpreadsheetFormatterContextTest implements SpreadsheetFo
                 )
             )
         ),
+        BinaryNumberConverterFunctions.multiply(), // multiplier
         LABEL_NAME_RESOLVER,
         JsonNodeConverterContexts.basic(
             ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterConverterTest.java
@@ -138,6 +138,7 @@ public final class SpreadsheetFormatterConverterTest implements ConverterTesting
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             SpreadsheetConverters.system(),
+            ExpressionNumberBinaryNumberConverterFunctions.multiply(),
             (s) -> {
                 throw new UnsupportedOperationException();
             },

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSharedConverterSpreadsheetFormatterContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSharedConverterSpreadsheetFormatterContextTest.java
@@ -88,6 +88,7 @@ public final class SpreadsheetFormatterSharedConverterSpreadsheetFormatterContex
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             SpreadsheetConverters.system(),
+            BinaryNumberConverterFunctions.multiply(), // multiplier
             (s) -> {
                 throw new UnsupportedOperationException();
             },

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSharedExpressionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetFormatterSharedExpressionTest.java
@@ -186,6 +186,7 @@ public final class SpreadsheetFormatterSharedExpressionTest extends SpreadsheetF
                     }
                 )
             ), // not used
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(), // not required
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetNumberParsePatternTest.java
@@ -1254,6 +1254,7 @@ public final class SpreadsheetNumberParsePatternTest extends SpreadsheetParsePat
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             SpreadsheetConverters.textToText(),
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(),
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/pattern/SpreadsheetParsePatternTestCase.java
@@ -868,6 +868,7 @@ public abstract class SpreadsheetParsePatternTestCase<P extends SpreadsheetParse
             SpreadsheetConverterContexts.NO_METADATA,
             SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
             Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
+            BinaryNumberConverterFunctions.fake(), // multiplier
             SpreadsheetLabelNameResolvers.fake(),
             JsonNodeConverterContexts.basic(
                 ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -1416,6 +1416,7 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 Optional.of(metadata),
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 converter,
+                MULTIPLIER,
                 LABEL_NAME_RESOLVER,
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNumberTest.java
@@ -153,6 +153,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetFormatterSelectorNu
                         );
                     }
                 },
+                MULTIPLIER,
                 LABEL_NAME_RESOLVER,
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserSelectorNumberTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameSpreadsheetParserSelectorNumberTest.java
@@ -93,6 +93,7 @@ public final class SpreadsheetMetadataPropertyNameSpreadsheetParserSelectorNumbe
                 SpreadsheetConverterContexts.NO_METADATA,
                 SpreadsheetConverterContexts.NO_VALIDATION_REFERENCE,
                 SpreadsheetConverters.system(),
+                BinaryNumberConverterFunctions.fake(), // multiplier
                 SpreadsheetLabelNameResolvers.fake(),
                 JsonNodeConverterContexts.basic(
                     ExpressionNumberConverterContexts.basic(

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataPropertyNameTestCase.java
@@ -19,6 +19,8 @@ package walkingkooka.spreadsheet.meta;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
+import walkingkooka.convert.BinaryNumberConverterFunction;
+import walkingkooka.convert.BinaryNumberConverterFunctions;
 import walkingkooka.convert.provider.ConverterSelector;
 import walkingkooka.currency.CurrencyCode;
 import walkingkooka.currency.CurrencyCodeLanguageTagContext;
@@ -34,6 +36,7 @@ import walkingkooka.net.UrlFragment;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.TypeNameTesting;
+import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.spreadsheet.format.provider.SpreadsheetFormatterSelector;
 import walkingkooka.spreadsheet.parser.provider.SpreadsheetParserSelector;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolver;
@@ -68,6 +71,8 @@ public abstract class SpreadsheetMetadataPropertyNameTestCase<N extends Spreadsh
     );
 
     final static SpreadsheetLabelNameResolver LABEL_NAME_RESOLVER = SpreadsheetLabelNameResolvers.fake();
+
+    final static BinaryNumberConverterFunction<SpreadsheetConverterContext> MULTIPLIER = BinaryNumberConverterFunctions.fake();
 
     SpreadsheetMetadataPropertyNameTestCase() {
         super();


### PR DESCRIPTION
- Previously BasicSpreadsheetConverterContext.multiplier assumed ExpressionNumberBinaryNumberConverterFunctions.multiply().