### PR TITLE
https://github.com/mP1/walkingkooka-convert/pull/557 ConverterTextToC…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/convert/provider/MissingConverterVerifier.java
+++ b/src/main/java/walkingkooka/spreadsheet/convert/provider/MissingConverterVerifier.java
@@ -1623,7 +1623,7 @@ final class MissingConverterVerifier {
 
             // text-to-csv-string-list..............................................................................
             verifier.addIfConversionFail(
-                "apple, banana, \"333 444\"",
+                "apple,banana,\"333 444\"",
                 CsvStringList.class,
                 SpreadsheetConvertersConverterProvider.TEXT_TO_CSV_STRING_LIST
             );

--- a/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/convert/SpreadsheetConvertersTest.java
@@ -1122,7 +1122,7 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
     @Test
     public void testFormAndValidationConvertStringToValidationCheckbox() {
         this.formAndValidationConvertAndCheck(
-            "111, 222",
+            "111,222",
             ValidationCheckbox.with(
                 Optional.of("111"),
                 Optional.of("222")
@@ -2802,7 +2802,7 @@ public final class SpreadsheetConvertersTest implements ClassTesting2<Spreadshee
     @Test
     public void testSpreadsheetValueConvertStringToCsvStringList() {
         this.spreadsheetValueConvertAndCheck(
-            "Apple, Banana, \"333 444\"",
+            "Apple,Banana,\"333 444\"",
             CsvStringList.EMPTY.setElements(
                 Lists.of(
                     "Apple",


### PR DESCRIPTION
…ollectionXXXCsvStringXXX & ConverterTextToCollectionXXXTsvStringXXX should not use Context#valueSeparator but Comma/Tab FIX

- https://github.com/mP1/walkingkooka-convert/pull/557
- ConverterTextToCollectionXXXCsvStringXXX & ConverterTextToCollectionXXXTsvStringXXX should not use Context#valueSeparator but Comma/Tab FIX

- Currently CsvStringList.parse fails on spaces before quoted tokens, and does not trim spaces in unquoted tokens.