### PR TITLE
SpreadsheetStorageRouter.list includes mounts

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouter.java
+++ b/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouter.java
@@ -89,7 +89,10 @@ final class SpreadsheetStorageRouter extends SpreadsheetStorage {
         this.labels = labels.setPrefix(LABEL);
         this.metadatas = metadatas.setPrefix(SPREADSHEET);
 
-        this.root = root;
+        this.root = SpreadsheetStorageRouterRootStorage.with(
+            root,
+            this
+        );
     }
 
     // SpreadsheetStorage.......................................................................................
@@ -263,43 +266,43 @@ final class SpreadsheetStorageRouter extends SpreadsheetStorage {
 
     private final static String SPREADSHEET_STRING = "spreadsheet";
 
-    private final static StoragePath SPREADSHEET = StoragePath.ROOT.append(
+    final static StoragePath SPREADSHEET = StoragePath.ROOT.append(
         StorageName.with(SPREADSHEET_STRING)
     );
 
     private final static String CELL_STRING = "cell";
 
-    private final static StoragePath CELL = StoragePath.ROOT.append(
+    final static StoragePath CELL = StoragePath.ROOT.append(
         StorageName.with(CELL_STRING)
     );
 
     private final static String ENVIRONMENT_STRING = "env";
 
-    private final static StoragePath ENVIRONMENT = StoragePath.ROOT.append(
+    final static StoragePath ENVIRONMENT = StoragePath.ROOT.append(
         StorageName.with(ENVIRONMENT_STRING)
     );
 
     private final static String FORM_STRING = "form";
 
-    private final static StoragePath FORM = StoragePath.ROOT.append(
+    final static StoragePath FORM = StoragePath.ROOT.append(
         StorageName.with(FORM_STRING)
     );
 
     private final static String LABEL_STRING = "label";
 
-    private final static StoragePath LABEL = StoragePath.ROOT.append(
+    final static StoragePath LABEL = StoragePath.ROOT.append(
         StorageName.with(LABEL_STRING)
     );
 
-    private final Storage<SpreadsheetStorageContext> cells;
+    final Storage<SpreadsheetStorageContext> cells;
 
-    private final Storage<SpreadsheetStorageContext> environment;
+    final Storage<SpreadsheetStorageContext> environment;
 
-    private final Storage<SpreadsheetStorageContext> forms;
+    final Storage<SpreadsheetStorageContext> forms;
 
-    private final Storage<SpreadsheetStorageContext> labels;
+    final Storage<SpreadsheetStorageContext> labels;
 
-    private final Storage<SpreadsheetStorageContext> metadatas;
+    final Storage<SpreadsheetStorageContext> metadatas;
 
     /**
      * This storage will provide storage for paths that dont match the cells, labels or metadata.

--- a/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterRootStorage.java
+++ b/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterRootStorage.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.storage;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.storage.Storage;
+import walkingkooka.storage.StorageContext;
+import walkingkooka.storage.StorageDelegator;
+import walkingkooka.storage.StoragePath;
+import walkingkooka.storage.StorageValueInfo;
+
+import java.util.List;
+
+/**
+ * A {@link Storage} that decorates {@link Storage#list(StoragePath, int, int, StorageContext)}, inserting entries
+ * for the mounted paths.
+ */
+final class SpreadsheetStorageRouterRootStorage implements Storage<SpreadsheetStorageContext>,
+    StorageDelegator<SpreadsheetStorageContext> {
+
+    static SpreadsheetStorageRouterRootStorage with(final Storage<SpreadsheetStorageContext> storage,
+                                                    final SpreadsheetStorageRouter router) {
+        return new SpreadsheetStorageRouterRootStorage(
+            storage,
+            router
+        );
+    }
+
+    private SpreadsheetStorageRouterRootStorage(final Storage<SpreadsheetStorageContext> storage,
+                                                final SpreadsheetStorageRouter router) {
+        super();
+
+        this.storage = storage;
+
+        this.router = router;
+    }
+
+    @Override
+    public List<StorageValueInfo> list(final StoragePath parent,
+                                       final int offset,
+                                       final int count,
+                                       final SpreadsheetStorageContext context) {
+        final Storage<SpreadsheetStorageContext> storage = this.storage;
+        List<StorageValueInfo> list;
+
+        if (StoragePath.ROOT.equals(parent)) {
+            list = Lists.array();
+
+            Loop: //
+            while (list.size() < count) {
+                switch (list.size() + offset) {
+                    // /cells
+                    case 0:
+                        list.add(
+                            this.addMountEntry(
+                                SpreadsheetStorageRouter.CELL,
+                                context
+                            )
+                        );
+                        break;
+                    // /environment
+                    case 1:
+                        list.add(
+                            this.addMountEntry(
+                                SpreadsheetStorageRouter.ENVIRONMENT,
+                                context
+                            )
+                        );
+                        break;
+                    // /forms
+                    case 2:
+                        list.add(
+                            this.addMountEntry(
+                                SpreadsheetStorageRouter.FORM,
+                                context
+                            )
+                        );
+                        break;
+                    // /labels
+                    case 3:
+                        list.add(
+                            this.addMountEntry(
+                                SpreadsheetStorageRouter.LABEL,
+                                context
+                            )
+                        );
+                        break;
+                    // /spreadsheet
+                    case 4:
+                        list.add(
+                            this.addMountEntry(
+                                SpreadsheetStorageRouter.SPREADSHEET,
+                                context
+                            )
+                        );
+                        break;
+                    default:
+                        final int storageOffset = offset + list.size() - 5;
+                        if(storageOffset >= 0) {
+                            list.addAll(
+                                storage.list(
+                                    parent,
+                                    storageOffset,
+                                    count - list.size(),
+                                    context
+                                )
+                            );
+                        }
+                        break Loop;
+                }
+            }
+
+            return Lists.immutable(list);
+        } else {
+            list = storage.list(
+                parent,
+                offset,
+                count,
+                context
+            );
+        }
+
+        return list;
+    }
+
+    private final SpreadsheetStorageRouter router;
+
+    private StorageValueInfo addMountEntry(final StoragePath path,
+                                           final SpreadsheetStorageContext context) {
+        return StorageValueInfo.with(
+            path,
+            context.createdAuditInfo()
+        );
+    }
+
+//    private StorageValueInfo addMount(final Storage<SpreadsheetStorageContext> mount,
+//                                      final StoragePath path,
+//                                      final SpreadsheetStorageContext context) {
+//        final List<StorageValueInfo> infos = mount.list(
+//            path,
+//            0,
+//            1,
+//            context
+//        );
+//
+//        StorageValueInfo info;
+//
+//        if (infos.size() == 1) {
+//            info = infos.get(0)
+//                .setPath(path);
+//        } else {
+//            info = StorageValueInfo.with(
+//                path,
+//                context.createdAuditInfo()
+//            );
+//        }
+//
+//        return info;
+//    }
+
+    // StorageDelegator.................................................................................................
+
+    @Override
+    public Storage<SpreadsheetStorageContext> storage() {
+        return this.storage;
+    }
+
+    private final Storage<SpreadsheetStorageContext> storage;
+
+    // Object...........................................................................................................
+
+    @Override
+    public String toString() {
+        return this.storage.toString();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterRootStorageTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterRootStorageTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet.storage;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.environment.AuditInfo;
+import walkingkooka.net.email.EmailAddress;
+import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataTesting;
+import walkingkooka.storage.Storage;
+import walkingkooka.storage.StoragePath;
+import walkingkooka.storage.StorageTesting;
+import walkingkooka.storage.StorageValue;
+import walkingkooka.storage.StorageValueInfo;
+import walkingkooka.storage.Storages;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public final class SpreadsheetStorageRouterRootStorageTest implements StorageTesting<SpreadsheetStorageRouterRootStorage, SpreadsheetStorageContext>,
+    SpreadsheetMetadataTesting {
+
+    private final static AuditInfo AUDIT_INFO = SPREADSHEET_ENVIRONMENT_CONTEXT.createdAuditInfo();
+
+    private final static StoragePath ITEM1 = StoragePath.parse("/item111");
+
+    private final static StoragePath ITEM2 = StoragePath.parse("/item222");
+
+    private final static StoragePath ITEM3 = StoragePath.parse("/other/item333");
+
+    @Test
+    public void testListOffsetZeroCountZero() {
+        this.listAndCheck(
+            this.createStorage(),
+            StoragePath.ROOT,
+            0,
+            0,
+            this.createContext()
+        );
+    }
+
+    @Test
+    public void testListOffsetZeroCountFive() {
+        this.listAndCheck(
+            this.createStorage(),
+            StoragePath.ROOT,
+            0,
+            5,
+            this.createContext(),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.CELL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.ENVIRONMENT,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.FORM,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.LABEL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            )
+        );
+    }
+
+    @Test
+    public void testListOffsetSpreadsheetCountOne() {
+        this.listAndCheck(
+            this.createStorage(),
+            StoragePath.ROOT,
+            4,
+            1,
+            this.createContext(),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            )
+        );
+    }
+
+    @Test
+    public void testListOffsetSpreadsheetCountTwo() {
+        this.listAndCheck(
+            this.createStorage(),
+            StoragePath.ROOT,
+            4,
+            2,
+            this.createContext(),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                ITEM1,
+                AUDIT_INFO
+            )
+        );
+    }
+
+    @Test
+    public void testListOffsetSpreadsheetCountFour() {
+        this.listAndCheck(
+            this.createStorage(),
+            StoragePath.ROOT,
+            4,
+            3,
+            this.createContext(),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                ITEM1,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                ITEM2,
+                AUDIT_INFO
+            )
+        );
+    }
+
+    @Override
+    public SpreadsheetStorageRouterRootStorage createStorage() {
+        final Storage<SpreadsheetStorageContext> root = Storages.treeMapStore();
+
+        final SpreadsheetStorageContext context = this.createContext();
+
+        root.save(
+            StorageValue.with(ITEM1)
+                .setValue(
+                    Optional.of("111")
+                ),
+            context
+        );
+
+        root.save(
+            StorageValue.with(ITEM2)
+                .setValue(
+                    Optional.of("222")
+                ),
+            context
+        );
+
+        root.save(
+            StorageValue.with(ITEM3)
+                .setValue(
+                    Optional.of("333")
+                ),
+            context
+        );
+
+        return SpreadsheetStorageRouterRootStorage.with(
+            root,
+            SpreadsheetStorageRouter.with(
+                SpreadsheetStorages.cell(),
+                SpreadsheetStorages.env(),
+                SpreadsheetStorages.form(),
+                SpreadsheetStorages.label(),
+                SpreadsheetStorages.metadata(),
+                root
+            )
+        );
+    }
+
+    @Override
+    public void testListWithNegativeCountFails() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void testListWithNegativeOffsetFails() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpreadsheetStorageContext createContext() {
+        return new FakeSpreadsheetStorageContext() {
+
+            @Override
+            public LocalDateTime now() {
+                return AUDIT_INFO.createdTimestamp();
+            }
+
+            @Override
+            public Optional<EmailAddress> user() {
+                return Optional.of(
+                    AUDIT_INFO.createdBy()
+                );
+            }
+        };
+    }
+
+    // class............................................................................................................
+
+    @Override
+    public Class<SpreadsheetStorageRouterRootStorage> type() {
+        return SpreadsheetStorageRouterRootStorage.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterTest.java
@@ -1510,8 +1510,28 @@ public final class SpreadsheetStorageRouterTest extends SpreadsheetStorageTestCa
             storage,
             StoragePath.ROOT,
             0, // offset
-            4, // count
-            context
+            5, // count
+            context,
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.CELL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.ENVIRONMENT,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.FORM,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.LABEL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            )
         );
     }
 
@@ -1816,8 +1836,28 @@ public final class SpreadsheetStorageRouterTest extends SpreadsheetStorageTestCa
             storage,
             StoragePath.ROOT,
             0,
-            2,
+            6,
             context,
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.CELL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.ENVIRONMENT,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.FORM,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.LABEL,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                SpreadsheetStorageRouter.SPREADSHEET,
+                AUDIT_INFO
+            ),
             StorageValueInfo.with(
                 StoragePath.parse("/root/"),
                 AUDIT_INFO


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9103
- SpreadsheetStorageRouter: Listing root should include cells, environment, forms, labels, metadata entries