### PR TITLE
MissingConverterVerifier.TEXT added string to LineEnding

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/SpreadsheetConverters.java
@@ -70,7 +70,8 @@ public final class SpreadsheetConverters implements PublicStaticHelper {
     private final static Converter<SpreadsheetConverterContext> TEXT = namedCollection(
         "TEXT",
         Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
-        SpreadsheetConverters.textToIndentation()
+        SpreadsheetConverters.textToIndentation(),
+        SpreadsheetConverters.textToLineEnding()
     );
 
     private static final Function<SpreadsheetConverterContext, SpreadsheetParserContext> SPREADSHEET_CONVERTER_CONTEXT_TO_SPREADSHEET_PARSER_CONTEXT = (final SpreadsheetConverterContext scc) ->

--- a/src/main/java/walkingkooka/spreadsheet/convert/provider/MissingConverterVerifier.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/provider/MissingConverterVerifier.java
@@ -1249,6 +1249,15 @@ final class MissingConverterVerifier {
                 SpreadsheetConvertersConverterProvider.TEXT // TEXT
             );
 
+            verifier.addIfConversionFail(
+                Lists.of(
+                    "\r\n",
+                    "crnl"
+                ),
+                LineEnding.class,
+                SpreadsheetConvertersConverterProvider.TEXT // TEXT
+            );
+
             // text-to-lineEnding.......................................................................................
             verifier.addIfConversionFail(
                 LineEnding.NL.text(),


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9124
- SpreadsheetConverters.TEXT add SpreadsheetConverters.textToLineEnding()