### PR TITLE
SpreadsheetExpressionEvaluationContext extends SpreadsheetMetadataCon…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/FakeSpreadsheetExpressionEvaluationContext.java
@@ -23,6 +23,7 @@ import walkingkooka.environment.EnvironmentContext;
 import walkingkooka.environment.EnvironmentValueName;
 import walkingkooka.io.TextReader;
 import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.email.EmailAddress;
 import walkingkooka.spreadsheet.convert.SpreadsheetConverterContext;
 import walkingkooka.spreadsheet.engine.SpreadsheetDelta;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
@@ -43,6 +44,7 @@ import walkingkooka.spreadsheet.value.SpreadsheetCell;
 import walkingkooka.storage.Storage;
 import walkingkooka.storage.StoragePath;
 import walkingkooka.storage.expression.function.FakeStorageExpressionEvaluationContext;
+import walkingkooka.store.StoreWatcher;
 import walkingkooka.terminal.TerminalId;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.printer.Printer;
@@ -58,6 +60,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Currency;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -356,6 +359,44 @@ public class FakeSpreadsheetExpressionEvaluationContext extends FakeStorageExpre
 
     @Override
     public Form<SpreadsheetValidationReference> form() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpreadsheetMetadata createMetadata(final EmailAddress user,
+                                              final Optional<Locale> locale) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SpreadsheetMetadata> loadMetadata(final SpreadsheetId id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpreadsheetMetadata saveMetadata(final SpreadsheetMetadata metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteMetadata(final SpreadsheetId id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<SpreadsheetMetadata> findMetadataBySpreadsheetName(final String name,
+                                                                   final int offset,
+                                                                   final int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Runnable addMetadataWatcher(final StoreWatcher<SpreadsheetMetadata> watcher) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Runnable addMetadataWatcherOnce(final StoreWatcher<SpreadsheetMetadata> watcher) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContext.java
@@ -28,6 +28,7 @@ import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.HasSpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
@@ -82,6 +83,7 @@ public interface SpreadsheetExpressionEvaluationContext extends FormHandlerExpre
     JsonNodeExpressionEvaluationContext,
     SpreadsheetConverterContext,
     SpreadsheetEnvironmentContext,
+    SpreadsheetMetadataContext,
     StorageExpressionEvaluationContext,
     TerminalExpressionEvaluationContext,
     ValidatorExpressionEvaluationContext<SpreadsheetValidationReference> {

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextConverter.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextConverter.java
@@ -40,6 +40,8 @@ import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextDelegator;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
@@ -101,6 +103,7 @@ final class SpreadsheetExpressionEvaluationContextConverter implements Spreadshe
     DecimalNumberContextDelegator,
     JsonNodeMarshallUnmarshallContextDelegator,
     LocaleContextDelegator,
+    SpreadsheetMetadataContextDelegator,
     TerminalContextDelegator {
 
     static SpreadsheetExpressionEvaluationContextConverter with(final Converter<SpreadsheetExpressionEvaluationContext> converter,
@@ -684,6 +687,13 @@ final class SpreadsheetExpressionEvaluationContextConverter implements Spreadshe
     @Override
     public Storage<SpreadsheetStorageContext> storage() {
         return this.context.storage();
+    }
+
+    // SpreadsheetMetadataContextDelegator..............................................................................
+
+    @Override
+    public SpreadsheetMetadataContext spreadsheetMetadataContext() {
+        return this.context;
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegator.java
@@ -31,6 +31,8 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContextDelegat
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextDelegator;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
@@ -75,6 +77,7 @@ public interface SpreadsheetExpressionEvaluationContextDelegator extends Spreads
     FormHandlerExpressionEvaluationContextDelegator<SpreadsheetValidationReference, SpreadsheetDelta>,
     ValidatorExpressionEvaluationContextDelegator<SpreadsheetValidationReference>,
     SpreadsheetEnvironmentContextDelegator,
+    SpreadsheetMetadataContextDelegator,
     StorageExpressionEvaluationContextDelegator,
     TerminalContextDelegator {
 
@@ -202,6 +205,13 @@ public interface SpreadsheetExpressionEvaluationContextDelegator extends Spreads
     }
 
     SpreadsheetExpressionEvaluationContext spreadsheetExpressionEvaluationContext();
+
+    // SpreadsheetMetadataContextDelegator..............................................................................
+
+    @Override
+    default SpreadsheetMetadataContext spreadsheetMetadataContext() {
+        return this.spreadsheetExpressionEvaluationContext();
+    }
 
     // StorageExpressionEvaluationContextDelegator......................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextLocalReferences.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextLocalReferences.java
@@ -39,6 +39,8 @@ import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextDelegator;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetColumnReference;
@@ -92,6 +94,7 @@ final class SpreadsheetExpressionEvaluationContextLocalReferences implements Spr
     FormHandlerContextDelegator<SpreadsheetValidationReference, SpreadsheetDelta>,
     JsonNodeMarshallUnmarshallContextDelegator,
     LocaleContextDelegator,
+    SpreadsheetMetadataContextDelegator,
     TerminalContextDelegator,
     UsesToStringBuilder {
 
@@ -542,6 +545,13 @@ final class SpreadsheetExpressionEvaluationContextLocalReferences implements Spr
 
     @Override
     public EnvironmentContext environmentContext() {
+        return this.context;
+    }
+
+    // SpreadsheetMetadataContextDelegator..............................................................................
+
+    @Override
+    public SpreadsheetMetadataContext spreadsheetMetadataContext() {
         return this.context;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextShared.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextShared.java
@@ -33,6 +33,7 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContext;
 import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContextDelegator;
 import walkingkooka.spreadsheet.formula.SpreadsheetFormulaParsers;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextDelegator;
 import walkingkooka.spreadsheet.parser.SpreadsheetParser;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReference;
@@ -69,6 +70,7 @@ import java.util.Set;
 abstract class SpreadsheetExpressionEvaluationContextShared implements SpreadsheetExpressionEvaluationContext,
     SpreadsheetEnvironmentContextDelegator,
     SpreadsheetConverterContextDelegator,
+    SpreadsheetMetadataContextDelegator,
     LocaleContextDelegator,
     TerminalContextDelegator {
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext.java
@@ -30,6 +30,7 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContext;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.parser.SpreadsheetParser;
 import walkingkooka.spreadsheet.parser.SpreadsheetParserContext;
@@ -506,6 +507,13 @@ final class SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext exten
 
     @Override
     public SpreadsheetEnvironmentContext spreadsheetEnvironmentContext() {
+        return this.spreadsheetContext;
+    }
+
+    // SpreadsheetMetadataContextDelegator..............................................................................
+
+    @Override
+    public SpreadsheetMetadataContext spreadsheetMetadataContext() {
         return this.spreadsheetContext;
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetEnvironmentContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetEnvironmentContext.java
@@ -477,6 +477,13 @@ final class SpreadsheetExpressionEvaluationContextSharedSpreadsheetEnvironmentCo
 
     private final SpreadsheetStorageContext spreadsheetStorageContext;
 
+    // SpreadsheetMetadataContextDelegator..............................................................................
+
+    @Override
+    public SpreadsheetMetadataContext spreadsheetMetadataContext() {
+        return this.spreadsheetMetadataContext;
+    }
+
     // SpreadsheetExpressionEvaluationContextSharedSpreadsheetEnvironmentContextSpreadsheetStorageContext
     final SpreadsheetMetadataContext spreadsheetMetadataContext;
 

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextTesting.java
@@ -25,6 +25,7 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContextTesting
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContextTesting;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataPropertyName;
 import walkingkooka.spreadsheet.provider.SpreadsheetProviderContextTesting;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
@@ -56,6 +57,7 @@ public interface SpreadsheetExpressionEvaluationContextTesting<C extends Spreads
     JsonNodeExpressionEvaluationContextTesting<C>,
     SpreadsheetEnvironmentContextTesting2<C>,
     SpreadsheetLabelNameResolverTesting<C>,
+    SpreadsheetMetadataContextTesting<C>,
     StorageExpressionEvaluationContextTesting2<C>,
     ValidatorExpressionEvaluationContextTesting<SpreadsheetValidationReference, C>,
     SpreadsheetProviderContextTesting<C> {

--- a/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextConverterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextConverterTest.java
@@ -56,6 +56,9 @@ import walkingkooka.spreadsheet.provider.SpreadsheetProviders;
 import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReferenceLoaders;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelNameResolvers;
 import walkingkooka.spreadsheet.store.repo.FakeSpreadsheetStoreRepository;
+import walkingkooka.store.Store;
+import walkingkooka.store.StoreWatcher;
+import walkingkooka.store.StoreWatchers;
 import walkingkooka.terminal.TerminalContexts;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharacterConstant;
@@ -569,6 +572,27 @@ public final class SpreadsheetExpressionEvaluationContextConverterTest implement
                                             null
                                     );
                                 }
+
+                                @Override
+                                public List<SpreadsheetMetadata> findByName(final String name,
+                                                                            final int offset,
+                                                                            final int count) {
+                                    Objects.requireNonNull(name, "name");
+                                    Store.checkOffsetAndCount(offset, count);
+                                    throw new UnsupportedOperationException();
+                                }
+
+                                @Override
+                                public Runnable addStoreWatcher(final StoreWatcher<SpreadsheetMetadata> watcher) {
+                                    return this.watchers.add(watcher);
+                                }
+
+                                @Override
+                                public Runnable addStoreWatcherOnce(final StoreWatcher<SpreadsheetMetadata> watcher) {
+                                    return this.watchers.addOnce(watcher);
+                                }
+
+                                private final StoreWatchers<SpreadsheetMetadata> watchers = StoreWatchers.empty();
                             };
                         }
                     },

--- a/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextDelegatorTest.java
@@ -45,6 +45,9 @@ import walkingkooka.storage.StoragePath;
 import walkingkooka.storage.StorageValue;
 import walkingkooka.storage.StorageValueInfo;
 import walkingkooka.storage.Storages;
+import walkingkooka.store.Store;
+import walkingkooka.store.StoreWatcher;
+import walkingkooka.store.StoreWatchers;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContextObjectPostProcessor;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContextPreProcessor;
@@ -250,6 +253,27 @@ public final class SpreadsheetExpressionEvaluationContextDelegatorTest implement
                                             null
                                     );
                                 }
+
+                                @Override
+                                public List<SpreadsheetMetadata> findByName(final String name,
+                                                                            final int offset,
+                                                                            final int count) {
+                                    Objects.requireNonNull(name, "name");
+                                    Store.checkOffsetAndCount(offset, count);
+                                    throw new UnsupportedOperationException();
+                                }
+
+                                @Override
+                                public Runnable addStoreWatcher(final StoreWatcher<SpreadsheetMetadata> watcher) {
+                                    return this.watchers.add(watcher);
+                                }
+
+                                @Override
+                                public Runnable addStoreWatcherOnce(final StoreWatcher<SpreadsheetMetadata> watcher) {
+                                    return this.watchers.addOnce(watcher);
+                                }
+
+                                private final StoreWatchers<SpreadsheetMetadata> watchers = StoreWatchers.empty();
                             };
                         }
                     },

--- a/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextLocalReferencesTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextLocalReferencesTest.java
@@ -46,6 +46,10 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContext;
 import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContexts;
 import walkingkooka.spreadsheet.format.SpreadsheetFormatterContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
+import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContexts;
+import walkingkooka.spreadsheet.meta.store.SpreadsheetMetadataStores;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellRangeReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.reference.SpreadsheetLabelMapping;
@@ -62,6 +66,7 @@ import walkingkooka.storage.StoragePath;
 import walkingkooka.storage.StorageValue;
 import walkingkooka.storage.StorageValueInfo;
 import walkingkooka.storage.Storages;
+import walkingkooka.store.StoreWatcher;
 import walkingkooka.template.TemplateValueName;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
@@ -879,6 +884,60 @@ public final class SpreadsheetExpressionEvaluationContextLocalReferencesTest imp
             Objects.requireNonNull(watcher, "watcher");
             throw new UnsupportedOperationException();
         }
+
+        // SpreadsheetMetadataContext...................................................................................
+
+        @Override
+        public SpreadsheetMetadata createMetadata(final EmailAddress user,
+                                                  final Optional<Locale> locale) {
+            return this.spreadsheetMetadataContext.createMetadata(
+                user,
+                locale
+            );
+        }
+
+        @Override
+        public Optional<SpreadsheetMetadata> loadMetadata(final SpreadsheetId id) {
+            return this.spreadsheetMetadataContext.loadMetadata(id);
+        }
+
+        @Override
+        public SpreadsheetMetadata saveMetadata(final SpreadsheetMetadata metadata) {
+            return this.spreadsheetMetadataContext.saveMetadata(metadata);
+        }
+
+        @Override
+        public void deleteMetadata(final SpreadsheetId id) {
+            this.spreadsheetMetadataContext.deleteMetadata(id);
+        }
+
+        @Override
+        public Runnable addMetadataWatcher(final StoreWatcher<SpreadsheetMetadata> watcher) {
+            return this.spreadsheetMetadataContext.addMetadataWatcher(watcher);
+        }
+
+        @Override
+        public Runnable addMetadataWatcherOnce(final StoreWatcher<SpreadsheetMetadata> watcher) {
+            return this.spreadsheetMetadataContext.addMetadataWatcherOnce(watcher);
+        }
+
+        @Override
+        public List<SpreadsheetMetadata> findMetadataBySpreadsheetName(final String name,
+                                                                       final int offset,
+                                                                       final int count) {
+            return this.spreadsheetMetadataContext.findMetadataBySpreadsheetName(
+                name,
+                offset,
+                count
+            );
+        }
+
+        private final SpreadsheetMetadataContext spreadsheetMetadataContext = SpreadsheetMetadataContexts.basic(
+            (e, l) -> SpreadsheetMetadata.EMPTY,
+            SpreadsheetMetadataStores.treeMap()
+        );
+
+        // SpreadsheetStorageContext....................................................................................
 
         @Override
         public Optional<StorageValue> loadStorage(final StoragePath path) {


### PR DESCRIPTION
…text

- Required to support functions that can create a new SpreadsheetMetadata from within a spreadsheet template(TODO).

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9253
- SpreadsheetExpressionEvaluationContext.createMetadata(EmailAddress, Optional<Locale>)