### PR TITLE
SpreadsheetMetadata.XXXConverterContext BinaryTextContext replaces in…

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -67,6 +67,7 @@ import walkingkooka.storage.HasUserDirectorieses;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
+import walkingkooka.text.TextPrinting;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.Parsers;
@@ -361,17 +362,18 @@ public class TestGwtTest extends GWTTestCase {
                         CaseSensitivity.INSENSITIVE,
                         metadata.spreadsheetConverterContext(
                             SpreadsheetMetadata.NO_CELL,
-                            StandardCharsets.UTF_8,
                             SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                             HasUserDirectorieses.empty(),
-                            Indentation.SPACES2,
                             LABEL_NAME_RESOLVER,
-                            lineEnding,
                             MEDIA_TYPE_DETECTOR,
                             BinaryNumberConverterFunctions.fake(),
                             SpreadsheetMetadataLoaders.fake(),
                             converterProvider,
+                            TextPrinting.with(
+                                Indentation.SPACES2,
+                                lineEnding
+                            ).setCharset(StandardCharsets.UTF_8),
                             currencyContext.setLocaleContext(this.localeContext),
                             providerContext
                         ),
@@ -420,17 +422,18 @@ public class TestGwtTest extends GWTTestCase {
                     value,
                     metadata.spreadsheetFormatterContext(
                         Optional.of(cell),
-                        StandardCharsets.UTF_8,
                         (final Optional<Object> v) -> {
                             throw new UnsupportedOperationException();
                         },
                         HasUserDirectorieses.empty(),
-                        Indentation.SPACES2,
                         LABEL_NAME_RESOLVER,
-                        lineEnding,
                         MEDIA_TYPE_DETECTOR,
                         BinaryNumberConverterFunctions.fake(),
-                        SpreadsheetMetadataLoaders.empty(),
+                        SpreadsheetMetadataLoaders.fake(),
+                        TextPrinting.with(
+                            Indentation.SPACES2,
+                            lineEnding
+                        ).setCharset(StandardCharsets.UTF_8),
                         currencyContext.setLocaleContext(this.localeContext),
                         SpreadsheetProviders.basic(
                             converterProvider,

--- a/src/it/j2cl-test/src/test/java/test/J2clTest.java
+++ b/src/it/j2cl-test/src/test/java/test/J2clTest.java
@@ -85,6 +85,7 @@ import walkingkooka.storage.HasUserDirectorieses;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
+import walkingkooka.text.TextPrinting;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.Parsers;
@@ -375,17 +376,18 @@ public class J2clTest {
                         CaseSensitivity.INSENSITIVE,
                         metadata.spreadsheetConverterContext(
                             SpreadsheetMetadata.NO_CELL,
-                            StandardCharsets.UTF_8,
                             SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                             HasUserDirectorieses.empty(),
-                            Indentation.SPACES2,
                             LABEL_NAME_RESOLVER,
-                            lineEnding,
                             MEDIA_TYPE_DETECTOR,
                             BinaryNumberConverterFunctions.fake(),
                             SpreadsheetMetadataLoaders.fake(),
                             converterProvider,
+                            TextPrinting.with(
+                                Indentation.SPACES2,
+                                lineEnding
+                            ).setCharset(StandardCharsets.UTF_8),
                             currencyContext.setLocaleContext(this.localeContext),
                             providerContext
                         ),
@@ -434,18 +436,18 @@ public class J2clTest {
                     value,
                     metadata.spreadsheetFormatterContext(
                         Optional.of(cell),
-                        StandardCharsets.UTF_8,
                         (final Optional<Object> v) -> {
                             throw new UnsupportedOperationException();
                         },
                         HasUserDirectorieses.empty(),
-                        Indentation.SPACES2,
                         LABEL_NAME_RESOLVER,
-                        lineEnding,
                         MEDIA_TYPE_DETECTOR,
                         BinaryNumberConverterFunctions.fake(),
                         SpreadsheetMetadataLoaders.fake(),
-                        SpreadsheetMetadataLoaders.empty(),
+                        TextPrinting.with(
+                            Indentation.SPACES2,
+                            lineEnding
+                        ).setCharset(StandardCharsets.UTF_8),
                         currencyContext.setLocaleContext(this.localeContext),
                         SpreadsheetProviders.basic(
                             converterProvider,

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngine.java
@@ -823,15 +823,13 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
             comparators,
             movedFromTo, // moved cells
             metadata.sortSpreadsheetComparatorContext(
-                context.charset(),
                 context, // HasUserDirectories
-                context.indentation(),
                 context, // ConverterProvider
-                context.lineEnding(),
                 context, // mediaTypeDetector
                 context.multiplier(), // multiplier
                 context, // SpreadsheetLabelNameResolver
                 context, // SpreadsheetMetadataLoader
+                context, // BinaryTextContext
                 context, // CurrencyLocaleContext
                 providerContext// ProviderContext
             )
@@ -1886,7 +1884,6 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                         context.spreadsheetMetadata()
                             .spreadsheetValidatorContext(
                                 cell.reference(), // reference
-                                context.charset(),
                                 (final ValidatorSelector v) -> context.validator(
                                     v,
                                     providerContext
@@ -1900,13 +1897,12 @@ final class BasicSpreadsheetEngine implements SpreadsheetEngine {
                                     Optional.ofNullable(value)
                                 ),
                                 context, // HasUserDirectories
-                                context.indentation(),
                                 context, // SpreadsheetLabelNameResolver
-                                context.lineEnding(),
                                 context, // MediaTypeDetector
                                 context.multiplier(), // multiplier
                                 context, // SpreadsheetMetadataLoader,
                                 context, // ConverterProvider
+                                context, // BinaryTextContext
                                 context, // CurrencyLocaleContext
                                 providerContext // ProviderContext
                             )

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextSharedSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineContextSharedSpreadsheetContext.java
@@ -143,16 +143,14 @@ final class SpreadsheetEngineContextSharedSpreadsheetContext extends Spreadsheet
             this.converterLike = this.spreadsheetMetadata()
                 .spreadsheetConverterContext(
                     SpreadsheetMetadata.NO_CELL,
-                    spreadsheetContext.charset(),
                     SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                     this.mode.converter(),
                     this, // HasUserDirectories
-                    this.indentation(),
                     this.spreadsheetLabelNameResolver,
-                    this.lineEnding(),
                     spreadsheetContext, // MediaTypeDetector
                     spreadsheetContext.multiplier(),
                     spreadsheetContext, // SpreadsheetMetadataLoader
+                    spreadsheetContext, // BinaryTextContext
                     spreadsheetContext, // CurrencyLocaleContext
                     spreadsheetContext, // SpreadsheetProvider
                     spreadsheetContext.providerContext()
@@ -320,7 +318,6 @@ final class SpreadsheetEngineContextSharedSpreadsheetContext extends Spreadsheet
         return this.spreadsheetMetadata()
             .spreadsheetFormatterContext(
                 cell,
-                context.charset(),
                 (final Optional<Object> v) -> this.setSpreadsheetMetadataMode(
                     SpreadsheetMetadataMode.FORMATTING
                 ).spreadsheetExpressionEvaluationContext(
@@ -331,12 +328,11 @@ final class SpreadsheetEngineContextSharedSpreadsheetContext extends Spreadsheet
                     v
                 ),
                 this, // HasUserDirectories
-                this.indentation(),
                 this, // SpreadsheetLabelNameResolver,
-                this.lineEnding(),
                 context, // MediaTypeDetector
                 context.multiplier(),
                 context, // SpreadsheetMetadataContext
+                context, // BinaryTextContext
                 context, // CurrencyLocaleContext
                 context, // spreadsheetProvider,
                 context.providerContext() // ProviderContext

--- a/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/expression/SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext.java
@@ -262,17 +262,15 @@ final class SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext exten
             this.spreadsheetConverterContext = this.spreadsheetMetadata()
                 .spreadsheetConverterContext(
                     this.cell,
-                    spreadsheetContext.charset(),
                     SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                     this.mode.converter(),
                     this, // HasUserDirectories
-                    this.indentation(),
                     this.spreadsheetLabelNameResolver,
-                    this.lineEnding(),
                     spreadsheetContext, // MediaTypeDetector
                     spreadsheetContext.multiplier(),
                     spreadsheetContext, // SpreadsheetMetadataLoader
                     spreadsheetContext, // SpreadsheetProvider, // SpreadsheetConverterProvider
+                    spreadsheetContext, // BinaryTextContext
                     spreadsheetContext, // CurrencyLocaleContext
                     spreadsheetContext.providerContext()
                 );
@@ -340,7 +338,6 @@ final class SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext exten
         return this.spreadsheetMetadata()
             .spreadsheetFormatterContext(
                 cell,
-                spreadsheetContext.charset(),
                 (final Optional<Object> v) -> this.setMode(
                     SpreadsheetMetadataMode.FORMATTING
                 ).addLocalVariable(
@@ -348,12 +345,11 @@ final class SpreadsheetExpressionEvaluationContextSharedSpreadsheetContext exten
                     v
                 ),
                 this, // HasUserDirectories
-                this.indentation(),
                 this.spreadsheetLabelNameResolver,
-                this.lineEnding(),
                 spreadsheetContext, // MediaTypeDetector
                 spreadsheetContext.multiplier(),
                 spreadsheetContext, // SpreadsheetMetadataLoader
+                spreadsheetContext, // BinaryTextContext
                 spreadsheetContext, // CurrencyLocaleContext
                 spreadsheetContext, // SpreadsheetProvider
                 spreadsheetContext.providerContext() // ProviderContext

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadata.java
@@ -108,10 +108,8 @@ import walkingkooka.spreadsheet.value.SpreadsheetCell;
 import walkingkooka.spreadsheet.viewport.AnchoredSpreadsheetSelection;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewport;
 import walkingkooka.storage.HasUserDirectories;
+import walkingkooka.text.BinaryTextContext;
 import walkingkooka.text.HasText;
-import walkingkooka.text.Indentation;
-import walkingkooka.text.LineEnding;
-import walkingkooka.text.TextPrinting;
 import walkingkooka.text.cursor.parser.InvalidCharacterExceptionFactory;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.Parsers;
@@ -150,7 +148,6 @@ import walkingkooka.validation.provider.ValidatorSelector;
 
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Currency;
 import java.util.List;
@@ -1007,28 +1004,24 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
     /**
      * Returns a {@link SpreadsheetComparatorContext} which may be used for sorting.
      */
-    public final SpreadsheetComparatorContext sortSpreadsheetComparatorContext(final Charset charset,
-                                                                               final HasUserDirectories hasUserDirectories,
-                                                                               final Indentation indentation,
+    public final SpreadsheetComparatorContext sortSpreadsheetComparatorContext(final HasUserDirectories hasUserDirectories,
                                                                                final SpreadsheetLabelNameResolver resolveIfLabel,
-                                                                               final LineEnding lineEnding,
                                                                                final MediaTypeDetector mediaTypeDetector,
                                                                                final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                                final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
                                                                                final SpreadsheetProvider spreadsheetProvider,
+                                                                               final BinaryTextContext binaryTextContext,
                                                                                final CurrencyLocaleContext currencyLocaleContext,
                                                                                final ProviderContext providerContext) {
         return this.spreadsheetComparatorContext(
             this.sortSpreadsheetConverterContext(
-                charset,
                 resolveIfLabel,
                 spreadsheetProvider, // ConverterProvider
                 hasUserDirectories,
-                indentation,
-                lineEnding,
                 mediaTypeDetector,
                 multiplier,
                 spreadsheetMetadataLoader,
+                binaryTextContext,
                 currencyLocaleContext,
                 providerContext // ProviderContext
             )
@@ -1038,30 +1031,26 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
     /**
      * Creates a {@link SpreadsheetConverterContext} to be used when doing a sort.
      */
-    private SpreadsheetConverterContext sortSpreadsheetConverterContext(final Charset charset,
-                                                                        final SpreadsheetLabelNameResolver labelNameResolver,
+    private SpreadsheetConverterContext sortSpreadsheetConverterContext(final SpreadsheetLabelNameResolver labelNameResolver,
                                                                         final ConverterProvider converterProvider,
                                                                         final HasUserDirectories hasUserDirectories,
-                                                                        final Indentation indentation,
-                                                                        final LineEnding lineEnding,
                                                                         final MediaTypeDetector mediaTypeDetector,
                                                                         final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                         final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
+                                                                        final BinaryTextContext binaryTextContext,
                                                                         final CurrencyLocaleContext currencyLocaleContext,
                                                                         final ProviderContext providerContext) {
         return this.spreadsheetConverterContext(
             NO_CELL,
-            charset,
             NO_VALIDATION_REFERENCE,
             SpreadsheetMetadataPropertyName.SORT_CONVERTER,
             hasUserDirectories,
-            indentation,
             labelNameResolver,
-            lineEnding,
             mediaTypeDetector,
             multiplier,
             spreadsheetMetadataLoader,
             converterProvider,
+            binaryTextContext,
             currencyLocaleContext,
             providerContext
         );
@@ -1084,31 +1073,27 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Returns a {@link SpreadsheetConverterContext}
      */
     public final SpreadsheetConverterContext spreadsheetConverterContext(final Optional<SpreadsheetCell> cell,
-                                                                         final Charset charset,
                                                                          final Optional<SpreadsheetValidationReference> validationReference,
                                                                          final SpreadsheetMetadataPropertyName<ConverterSelector> converterSelectorPropertyName,
                                                                          final HasUserDirectories hasUserDirectories,
-                                                                         final Indentation indentation,
                                                                          final SpreadsheetLabelNameResolver labelNameResolver,
-                                                                         final LineEnding lineEnding,
                                                                          final MediaTypeDetector mediaTypeDetector,
                                                                          final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                          final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
                                                                          final ConverterProvider converterProvider,
+                                                                         final BinaryTextContext binaryTextContext,
                                                                          final CurrencyLocaleContext currencyLocaleContext,
                                                                          final ProviderContext providerContext) {
         Objects.requireNonNull(cell, "cell");
-        Objects.requireNonNull(charset, "charset");
         Objects.requireNonNull(validationReference, "validationReference");
         Objects.requireNonNull(converterSelectorPropertyName, "converterSelectorPropertyName");
         Objects.requireNonNull(hasUserDirectories, "hasUserDirectories");
-        Objects.requireNonNull(indentation, "indentation");
         Objects.requireNonNull(labelNameResolver, "labelNameResolver");
-        Objects.requireNonNull(lineEnding, "lineEnding");
         Objects.requireNonNull(mediaTypeDetector, "mediaTypeDetector");
         Objects.requireNonNull(multiplier, "multiplier");
         Objects.requireNonNull(spreadsheetMetadataLoader, "spreadsheetMetadataLoader");
         Objects.requireNonNull(converterProvider, "converterProvider");
+        Objects.requireNonNull(binaryTextContext, "binaryTextContext");
         Objects.requireNonNull(currencyLocaleContext, "currencyLocaleContext");
         Objects.requireNonNull(providerContext, "providerContext");
 
@@ -1192,10 +1177,7 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
                         valueSeparator, // valueSeparator
                         Converters.fake(),
                         BinaryNumberConverterFunctions.fake(),
-                        TextPrinting.with(
-                            indentation,
-                            lineEnding
-                        ).setCharset(charset),
+                        binaryTextContext,
                         currencyLocaleContext,
                         dateTimeContext,
                         decimalNumberContext
@@ -1263,28 +1245,24 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Creates a {@link SpreadsheetFormatterContext}.
      */
     public final SpreadsheetFormatterContext spreadsheetFormatterContext(final Optional<SpreadsheetCell> cell,
-                                                                         final Charset charset,
                                                                          final Function<Optional<Object>, SpreadsheetExpressionEvaluationContext> spreadsheetExpressionEvaluationContext,
                                                                          final HasUserDirectories hasUserDirectories,
-                                                                         final Indentation indentation,
                                                                          final SpreadsheetLabelNameResolver labelNameResolver,
-                                                                         final LineEnding lineEnding,
                                                                          final MediaTypeDetector mediaTypeDetector,
                                                                          final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                          final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
+                                                                         final BinaryTextContext binaryTextContext,
                                                                          final CurrencyLocaleContext currencyLocaleContext,
                                                                          final SpreadsheetProvider spreadsheetProvider,
                                                                          final ProviderContext providerContext) {
         Objects.requireNonNull(cell, "cell");
-        Objects.requireNonNull(charset, "charset");
         Objects.requireNonNull(spreadsheetExpressionEvaluationContext, "spreadsheetExpressionEvaluationContext");
         Objects.requireNonNull(hasUserDirectories, "hasUserDirectories");
-        Objects.requireNonNull(indentation, "indentation");
         Objects.requireNonNull(labelNameResolver, "labelNameResolver");
-        Objects.requireNonNull(lineEnding, "lineEnding");
         Objects.requireNonNull(mediaTypeDetector, "mediaTypeDetector");
         Objects.requireNonNull(multiplier, "multiplier");
         Objects.requireNonNull(spreadsheetMetadataLoader, "spreadsheetMetadataLoader");
+        Objects.requireNonNull(binaryTextContext, "binaryTextContext");
         Objects.requireNonNull(currencyLocaleContext, "currencyLocaleContext");
         Objects.requireNonNull(spreadsheetProvider, "spreadsheetProvider");
         Objects.requireNonNull(providerContext, "providerContext");
@@ -1306,17 +1284,15 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         try {
             formatSpreadsheetConverterContext = this.spreadsheetConverterContext(
                 cell,
-                charset,
                 NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.FORMATTING_CONVERTER,
                 hasUserDirectories,
-                indentation,
                 labelNameResolver,
-                lineEnding,
                 mediaTypeDetector,
                 multiplier,
                 spreadsheetMetadataLoader,
                 spreadsheetProvider,
+                binaryTextContext,
                 currencyLocaleContext,
                 providerContext
             );
@@ -1348,30 +1324,26 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Creates a {@link SpreadsheetFormatterContext}.
      */
     public final SpreadsheetFormatterProviderSamplesContext spreadsheetFormatterProviderSamplesContext(final Optional<SpreadsheetCell> cell,
-                                                                                                       final Charset charset,
                                                                                                        final Function<Optional<Object>, SpreadsheetExpressionEvaluationContext> spreadsheetExpressionEvaluationContext,
                                                                                                        final HasUserDirectories hasUserDirectories,
-                                                                                                       final Indentation indentation,
                                                                                                        final SpreadsheetLabelNameResolver labelNameResolver,
-                                                                                                       final LineEnding lineEnding,
                                                                                                        final MediaTypeDetector mediaTypeDetector,
                                                                                                        final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                                                        final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
+                                                                                                       final BinaryTextContext binaryTextContext,
                                                                                                        final CurrencyLocaleContext currencyLocaleContext,
                                                                                                        final SpreadsheetProvider spreadsheetProvider,
                                                                                                        final ProviderContext providerContext) {
         return SpreadsheetFormatterProviderSamplesContexts.basic(
             this.spreadsheetFormatterContext(
                 cell,
-                charset,
                 spreadsheetExpressionEvaluationContext,
                 hasUserDirectories,
-                indentation,
                 labelNameResolver,
-                lineEnding,
                 mediaTypeDetector,
                 multiplier,
                 spreadsheetMetadataLoader,
+                binaryTextContext,
                 currencyLocaleContext,
                 spreadsheetProvider,
                 providerContext
@@ -1470,31 +1442,27 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
      * Creates a {@link SpreadsheetValidatorContext} with the given {@link SpreadsheetCellReference}.
      */
     public final SpreadsheetValidatorContext spreadsheetValidatorContext(final SpreadsheetValidationReference cellOrLabel,
-                                                                         final Charset charset,
                                                                          final Function<ValidatorSelector, Validator<SpreadsheetValidationReference, SpreadsheetValidatorContext>> validatorSelectorToValidator,
                                                                          final BiFunction<Object, SpreadsheetValidationReference, SpreadsheetExpressionEvaluationContext> referenceToExpressionEvaluationContext,
                                                                          final HasUserDirectories hasUserDirectories,
-                                                                         final Indentation indentation,
                                                                          final SpreadsheetLabelNameResolver labelNameResolver,
-                                                                         final LineEnding lineEnding,
                                                                          final MediaTypeDetector mediaTypeDetector,
                                                                          final BinaryNumberConverterFunction<SpreadsheetConverterContext> multiplier,
                                                                          final SpreadsheetMetadataLoader spreadsheetMetadataLoader,
                                                                          final ConverterProvider converterProvider,
+                                                                         final BinaryTextContext binaryTextContext,
                                                                          final CurrencyLocaleContext currencyLocaleContext,
                                                                          final ProviderContext providerContext) {
         Objects.requireNonNull(cellOrLabel, "cellOrLabel");
-        Objects.requireNonNull(charset, "charset");
         Objects.requireNonNull(validatorSelectorToValidator, "validatorSelectorToValidator");
         Objects.requireNonNull(referenceToExpressionEvaluationContext, "referenceToExpressionEvaluationContext");
         Objects.requireNonNull(hasUserDirectories, "hasUserDirectories");
-        Objects.requireNonNull(indentation, "indentation");
         Objects.requireNonNull(labelNameResolver, "labelNameResolver");
-        Objects.requireNonNull(lineEnding, "lineEnding");
         Objects.requireNonNull(mediaTypeDetector, "mediaTypeDetector");
         Objects.requireNonNull(multiplier, "multiplier");
         Objects.requireNonNull(spreadsheetMetadataLoader, "spreadsheetMetadataLoader");
         Objects.requireNonNull(converterProvider, "converterProvider");
+        Objects.requireNonNull(binaryTextContext, "binaryTextContext");
         Objects.requireNonNull(currencyLocaleContext, "currencyLocaleContext");
         Objects.requireNonNull(providerContext, "providerContext");
 
@@ -1504,17 +1472,15 @@ public abstract class SpreadsheetMetadata implements CanBeEmpty,
         try {
             spreadsheetConverterContext = this.spreadsheetConverterContext(
                 NO_CELL,
-                charset,
                 Optional.of(cellOrLabel), // validationReference
                 SpreadsheetMetadataPropertyName.VALIDATION_CONVERTER,
                 hasUserDirectories,
-                indentation,
                 labelNameResolver,
-                lineEnding,
                 mediaTypeDetector,
                 multiplier,
                 spreadsheetMetadataLoader,
                 converterProvider,
+                binaryTextContext,
                 currencyLocaleContext,
                 providerContext
             );

--- a/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTesting.java
@@ -614,17 +614,15 @@ public interface SpreadsheetMetadataTesting extends BinaryTextContextTesting,
 
     SpreadsheetConverterContext SPREADSHEET_FORMULA_CONVERTER_CONTEXT = METADATA_EN_AU.spreadsheetConverterContext(
         SpreadsheetMetadata.NO_CELL,
-        CHARSET,
         SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
         SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
         HAS_USER_DIRECTORIES,
-        INDENTATION,
         SPREADSHEET_LABEL_NAME_RESOLVER,
-        LINE_ENDING,
         MEDIA_TYPE_DETECTOR,
         MULTIPLIER,
         SPREADSHEET_METADATA_LOADER,
         CONVERTER_PROVIDER,
+        BINARY_TEXT_CONTEXT,
         CURRENCY_LOCALE_CONTEXT,
         PROVIDER_CONTEXT
     );
@@ -655,15 +653,13 @@ public interface SpreadsheetMetadataTesting extends BinaryTextContextTesting,
 
     SpreadsheetFormatterContext SPREADSHEET_FORMATTER_CONTEXT = METADATA_EN_AU.spreadsheetFormatterContext(
         SpreadsheetMetadata.NO_CELL,
-        CHARSET,
         FORMATTER_CONTEXT_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT_BI_FUNCTION,
         HAS_USER_DIRECTORIES,
-        INDENTATION,
         SPREADSHEET_LABEL_NAME_RESOLVER,
-        LINE_ENDING,
         MEDIA_TYPE_DETECTOR,
         MULTIPLIER,
         SPREADSHEET_METADATA_LOADER,
+        BINARY_TEXT_CONTEXT,
         CURRENCY_LOCALE_CONTEXT,
         SPREADSHEET_PROVIDER,
         PROVIDER_CONTEXT
@@ -671,15 +667,13 @@ public interface SpreadsheetMetadataTesting extends BinaryTextContextTesting,
 
     SpreadsheetFormatterProviderSamplesContext SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT = METADATA_EN_AU.spreadsheetFormatterProviderSamplesContext(
         SpreadsheetMetadata.NO_CELL,
-        CHARSET,
         FORMATTER_CONTEXT_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT_BI_FUNCTION,
         HAS_USER_DIRECTORIES,
-        INDENTATION,
         SPREADSHEET_LABEL_NAME_RESOLVER,
-        LINE_ENDING,
         MEDIA_TYPE_DETECTOR,
         MULTIPLIER,
         SPREADSHEET_METADATA_LOADER,
+        BINARY_TEXT_CONTEXT,
         CURRENCY_LOCALE_CONTEXT,
         SPREADSHEET_PROVIDER,
         PROVIDER_CONTEXT

--- a/src/test/java/walkingkooka/spreadsheet/format/provider/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/provider/SpreadsheetFormattersSpreadsheetFormatterProviderTest.java
@@ -45,7 +45,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetExpressionReferenceLoaders;
 import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
 import walkingkooka.spreadsheet.store.repo.FakeSpreadsheetStoreRepository;
 import walkingkooka.spreadsheet.value.SpreadsheetErrorKind;
-import walkingkooka.text.Indentation;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContexts;
@@ -113,7 +112,6 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
         SPREADSHEET_FORMATTER_PROVIDER_SAMPLES_CONTEXT = SpreadsheetFormatterProviderSamplesContexts.basic(
             METADATA_EN_AU.spreadsheetFormatterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 (Optional<Object> value) -> SpreadsheetExpressionEvaluationContexts.spreadsheetContext(
                     SpreadsheetMetadataMode.FORMULA,
                     SpreadsheetMetadata.NO_CELL,
@@ -153,12 +151,11 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
                     TERMINAL_CONTEXT
                 ),
                 HAS_USER_DIRECTORIES,
-                Indentation.SPACES2,
                 SPREADSHEET_LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 SPREADSHEET_PROVIDER,
                 PROVIDER_CONTEXT
@@ -4755,15 +4752,13 @@ public final class SpreadsheetFormattersSpreadsheetFormatterProviderTest impleme
                     SpreadsheetFormula.EMPTY.setValue(value)
                 )
             ),
-            CHARSET,
             FORMATTER_CONTEXT_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT_BI_FUNCTION,
             HAS_USER_DIRECTORIES,
-            Indentation.SPACES2,
             SPREADSHEET_LABEL_NAME_RESOLVER,
-            LINE_ENDING,
             MEDIA_TYPE_DETECTOR,
             MULTIPLIER,
             SPREADSHEET_METADATA_LOADER,
+            BINARY_TEXT_CONTEXT,
             CURRENCY_LOCALE_CONTEXT,
             SPREADSHEET_PROVIDER,
             PROVIDER_CONTEXT

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataEmptyTest.java
@@ -251,7 +251,6 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
             IllegalStateException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetValidatorContext(
                 SpreadsheetSelection.A1,
-                CHARSET,
                 (final ValidatorSelector validatorSelector) -> {
                     throw new UnsupportedOperationException();
                 },
@@ -260,13 +259,12 @@ public final class SpreadsheetMetadataEmptyTest extends SpreadsheetMetadataTestC
                     throw new UnsupportedOperationException();
                 },
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataNonEmptyTest.java
@@ -2053,17 +2053,15 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
             null,
             metadata.spreadsheetFormatterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 (final Optional<Object> value) -> {
                     throw new UnsupportedOperationException();
                 },
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 SpreadsheetProviders.basic(
                     SpreadsheetConvertersConverterProviders.spreadsheetConverters(
@@ -2104,17 +2102,15 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
             null,
             metadata.spreadsheetFormatterProviderSamplesContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 (final Optional<Object> v) -> {
                     throw new UnsupportedOperationException();
                 },
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 SpreadsheetProviders.basic(
                     SpreadsheetConvertersConverterProviders.spreadsheetConverters(
@@ -2440,7 +2436,6 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                 ','
             ).spreadsheetValidatorContext(
                 cellOrLabel,
-                CHARSET,
                 (final ValidatorSelector validatorSelector) -> {
                     throw new UnsupportedOperationException();
                 },
@@ -2449,13 +2444,12 @@ public final class SpreadsheetMetadataNonEmptyTest extends SpreadsheetMetadataTe
                     throw new UnsupportedOperationException();
                 },
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 ConverterProviders.converters(),
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTest.java
@@ -930,63 +930,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 null,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
-                CURRENCY_LOCALE_CONTEXT,
-                PROVIDER_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testSpreadsheetConverterContextWithNullCharsetFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
-                SpreadsheetMetadata.NO_CELL,
-                null, // charset
-                SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
-                SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
-                HAS_USER_DIRECTORIES,
-                INDENTATION,
-                LABEL_NAME_RESOLVER,
-                LINE_ENDING,
-                MEDIA_TYPE_DETECTOR,
-                MULTIPLIER,
-                SPREADSHEET_METADATA_LOADER,
-                CONVERTER_PROVIDER,
-                CURRENCY_LOCALE_CONTEXT,
-                PROVIDER_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testSpreadsheetConverterContextWithNullIndentationFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
-                SpreadsheetMetadata.NO_CELL,
-                CHARSET,
-                SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
-                SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
-                HAS_USER_DIRECTORIES,
-                null,
-                LABEL_NAME_RESOLVER,
-                LINE_ENDING,
-                MEDIA_TYPE_DETECTOR,
-                MULTIPLIER,
-                SPREADSHEET_METADATA_LOADER,
-                CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -999,17 +951,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 null,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1022,17 +972,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 null,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1045,17 +993,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 null,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1068,40 +1014,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
-                null,
-                LINE_ENDING,
-                MEDIA_TYPE_DETECTOR,
-                MULTIPLIER,
-                SPREADSHEET_METADATA_LOADER,
-                CONVERTER_PROVIDER,
-                CURRENCY_LOCALE_CONTEXT,
-                PROVIDER_CONTEXT
-            )
-        );
-    }
-
-    @Test
-    public void testSpreadsheetConverterContextWithNullLineEndingFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
-                SpreadsheetMetadata.NO_CELL,
-                CHARSET,
-                SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
-                SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
-                HAS_USER_DIRECTORIES,
-                INDENTATION,
-                LABEL_NAME_RESOLVER,
                 null,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1114,17 +1035,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 null,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1137,17 +1056,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 null,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1160,17 +1077,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 null,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1183,16 +1098,35 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
+                null,
+                BINARY_TEXT_CONTEXT,
+                CURRENCY_LOCALE_CONTEXT,
+                PROVIDER_CONTEXT
+            )
+        );
+    }
+
+    @Test
+    public void testSpreadsheetConverterContextWithNullBinaryTextContextFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
+                SpreadsheetMetadata.NO_CELL,
+                SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
+                SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
+                HAS_USER_DIRECTORIES,
+                LABEL_NAME_RESOLVER,
+                MEDIA_TYPE_DETECTOR,
+                MULTIPLIER,
+                SPREADSHEET_METADATA_LOADER,
+                CONVERTER_PROVIDER,
                 null,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
@@ -1206,17 +1140,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 null,
                 PROVIDER_CONTEXT
             )
@@ -1229,17 +1161,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             NullPointerException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 null
             )
@@ -1252,17 +1182,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
             IllegalStateException.class,
             () -> SpreadsheetMetadata.EMPTY.spreadsheetConverterContext(
                 SpreadsheetMetadata.NO_CELL,
-                CHARSET,
                 SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                 SpreadsheetMetadataPropertyName.QUERY_CONVERTER,
                 HAS_USER_DIRECTORIES,
-                INDENTATION,
                 LABEL_NAME_RESOLVER,
-                LINE_ENDING,
                 MEDIA_TYPE_DETECTOR,
                 MULTIPLIER,
                 SPREADSHEET_METADATA_LOADER,
                 CONVERTER_PROVIDER,
+                BINARY_TEXT_CONTEXT,
                 CURRENCY_LOCALE_CONTEXT,
                 PROVIDER_CONTEXT
             )
@@ -1335,17 +1263,15 @@ public final class SpreadsheetMetadataTest implements BinaryTextContextTesting,
 
         final SpreadsheetConverterContext context = metadata.spreadsheetConverterContext(
             Optional.of(cell),
-            CHARSET,
             SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
             HAS_USER_DIRECTORIES,
-            INDENTATION,
             LABEL_NAME_RESOLVER,
-            LINE_ENDING,
             MEDIA_TYPE_DETECTOR,
             MULTIPLIER,
             SPREADSHEET_METADATA_LOADER,
             ConverterProviders.converters(),
+            BINARY_TEXT_CONTEXT,
             CURRENCY_LOCALE_CONTEXT,
             PROVIDER_CONTEXT
         );

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestCase.java
@@ -785,41 +785,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     null,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
-                    CURRENCY_LOCALE_CONTEXT,
-                    PROVIDER_CONTEXT
-                )
-        );
-    }
-
-    @Test
-    public final void testSpreadsheetValidatorContextWithNullCharsetFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> this.createObject()
-                .spreadsheetValidatorContext(
-                    SpreadsheetSelection.A1,
-                    null,
-                    VALIDATOR_SELECTOR_TO_VALIDATOR,
-                    VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
-                    HAS_USER_DIRECTORIES,
-                    INDENTATION,
-                    LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
-                    MEDIA_TYPE_DETECTOR,
-                    MULTIPLIER,
-                    SPREADSHEET_METADATA_LOADER,
-                    CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -833,17 +807,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     null,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -857,17 +829,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     null,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -881,41 +851,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     null,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
-                    CURRENCY_LOCALE_CONTEXT,
-                    PROVIDER_CONTEXT
-                )
-        );
-    }
-
-    @Test
-    public final void testSpreadsheetValidatorContextWithNullIndentationFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> this.createObject()
-                .spreadsheetValidatorContext(
-                    SpreadsheetSelection.A1,
-                    CHARSET,
-                    VALIDATOR_SELECTOR_TO_VALIDATOR,
-                    VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
-                    HAS_USER_DIRECTORIES,
-                    null,
-                    LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
-                    MEDIA_TYPE_DETECTOR,
-                    MULTIPLIER,
-                    SPREADSHEET_METADATA_LOADER,
-                    CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -929,41 +873,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
-                    null,
-                    LINE_ENDING,
-                    MEDIA_TYPE_DETECTOR,
-                    MULTIPLIER,
-                    SPREADSHEET_METADATA_LOADER,
-                    CONVERTER_PROVIDER,
-                    CURRENCY_LOCALE_CONTEXT,
-                    PROVIDER_CONTEXT
-                )
-        );
-    }
-
-    @Test
-    public final void testSpreadsheetValidatorContextWithLineEndingFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> this.createObject()
-                .spreadsheetValidatorContext(
-                    SpreadsheetSelection.A1,
-                    CHARSET,
-                    VALIDATOR_SELECTOR_TO_VALIDATOR,
-                    VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
-                    HAS_USER_DIRECTORIES,
-                    INDENTATION,
-                    LABEL_NAME_RESOLVER,
                     null,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -977,17 +895,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     null,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -1001,17 +917,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     null,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -1025,17 +939,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     null,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
                 )
@@ -1049,16 +961,36 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
+                    null,
+                    BINARY_TEXT_CONTEXT,
+                    CURRENCY_LOCALE_CONTEXT,
+                    PROVIDER_CONTEXT
+                )
+        );
+    }
+
+    @Test
+    public final void testSpreadsheetValidatorContextWithBinaryTextContextFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createObject()
+                .spreadsheetValidatorContext(
+                    SpreadsheetSelection.A1,
+                    VALIDATOR_SELECTOR_TO_VALIDATOR,
+                    VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
+                    HAS_USER_DIRECTORIES,
+                    LABEL_NAME_RESOLVER,
+                    MEDIA_TYPE_DETECTOR,
+                    MULTIPLIER,
+                    SPREADSHEET_METADATA_LOADER,
+                    CONVERTER_PROVIDER,
                     null,
                     CURRENCY_LOCALE_CONTEXT,
                     PROVIDER_CONTEXT
@@ -1073,17 +1005,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     null,
                     PROVIDER_CONTEXT
                 )
@@ -1097,17 +1027,15 @@ public abstract class SpreadsheetMetadataTestCase<T extends SpreadsheetMetadata>
             () -> this.createObject()
                 .spreadsheetValidatorContext(
                     SpreadsheetSelection.A1,
-                    CHARSET,
                     VALIDATOR_SELECTOR_TO_VALIDATOR,
                     VALUE_N_REFERENCE_TO_SPREADSHEET_EXPRESSION_EVALUATION_CONTEXT,
                     HAS_USER_DIRECTORIES,
-                    INDENTATION,
                     LABEL_NAME_RESOLVER,
-                    LINE_ENDING,
                     MEDIA_TYPE_DETECTOR,
                     MULTIPLIER,
                     SPREADSHEET_METADATA_LOADER,
                     CONVERTER_PROVIDER,
+                    BINARY_TEXT_CONTEXT,
                     CURRENCY_LOCALE_CONTEXT,
                     null
                 )

--- a/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/meta/SpreadsheetMetadataTestingTest.java
@@ -34,7 +34,6 @@ import walkingkooka.spreadsheet.environment.SpreadsheetEnvironmentContextTesting
 import walkingkooka.spreadsheet.formula.SpreadsheetFormula;
 import walkingkooka.spreadsheet.formula.parser.SpreadsheetFormulaParserToken;
 import walkingkooka.storage.HasUserDirectorieses;
-import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
 import walkingkooka.text.printer.TreePrintableTesting;
 
@@ -99,17 +98,15 @@ public final class SpreadsheetMetadataTestingTest implements SpreadsheetMetadata
 
         final SpreadsheetConverterContext converterContext = METADATA_EN_AU.spreadsheetConverterContext(
             SpreadsheetMetadata.NO_CELL,
-            SpreadsheetMetadataTestingTest.CHARSET,
             SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
             SpreadsheetMetadataPropertyName.SCRIPTING_CONVERTER,
             HasUserDirectorieses.empty(), // no current working directory
-            INDENTATION,
             SPREADSHEET_LABEL_NAME_RESOLVER,
-            LINE_ENDING,
             MEDIA_TYPE_DETECTOR,
             MULTIPLIER,
             SPREADSHEET_METADATA_LOADER,
             CONVERTER_PROVIDER,
+            BINARY_TEXT_CONTEXT,
             CURRENCY_LOCALE_CONTEXT,
             PROVIDER_CONTEXT
         );
@@ -293,17 +290,15 @@ public final class SpreadsheetMetadataTestingTest implements SpreadsheetMetadata
     public void testSpreadsheetFormatterContext() {
         METADATA_EN_AU.spreadsheetFormatterContext(
             SpreadsheetMetadata.NO_CELL,
-            CHARSET,
             (final Optional<Object> value) -> {
                 throw new UnsupportedOperationException();
             },
             HAS_USER_DIRECTORIES,
-            Indentation.SPACES2,
             SPREADSHEET_LABEL_NAME_RESOLVER,
-            LINE_ENDING,
             MEDIA_TYPE_DETECTOR,
             MULTIPLIER,
             SPREADSHEET_METADATA_LOADER,
+            BINARY_TEXT_CONTEXT,
             CURRENCY_LOCALE_CONTEXT,
             SPREADSHEET_PROVIDER,
             PROVIDER_CONTEXT

--- a/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/sample/Sample.java
@@ -84,6 +84,7 @@ import walkingkooka.storage.HasUserDirectorieses;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
+import walkingkooka.text.TextPrinting;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.Parsers;
@@ -374,17 +375,18 @@ public final class Sample {
                         CaseSensitivity.INSENSITIVE,
                         metadata.spreadsheetConverterContext(
                             SpreadsheetMetadata.NO_CELL,
-                            StandardCharsets.UTF_8,
                             SpreadsheetMetadata.NO_VALIDATION_REFERENCE,
                             SpreadsheetMetadataPropertyName.FORMULA_CONVERTER,
                             HasUserDirectorieses.empty(),
-                            Indentation.SPACES2,
                             LABEL_NAME_RESOLVER,
-                            lineEnding,
                             MEDIA_TYPE_DETECTOR,
                             BinaryNumberConverterFunctions.fake(),
                             SpreadsheetMetadataLoaders.fake(),
                             converterProvider,
+                            TextPrinting.with(
+                                Indentation.SPACES2,
+                                lineEnding
+                            ).setCharset(StandardCharsets.UTF_8),
                             currencyContext.setLocaleContext(this.localeContext),
                             providerContext
                         ),
@@ -433,17 +435,18 @@ public final class Sample {
                     value,
                     metadata.spreadsheetFormatterContext(
                         Optional.of(cell),
-                        StandardCharsets.UTF_8,
                         (final Optional<Object> v) -> {
                             throw new UnsupportedOperationException();
                         },
                         HasUserDirectorieses.empty(),
-                        Indentation.SPACES2,
                         LABEL_NAME_RESOLVER,
-                        lineEnding,
                         MEDIA_TYPE_DETECTOR,
                         BinaryNumberConverterFunctions.fake(),
                         SpreadsheetMetadataLoaders.fake(),
+                        TextPrinting.with(
+                            Indentation.SPACES2,
+                            lineEnding
+                        ).setCharset(StandardCharsets.UTF_8),
                         currencyContext.setLocaleContext(this.localeContext),
                         SpreadsheetProviders.basic(
                             converterProvider,


### PR DESCRIPTION
…line parameters

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9477
- SpreadsheetMetadata.spreadsheetConverterContext BinaryTextContext replaces inline parameters