### PR TITLE
SpreadsheetContextSharedMutableSpreadsheetId removed SpreadsheetMetad…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextSharedMutableSpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContextSharedMutableSpreadsheetId.java
@@ -31,7 +31,6 @@ import walkingkooka.spreadsheet.engine.SpreadsheetEngineContexts;
 import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
-import walkingkooka.spreadsheet.meta.SpreadsheetMetadataCreator;
 import walkingkooka.spreadsheet.provider.SpreadsheetProvider;
 import walkingkooka.spreadsheet.store.repo.SpreadsheetStoreRepository;
 import walkingkooka.terminal.TerminalContexts;
@@ -47,7 +46,6 @@ import java.util.Objects;
 final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetContextShared {
 
     static SpreadsheetContextSharedMutableSpreadsheetId with(final MediaTypeDetector mediaTypeDetector,
-                                                             final SpreadsheetMetadataCreator metadataCreator,
                                                              final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                              final SpreadsheetEngine spreadsheetEngine,
                                                              final SpreadsheetContextSupplier spreadsheetContextSupplier,
@@ -57,7 +55,6 @@ final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetCont
                                                              final SpreadsheetProvider spreadsheetProvider,
                                                              final ProviderContext providerContext) {
         Objects.requireNonNull(mediaTypeDetector, "mediaTypeDetector");
-        Objects.requireNonNull(metadataCreator, "metadataCreator");
         Objects.requireNonNull(multiplier, "multiplier");
         Objects.requireNonNull(spreadsheetEngine, "spreadsheetEngine");
         Objects.requireNonNull(spreadsheetContextSupplier, "spreadsheetContextSupplier");
@@ -69,7 +66,6 @@ final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetCont
 
         return new SpreadsheetContextSharedMutableSpreadsheetId(
             mediaTypeDetector,
-            metadataCreator,
             multiplier,
             spreadsheetEngine,
             spreadsheetContextSupplier,
@@ -83,7 +79,6 @@ final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetCont
     }
 
     private SpreadsheetContextSharedMutableSpreadsheetId(final MediaTypeDetector mediaTypeDetector,
-                                                         final SpreadsheetMetadataCreator metadataCreator,
                                                          final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                          final SpreadsheetEngine spreadsheetEngine,
                                                          final SpreadsheetContextSupplier spreadsheetContextSupplier,
@@ -95,7 +90,7 @@ final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetCont
                                                          final ProviderContext providerContext) {
         super(
             mediaTypeDetector,
-            metadataCreator,
+            spreadsheetMetadataContext, // SpreadsheetMetadataCreator
             multiplier,
             spreadsheetEngine,
             spreadsheetEngineContext,
@@ -168,7 +163,6 @@ final class SpreadsheetContextSharedMutableSpreadsheetId extends SpreadsheetCont
                                                  final ProviderContext providerContext) {
         return new SpreadsheetContextSharedMutableSpreadsheetId(
             this.mediaTypeDetector,
-            this.metadataCreator,
             this.multiplier,
             this.spreadsheetEngine,
             this.spreadsheetContextSupplier,

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetContexts.java
@@ -76,7 +76,6 @@ public final class SpreadsheetContexts implements PublicStaticHelper {
      * {@see SpreadsheetContextSharedMutableSpreadsheetId}
      */
     public static SpreadsheetContext mutableSpreadsheetId(final MediaTypeDetector mediaTypeDetector,
-                                                          final SpreadsheetMetadataCreator metadataCreator,
                                                           final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                           final SpreadsheetEngine spreadsheetEngine,
                                                           final SpreadsheetContextSupplier spreadsheetContextSupplier,
@@ -87,7 +86,6 @@ public final class SpreadsheetContexts implements PublicStaticHelper {
                                                           final ProviderContext providerContext) {
         return SpreadsheetContextSharedMutableSpreadsheetId.with(
             mediaTypeDetector,
-            metadataCreator,
             multiplier,
             spreadsheetEngine,
             spreadsheetContextSupplier,

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextSharedMutableSpreadsheetIdTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetContextSharedMutableSpreadsheetIdTest.java
@@ -35,6 +35,7 @@ import walkingkooka.spreadsheet.export.provider.SpreadsheetExporterAliasSet;
 import walkingkooka.spreadsheet.expression.SpreadsheetExpressionFunctions;
 import walkingkooka.spreadsheet.format.provider.SpreadsheetFormatterAliasSet;
 import walkingkooka.spreadsheet.importer.provider.SpreadsheetImporterAliasSet;
+import walkingkooka.spreadsheet.meta.FakeSpreadsheetMetadataContext;
 import walkingkooka.spreadsheet.meta.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadataContext;
@@ -63,7 +64,17 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
         throw new UnsupportedOperationException();
     };
 
-    private final static SpreadsheetMetadataContext SPREADSHEET_METADATA_CONTEXT = SpreadsheetMetadataContexts.fake();
+    private final static SpreadsheetMetadataContext SPREADSHEET_METADATA_CONTEXT = new FakeSpreadsheetMetadataContext() {
+
+        @Override
+        public SpreadsheetMetadata createMetadata(final EmailAddress user,
+                                                  final Optional<Locale> locale) {
+            return SPREADSHEET_METADATA_CREATOR.createMetadata(
+                user,
+                locale
+            );
+        }
+    };
 
     private final static SpreadsheetId OTHER_SPREADSHEET_ID = SpreadsheetId.with(999);
 
@@ -76,26 +87,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
         assertThrows(
             NullPointerException.class,
             () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
-                null,
-                SPREADSHEET_METADATA_CREATOR,
-                MULTIPLIER,
-                SPREADSHEET_ENGINE,
-                SPREADSHEET_CONTEXT_SUPPLIER,
-                SPREADSHEET_METADATA_CONTEXT,
-                CURRENCY_LOCALE_CONTEXT,
-                SPREADSHEET_ENVIRONMENT_CONTEXT,
-                SPREADSHEET_PROVIDER,
-                PROVIDER_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testWithNullSpreadsheetMetadataCreatorFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
-                MEDIA_TYPE_DETECTOR,
                 null,
                 MULTIPLIER,
                 SPREADSHEET_ENGINE,
@@ -115,7 +106,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
             NullPointerException.class,
             () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
                 MEDIA_TYPE_DETECTOR,
-                SPREADSHEET_METADATA_CREATOR,
                 null,
                 SPREADSHEET_ENGINE,
                 SPREADSHEET_CONTEXT_SUPPLIER,
@@ -134,7 +124,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
             NullPointerException.class,
             () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
                 MEDIA_TYPE_DETECTOR,
-                SPREADSHEET_METADATA_CREATOR,
                 MULTIPLIER,
                 null,
                 SPREADSHEET_CONTEXT_SUPPLIER,
@@ -153,7 +142,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
             NullPointerException.class,
             () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
                 MEDIA_TYPE_DETECTOR,
-                SPREADSHEET_METADATA_CREATOR,
                 MULTIPLIER,
                 SPREADSHEET_ENGINE,
                 null,
@@ -172,7 +160,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
             NullPointerException.class,
             () -> SpreadsheetContextSharedMutableSpreadsheetId.with(
                 MEDIA_TYPE_DETECTOR,
-                SPREADSHEET_METADATA_CREATOR,
                 MULTIPLIER,
                 SPREADSHEET_ENGINE,
                 SPREADSHEET_CONTEXT_SUPPLIER,
@@ -607,7 +594,6 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
 
         return SpreadsheetContextSharedMutableSpreadsheetId.with(
             MEDIA_TYPE_DETECTOR,
-            SPREADSHEET_METADATA_CREATOR,
             MULTIPLIER,
             SPREADSHEET_ENGINE,
             (SpreadsheetId id) -> {
@@ -625,9 +611,7 @@ public final class SpreadsheetContextSharedMutableSpreadsheetIdTest extends Spre
                 );
             },
             SpreadsheetMetadataContexts.basic(
-                (u, dl) -> {
-                    throw new UnsupportedOperationException();
-                },
+                SPREADSHEET_METADATA_CREATOR,
                 store
             ),
             currencyLocaleContext,

--- a/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageRouterTest.java
@@ -3043,7 +3043,6 @@ public final class SpreadsheetStorageRouterTest extends SpreadsheetStorageTestCa
                                                         final SpreadsheetEnvironmentContext spreadsheetEnvironmentContext) {
         return SpreadsheetContexts.mutableSpreadsheetId(
             MEDIA_TYPE_DETECTOR,
-            SPREADSHEET_METADATA_CREATOR,
             MULTIPLIER,
             SpreadsheetEngines.basic(),
             spreadsheetContextSupplier,


### PR DESCRIPTION
…ataCreator

- Unnecessary because SpreadsheetMetadataContext is also required