### PR TITLE
SpreadsheetStorageContext.parseStoragePath default method removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContext.java
@@ -27,7 +27,6 @@ import walkingkooka.spreadsheet.reference.SpreadsheetLabelName;
 import walkingkooka.spreadsheet.validation.SpreadsheetValidationReference;
 import walkingkooka.spreadsheet.value.SpreadsheetCell;
 import walkingkooka.storage.StorageContext;
-import walkingkooka.storage.StoragePath;
 import walkingkooka.store.StoreWatcher;
 import walkingkooka.validation.form.Form;
 import walkingkooka.validation.form.FormName;
@@ -89,16 +88,6 @@ public interface SpreadsheetStorageContext extends StorageContext,
     Runnable addLabelWatcher(final StoreWatcher<SpreadsheetLabelMapping> watcher);
 
     Runnable addLabelWatcherOnce(final StoreWatcher<SpreadsheetLabelMapping> watcher);
-
-    // StorageContext...................................................................................................
-
-    @Override
-    default StoragePath parseStoragePath(final String text) {
-        return StoragePath.parseSpecial(
-            text,
-            this // HasUserDirectories
-        );
-    }
 
     // SpreadsheetEnvironmentContext....................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContextBasic.java
+++ b/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContextBasic.java
@@ -86,13 +86,6 @@ final class SpreadsheetStorageContextBasic implements SpreadsheetStorageContext,
         this.storageContext = storageContext;
     }
 
-    // SpreadsheetStorageContext........................................................................................
-
-    @Override
-    public StoragePath parseStoragePath(final String text) {
-        return SpreadsheetStorageContext.super.parseStoragePath(text);
-    }
-
     // SpreadsheetStorageContext: cells.................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContextDelegator.java
+++ b/src/main/java/walkingkooka/spreadsheet/storage/SpreadsheetStorageContextDelegator.java
@@ -69,11 +69,6 @@ public interface SpreadsheetStorageContextDelegator extends SpreadsheetStorageCo
     // SpreadsheetStorageContextDelegator...............................................................................
 
     @Override
-    default StoragePath parseStoragePath(final String text) {
-        return SpreadsheetStorageContext.super.parseStoragePath(text);
-    }
-
-    @Override
     default Set<SpreadsheetCell> loadCells(final SpreadsheetExpressionReference cellsOrLabel) {
         return this.spreadsheetStorageContext()
             .loadCells(cellsOrLabel);


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet/issues/9772
- SpreadsheetStorageContext.parseStoragePath remove