### PR TITLE
SpreadsheetConverterContext extends SpreadsheetMetadataLoader 2/2

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -426,6 +426,7 @@ public class TestGwtTest extends GWTTestCase {
                         LABEL_NAME_RESOLVER,
                         lineEnding,
                         BinaryNumberConverterFunctions.fake(),
+                        SpreadsheetMetadataLoaders.empty(),
                         currencyContext.setLocaleContext(this.localeContext),
                         SpreadsheetProviders.basic(
                             converterProvider,

--- a/src/it/j2cl-test/src/test/java/test/J2clTest.java
+++ b/src/it/j2cl-test/src/test/java/test/J2clTest.java
@@ -441,6 +441,7 @@ public class J2clTest {
                         lineEnding,
                         BinaryNumberConverterFunctions.fake(),
                         SpreadsheetMetadataLoaders.fake(),
+                        SpreadsheetMetadataLoaders.empty(),
                         currencyContext.setLocaleContext(this.localeContext),
                         SpreadsheetProviders.basic(
                             converterProvider,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9303
- SpreadsheetConverterContext extends SpreadsheetMetadataLoader