### PR TITLE
SpreadsheetComparator.extractValue

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/compare/FakeSpreadsheetComparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/FakeSpreadsheetComparator.java
@@ -18,6 +18,9 @@
 package walkingkooka.spreadsheet.compare;
 
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorName;
+import walkingkooka.spreadsheet.value.SpreadsheetCell;
+
+import java.util.Optional;
 
 public class FakeSpreadsheetComparator<T> implements SpreadsheetComparator<T> {
 
@@ -26,7 +29,8 @@ public class FakeSpreadsheetComparator<T> implements SpreadsheetComparator<T> {
     }
 
     @Override
-    public Class<T> type() {
+    public Optional<T> extractValue(final SpreadsheetCell cell,
+                                    final SpreadsheetComparatorContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparator.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparator.java
@@ -19,21 +19,22 @@ package walkingkooka.spreadsheet.compare;
 
 import walkingkooka.naming.HasName;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorName;
+import walkingkooka.spreadsheet.value.SpreadsheetCell;
 
 import java.util.Comparator;
+import java.util.Optional;
 
 /**
- * A {@link Comparator} that includes a type property. Sorting cells is a two phase operation, first all cell values are
- * converted to the {@link SpreadsheetComparator#type()} and then converted cell values are sorted using this {@link Comparator}.
- * Cells that could not be converted will be placed before or after the sorted list of cells.
+ * A {@link Comparator} that sorts value from a {@link SpreadsheetCell}
  */
 public interface SpreadsheetComparator<T> extends Comparator<T>,
     HasName<SpreadsheetComparatorName> {
 
     /**
-     * The type handled by this {@link Comparator}. This is used to convert the left/right values before calling {@link Comparator#compare(Object, Object)}.
+     * Extract a value from the given {@link SpreadsheetCell}.
      */
-    Class<T> type();
+    Optional<T> extractValue(final SpreadsheetCell cell,
+                             final SpreadsheetComparatorContext context);
 
     /**
      * Returns a reversed {@link SpreadsheetComparator}

--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorReverse.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorReverse.java
@@ -20,8 +20,10 @@ package walkingkooka.spreadsheet.compare;
 import walkingkooka.Cast;
 import walkingkooka.compare.Comparators;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorName;
+import walkingkooka.spreadsheet.value.SpreadsheetCell;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Wraps another {@link SpreadsheetComparator} and reverses the compare result.
@@ -41,8 +43,12 @@ final class SpreadsheetComparatorReverse<T> implements SpreadsheetComparator<T> 
     }
 
     @Override
-    public Class<T> type() {
-        return this.comparator.type();
+    public Optional<T> extractValue(final SpreadsheetCell cell,
+                                    final SpreadsheetComparatorContext context) {
+        return this.comparator.extractValue(
+            cell,
+            context
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorTesting.java
@@ -17,18 +17,101 @@
 
 package walkingkooka.spreadsheet.compare;
 
+import org.junit.jupiter.api.Test;
 import walkingkooka.compare.ComparatorTesting2;
 import walkingkooka.naming.HasNameTesting;
+import walkingkooka.spreadsheet.formula.SpreadsheetFormula;
+import walkingkooka.spreadsheet.reference.SpreadsheetSelection;
+import walkingkooka.spreadsheet.value.SpreadsheetCell;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface SpreadsheetComparatorTesting<C extends SpreadsheetComparator<T>, T> extends ComparatorTesting2<C, T>,
     HasNameTesting {
 
-    default <TT> void typeAndCheck(final SpreadsheetComparator<TT> comparator,
-                                   final Class<TT> expected) {
-        this.checkEquals(
-            expected,
-            comparator.type(),
-            comparator::toString
+    @Test
+    default void testExtractValueWithNullContextFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createComparator()
+                .extractValue(
+                    SpreadsheetSelection.A1.setFormula(
+                        SpreadsheetFormula.EMPTY
+                    ),
+                    null
+                )
         );
     }
+
+    default void extractValueAndCheck(final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context) {
+        this.extractValueAndCheck(
+            this.createComparator(),
+            cell,
+            context,
+            Optional.empty()
+        );
+    }
+
+    default void extractValueAndCheck(final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context,
+                                      final T expected) {
+        this.extractValueAndCheck(
+            this.createComparator(),
+            cell,
+            context,
+            Optional.of(expected)
+        );
+    }
+
+    default void extractValueAndCheck(final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context,
+                                      final Optional<T> expected) {
+        this.extractValueAndCheck(
+            this.createComparator(),
+            cell,
+            context,
+            expected
+        );
+    }
+
+    default void extractValueAndCheck(final SpreadsheetComparator<T> comparator,
+                                      final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context) {
+        this.extractValueAndCheck(
+            comparator,
+            cell,
+            context,
+            Optional.empty()
+        );
+    }
+
+    default void extractValueAndCheck(final SpreadsheetComparator<T> comparator,
+                                      final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context,
+                                      final T expected) {
+        this.extractValueAndCheck(
+            comparator,
+            cell,
+            context,
+            Optional.of(expected)
+        );
+    }
+
+    default void extractValueAndCheck(final SpreadsheetComparator<T> comparator,
+                                      final SpreadsheetCell cell,
+                                      final SpreadsheetComparatorContext context,
+                                      final Optional<T> expected) {
+        this.checkEquals(
+            expected,
+            comparator.extractValue(
+                cell,
+                context
+            )
+        );
+    }
+
+    SpreadsheetComparatorContext createContext();
 }

--- a/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorValue.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorValue.java
@@ -19,9 +19,11 @@ package walkingkooka.spreadsheet.compare;
 
 import walkingkooka.Cast;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorName;
+import walkingkooka.spreadsheet.value.SpreadsheetCell;
 
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Wraps a {@link Comparator} along with a {@link Class type}.
@@ -46,9 +48,22 @@ final class SpreadsheetComparatorValue<T> implements SpreadsheetComparator<T> {
         this.name = name;
     }
 
+    /**
+     * Extracts the value or error from the given {@link SpreadsheetCell}
+     */
     @Override
-    public Class<T> type() {
-        return this.type;
+    public Optional<T> extractValue(final SpreadsheetCell cell,
+                                    final SpreadsheetComparatorContext context) {
+        return Optional.ofNullable(
+            context.convert(
+                null != cell ?
+                    cell.formula().
+                        errorOrValue()
+                        .orElse(null) :
+                    null,
+                this.type
+            ).orElseLeft(null)
+        );
     }
 
     private final Class<T> type;

--- a/src/main/java/walkingkooka/spreadsheet/compare/provider/SpreadsheetColumnOrRowSpreadsheetComparators.java
+++ b/src/main/java/walkingkooka/spreadsheet/compare/provider/SpreadsheetColumnOrRowSpreadsheetComparators.java
@@ -96,43 +96,14 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparators {
                        final SpreadsheetComparatorContext context) {
         int result = Comparators.EQUAL;
 
-        final Object leftValue = valueOf(left);
-        final Object rightValue = valueOf(right);
-
         // try one by one, until a non equal match.
         for (final SpreadsheetComparator<?> comparator : this.comparators) {
-            final Class<?> type = comparator.type();
-
-            Object convertedLeftValue = null;
-            if (null != leftValue) {
-                convertedLeftValue = context.convert(
-                    leftValue,
-                    type
-                ).orElseLeft(null);
-            }
-
-            Object convertedRightValue = null;
-            if (null != rightValue) {
-                convertedRightValue = context.convert(
-                    rightValue,
-                    type
-                ).orElseLeft(null);
-            }
-
-            final boolean missingLeft = null == convertedLeftValue;
-            final boolean missingRight = null == convertedRightValue;
-            if (missingLeft || missingRight) {
-                result = missingLeft && missingRight ?
-                    Comparators.EQUAL :
-                    missingLeft ?
-                        Comparators.MORE :
-                        Comparators.LESS; // missing | nulls etc come AFTER
-            } else {
-                result = comparator.compare(
-                    Cast.to(convertedLeftValue),
-                    Cast.to(convertedRightValue)
-                );
-            }
+             result = compareValue(
+                Cast.to(comparator),
+                left,
+                right,
+                context
+            );
 
             if (Comparators.EQUAL != result) {
                 break;
@@ -142,12 +113,41 @@ public final class SpreadsheetColumnOrRowSpreadsheetComparators {
         return result;
     }
 
-    private static Object valueOf(final SpreadsheetCell cell) {
-        return null == cell ?
-            null :
-            cell.formula().
-                errorOrValue()
-                .orElse(null);
+    private static <T> int compareValue(final SpreadsheetComparator<T> comparator,
+                                        final SpreadsheetCell left,
+                                        final SpreadsheetCell right,
+                                        final SpreadsheetComparatorContext context) {
+        final T leftValue = comparator.extractValue(
+            left,
+            context
+        ).orElse(null);
+
+        final T rightValue = comparator.extractValue(
+            right,
+            context
+        ).orElse(null);
+
+        final boolean missingLeft = null == leftValue;
+        final boolean missingRight = null == rightValue;
+
+        int result = Comparators.EQUAL;
+
+        if (missingLeft || missingRight) {
+            result = missingLeft && missingRight ?
+                Comparators.EQUAL :
+                missingLeft ?
+                    Comparators.MORE :
+                    Comparators.LESS; // missing | nulls etc come AFTER
+        } else {
+            result = comparator.compare(
+                //Cast.to(convertedLeftValue),
+                //Cast.to(convertedRightValue)
+                leftValue,
+                rightValue
+            );
+        }
+
+        return result;
     }
 
     public SpreadsheetColumnOrRowReferenceOrRange columnOrRow() {

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorReverseTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorReverseTest.java
@@ -23,8 +23,6 @@ import walkingkooka.Cast;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 
-import java.time.LocalTime;
-
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,18 +58,6 @@ public final class SpreadsheetComparatorReverseTest implements SpreadsheetCompar
                     comparator
                 )
             )
-        );
-    }
-
-    @Test
-    public void testType() {
-        final SpreadsheetComparator<LocalTime> comparator = SpreadsheetComparators.hourOfDay();
-
-        this.typeAndCheck(
-            SpreadsheetComparators.reverse(
-                comparator
-            ),
-            LocalTime.class
         );
     }
 
@@ -127,6 +113,11 @@ public final class SpreadsheetComparatorReverseTest implements SpreadsheetCompar
                 SpreadsheetComparators.textCaseInsensitive()
             )
         );
+    }
+
+    @Override
+    public SpreadsheetComparatorContext createContext() {
+        return new FakeSpreadsheetComparatorContext();
     }
 
     // Class............................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorValueTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorValueTest.java
@@ -87,14 +87,6 @@ public final class SpreadsheetComparatorValueTest implements SpreadsheetComparat
     }
 
     @Test
-    public void testType() {
-        this.typeAndCheck(
-            this.createComparator(),
-            String.class
-        );
-    }
-
-    @Test
     public void testCompareLess() {
         this.compareAndCheckLess(
             "apple",
@@ -109,6 +101,22 @@ public final class SpreadsheetComparatorValueTest implements SpreadsheetComparat
             "Banana"
         );
     }
+
+    @Override
+    public SpreadsheetComparatorValue<String> createComparator() {
+        return SpreadsheetComparatorValue.with(
+            String.class,
+            String.CASE_INSENSITIVE_ORDER,
+            NAME
+        );
+    }
+
+    @Override
+    public SpreadsheetComparatorContext createContext() {
+        return new FakeSpreadsheetComparatorContext();
+    }
+
+    // hashCode/equals..................................................................................................
 
     @Test
     public void testEqualsDifferentComparator() {
@@ -163,16 +171,7 @@ public final class SpreadsheetComparatorValueTest implements SpreadsheetComparat
         );
     }
 
-    // Comparator.......................................................................................................
-
-    @Override
-    public SpreadsheetComparatorValue<String> createComparator() {
-        return SpreadsheetComparatorValue.with(
-            String.class,
-            String.CASE_INSENSITIVE_ORDER,
-            NAME
-        );
-    }
+    // class............................................................................................................
 
     @Override
     public Class<SpreadsheetComparatorValue<String>> type() {

--- a/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/compare/SpreadsheetComparatorsTest.java
@@ -27,7 +27,6 @@ import walkingkooka.reflect.PublicStaticHelperTesting;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorName;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorProvider;
 import walkingkooka.spreadsheet.compare.provider.SpreadsheetComparatorProviders;
-import walkingkooka.tree.expression.ExpressionNumber;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 
 import java.lang.reflect.Method;
@@ -47,7 +46,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testDate() {
         this.compareAndCheckLess(
             SpreadsheetComparators.date(),
-            LocalDate.class,
             LocalDate.of(1999, 1, 31),
             LocalDate.of(2001, 12, 1)
         );
@@ -57,7 +55,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testDate2() {
         this.compareAndCheckLess(
             SpreadsheetComparators.date(),
-            LocalDate.class,
             LocalDate.of(1999, 1, 1),
             LocalDate.of(2001, 2, 2)
         );
@@ -67,7 +64,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testDateTime() {
         this.compareAndCheckLess(
             SpreadsheetComparators.dateTime(),
-            LocalDateTime.class,
             LocalDateTime.of(1999, 1, 31, 12, 58, 59),
             LocalDateTime.of(2001, 12, 1, 12, 58, 59)
         );
@@ -77,7 +73,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testDayOfMonth() {
         this.compareAndCheckLess(
             SpreadsheetComparators.dayOfMonth(),
-            LocalDate.class,
             LocalDate.of(2001, 12, 1),
             LocalDate.of(1999, 1, 31)
         );
@@ -87,7 +82,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testDayOfWeek() {
         this.compareAndCheckLess(
             SpreadsheetComparators.dayOfWeek(),
-            LocalDate.class,
             LocalDate.of(2024, 4, 19),
             LocalDate.of(2024, 4, 20)
         );
@@ -97,7 +91,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testHourOfAmpm() {
         this.compareAndCheckLess(
             SpreadsheetComparators.hourOfAmPm(),
-            LocalTime.class,
             LocalTime.of(13, 1, 11),
             LocalTime.of(2, 2, 22)
         );
@@ -107,7 +100,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testHourOfDay() {
         this.compareAndCheckLess(
             SpreadsheetComparators.hourOfAmPm(),
-            LocalTime.class,
             LocalTime.of(1, 11, 11),
             LocalTime.of(2, 2, 2)
         );
@@ -117,7 +109,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testMinuteOfHour() {
         this.compareAndCheckLess(
             SpreadsheetComparators.minuteOfHour(),
-            LocalTime.class,
             LocalTime.of(13, 1, 11),
             LocalTime.of(2, 2, 22)
         );
@@ -127,7 +118,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testMonthOfYear() {
         this.compareAndCheckLess(
             SpreadsheetComparators.monthOfYear(),
-            LocalDate.class,
             LocalDate.of(2001, 1, 31),
             LocalDate.of(1999, 12, 2)
         );
@@ -137,7 +127,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testNanoOfSecond() {
         this.compareAndCheckLess(
             SpreadsheetComparators.nanoOfSecond(),
-            LocalTime.class,
             LocalTime.of(1, 1, 11, 100),
             LocalTime.of(2, 2, 22, 222)
         );
@@ -173,7 +162,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testNumber() {
         this.compareAndCheckLess(
             SpreadsheetComparators.number(),
-            ExpressionNumber.class,
             ExpressionNumberKind.BIG_DECIMAL.zero(),
             ExpressionNumberKind.BIG_DECIMAL.one()
         );
@@ -183,7 +171,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testNumberDifferentExpressionNumberKind() {
         this.compareAndCheckLess(
             SpreadsheetComparators.number(),
-            ExpressionNumber.class,
             ExpressionNumberKind.BIG_DECIMAL.zero(),
             ExpressionNumberKind.DOUBLE.one()
         );
@@ -193,7 +180,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testSecondOfMinute() {
         this.compareAndCheckLess(
             SpreadsheetComparators.secondsOfMinute(),
-            LocalTime.class,
             LocalTime.of(11, 11, 1, 100),
             LocalTime.of(2, 2, 22, 222)
         );
@@ -203,7 +189,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testStringCaseInsensitive() {
         this.compareAndCheckLess(
             SpreadsheetComparators.textCaseInsensitive(),
-            String.class,
             "abc",
             "XYZ"
         );
@@ -213,7 +198,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testText() {
         this.compareAndCheckLess(
             SpreadsheetComparators.text(),
-            String.class,
             "abc",
             "xyz"
         );
@@ -223,7 +207,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testText2() {
         this.compareAndCheckLess(
             SpreadsheetComparators.text(),
-            String.class,
             "BCD",
             "abc"
         );
@@ -233,7 +216,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testTextWithNumbers() {
         this.compareAndCheckLess(
             SpreadsheetComparators.textWithNumbers(),
-            String.class,
             "ABC 00001 DEF",
             "ABC 23 DEF"
         );
@@ -243,7 +225,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testStringCaseInsensitive2() {
         this.compareAndCheckLess(
             SpreadsheetComparators.textCaseInsensitive(),
-            String.class,
             "abc",
             "BCD"
         );
@@ -253,7 +234,6 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testTime() {
         this.compareAndCheckLess(
             SpreadsheetComparators.time(),
-            LocalTime.class,
             LocalTime.of(1, 58, 59),
             LocalTime.of(2, 58, 59)
         );
@@ -263,25 +243,8 @@ public final class SpreadsheetComparatorsTest implements PublicStaticHelperTesti
     public void testYear() {
         this.compareAndCheckLess(
             SpreadsheetComparators.monthOfYear(),
-            LocalDate.class,
             LocalDate.of(1999, 1, 1),
             LocalDate.of(2000, 12, 31)
-        );
-    }
-
-    private <T> void compareAndCheckLess(final SpreadsheetComparator<T> comparator,
-                                         final Class<T> type,
-                                         final T left,
-                                         final T right) {
-        this.checkEquals(
-            type,
-            comparator.type(),
-            () -> comparator + " type"
-        );
-        this.compareAndCheckLess(
-            comparator,
-            left,
-            right
         );
     }
 


### PR DESCRIPTION
- Adds support for extracting any value from a nullable SpreadsheetCell.

- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9645
- SpreadsheetColumnOrRowSpreadsheetComparators only extracts SpreadsheetCell#value